### PR TITLE
[FIX] Grafana PVC 파일 권한 설정 추가

### DIFF
--- a/k8s/monitoring/grafana/deployment.yaml
+++ b/k8s/monitoring/grafana/deployment.yaml
@@ -13,6 +13,10 @@ spec:
       labels:
         app: grafana
     spec:
+      securityContext:
+        fsGroup: 472
+        runAsUser: 472
+        runAsGroup: 472
       containers:
         - name: grafana
           image: grafana/grafana:10.4.0


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #24 

## ✏️ 작업 내용
`GF_PATHS_DATA='/var/lib/grafana' is not writable.
mkdir: can't create directory '/var/lib/grafana/plugins': Permission denied`

PVC가 마운트될 때 디렉토리 소유권이 root로 설정
-> 하지만 Grafana 컨테이너는 472번 유저로 실행
-> 데이터 폴더에 쓰기 권한X

securityContext 추가
fsGroup: 472   → 마운트된 볼륨 소유권을 472 그룹으로 설정
runAsUser: 472 → 컨테이너를 472 유저로 실행
runAsGroup: 472 → 컨테이너를 472 그룹으로 실행

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
