### PR TITLE
[FIX] Grafana GKE 로드밸런서 헬스체크 설정 추가

### DIFF
--- a/k8s/monitoring/grafana/backendconfig.yaml
+++ b/k8s/monitoring/grafana/backendconfig.yaml
@@ -1,0 +1,11 @@
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: grafana-backend-config
+  namespace: monitoring
+spec:
+  healthCheck:
+    checkIntervalSec: 15
+    port: 3000
+    type: HTTP
+    requestPath: /api/health

--- a/k8s/monitoring/grafana/service.yaml
+++ b/k8s/monitoring/grafana/service.yaml
@@ -3,6 +3,8 @@ kind: Service
 metadata:
   name: grafana-service
   namespace: monitoring
+  annotations:
+    cloud.google.com/backend-config: '{"default": "grafana-backend-config"}'
 spec:
   selector:
     app: grafana


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #24 

## ✏️ 작업 내용

기존: GKE → GET / → Grafana 302 반환 →  UNHEALTHY
변경: GKE → GET /api/health → Grafana 200 반환 → HEALTHY

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
