### PR TITLE
[REFACTOR] ApiResponse 공통 응답 포맷 변경

### DIFF
--- a/src/main/java/com/kusitms/kkium/global/response/ApiResponse.java
+++ b/src/main/java/com/kusitms/kkium/global/response/ApiResponse.java
@@ -6,6 +6,7 @@ import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,7 +21,7 @@ public class ApiResponse<T> {
   // 성공 응답 - 데이터 있음
   public static <T> ApiResponse<T> success(T data) {
     ApiResponse<T> response = new ApiResponse<>();
-    response.status = 200;
+    response.status = HttpStatus.OK.value();
     response.code = "SUCCESS";
     response.message = "요청이 성공했습니다.";
     response.data = data;
@@ -30,7 +31,7 @@ public class ApiResponse<T> {
   // 성공 응답 - 커스텀 메시지
   public static <T> ApiResponse<T> success(String message, T data) {
     ApiResponse<T> response = new ApiResponse<>();
-    response.status = 200;
+    response.status = HttpStatus.OK.value();
     response.code = "SUCCESS";
     response.message = message;
     response.data = data;
@@ -40,7 +41,7 @@ public class ApiResponse<T> {
   // 성공 응답 - 데이터 없음 (삭제, 수정 등)
   public static <T> ApiResponse<T> successWithNoContent() {
     ApiResponse<T> response = new ApiResponse<>();
-    response.status = 200;
+    response.status = HttpStatus.OK.value();
     response.code = "SUCCESS";
     response.message = "요청이 성공했습니다.";
     response.data = null;
@@ -49,7 +50,7 @@ public class ApiResponse<T> {
 
   public static <T> ApiResponse<T> successWithNoContent(String message) {
     ApiResponse<T> response = new ApiResponse<>();
-    response.status = 200;
+    response.status = HttpStatus.OK.value();
     response.code = "SUCCESS";
     response.message = message;
     response.data = null;

--- a/src/main/java/com/kusitms/kkium/global/response/ApiResponse.java
+++ b/src/main/java/com/kusitms/kkium/global/response/ApiResponse.java
@@ -9,10 +9,10 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@JsonPropertyOrder({"isSuccess", "code", "message", "data"})
+@JsonPropertyOrder({"status", "code", "message", "data"})
 public class ApiResponse<T> {
 
-  private Boolean isSuccess;
+  private int status;
   private String code;
   private String message;
   private T data;
@@ -20,7 +20,7 @@ public class ApiResponse<T> {
   // 성공 응답 - 데이터 있음
   public static <T> ApiResponse<T> success(T data) {
     ApiResponse<T> response = new ApiResponse<>();
-    response.isSuccess = true;
+    response.status = 200;
     response.code = "SUCCESS";
     response.message = "요청이 성공했습니다.";
     response.data = data;
@@ -30,7 +30,7 @@ public class ApiResponse<T> {
   // 성공 응답 - 커스텀 메시지
   public static <T> ApiResponse<T> success(String message, T data) {
     ApiResponse<T> response = new ApiResponse<>();
-    response.isSuccess = true;
+    response.status = 200;
     response.code = "SUCCESS";
     response.message = message;
     response.data = data;
@@ -40,7 +40,7 @@ public class ApiResponse<T> {
   // 성공 응답 - 데이터 없음 (삭제, 수정 등)
   public static <T> ApiResponse<T> successWithNoContent() {
     ApiResponse<T> response = new ApiResponse<>();
-    response.isSuccess = true;
+    response.status = 200;
     response.code = "SUCCESS";
     response.message = "요청이 성공했습니다.";
     response.data = null;
@@ -49,7 +49,7 @@ public class ApiResponse<T> {
 
   public static <T> ApiResponse<T> successWithNoContent(String message) {
     ApiResponse<T> response = new ApiResponse<>();
-    response.isSuccess = true;
+    response.status = 200;
     response.code = "SUCCESS";
     response.message = message;
     response.data = null;
@@ -59,7 +59,7 @@ public class ApiResponse<T> {
   // 실패 응답
   public static <T> ApiResponse<T> fail(ErrorCode errorCode) {
     ApiResponse<T> response = new ApiResponse<>();
-    response.isSuccess = false;
+    response.status = errorCode.getStatus().value();
     response.code = errorCode.getCode();
     response.message = errorCode.getMessage();
     response.data = null;
@@ -69,7 +69,7 @@ public class ApiResponse<T> {
   // 실패 응답 - 커스텀 메시지
   public static <T> ApiResponse<T> fail(ErrorCode errorCode, String message) {
     ApiResponse<T> response = new ApiResponse<>();
-    response.isSuccess = false;
+    response.status = errorCode.getStatus().value();
     response.code = errorCode.getCode();
     response.message = message;
     response.data = null;


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #6 

## ✏️ 작업 내용

- ApiResponse 필드 변경: `isSuccess: Boolean` → `status: int` (HTTP 상태 코드 숫자값)
- `@JsonPropertyOrder` 수정: `isSuccess` → `status`
- `success()` 계열 메서드: `isSuccess = true` → `status = 200`
- `fail()` 계열 메서드: `isSuccess = false` → `status = errorCode.getStatus().value()`

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
