### PR TITLE
[FIX] ArgoCD monitoring app 하위 폴더 탐색 설정 추가 

### DIFF
--- a/argocd/argocd-monitoring-app.yaml
+++ b/argocd/argocd-monitoring-app.yaml
@@ -9,6 +9,8 @@ spec:
     repoURL: https://github.com/team-KKIUM/KKIUM-BE
     targetRevision: develop
     path: k8s/monitoring
+    directory:
+      recurse: true
   destination:
     server: https://kubernetes.default.svc
     namespace: monitoring


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #24 

## ✏️ 작업 내용

- directory.recurse: true 옵션을 추가해서 하위 폴더까지 탐색하도록 설정 (prometheus, grafana 폴더 읽도록)

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
