### PR TITLE
[FIX] Grafana 설정 저장을 위한 pvc 추가

### DIFF
--- a/k8s/monitoring/grafana/deployment.yaml
+++ b/k8s/monitoring/grafana/deployment.yaml
@@ -41,7 +41,12 @@ spec:
           volumeMounts:
             - name: datasource
               mountPath: /etc/grafana/provisioning/datasources
+            - name: grafana-storage
+              mountPath: /var/lib/grafana
       volumes:
         - name: datasource
           configMap:
             name: grafana-datasource
+        - name: grafana-storage
+          persistentVolumeClaim:
+            claimName: grafana-pvc

--- a/k8s/monitoring/grafana/pvc.yaml
+++ b/k8s/monitoring/grafana/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-pvc
+  namespace: monitoring
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: standard-rwo


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #24 

## ✏️ 작업 내용

- /var/lib/grafana 경로를 외부 디스크(PVC)에 마운트해서 Pod가 재시작돼도 데이터가 유지

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
