### PR TITLE
[FEAT] Notion OAuth 연결 플로우 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,10 @@ dependencies {
     // playwright (CSR 사이트 스크래핑)
     implementation 'com.microsoft.playwright:playwright:1.49.0'
 
-	  // actuator
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // actuator
 	  implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	  // pdf parsing

--- a/k8s/app/deployment.yaml
+++ b/k8s/app/deployment.yaml
@@ -71,6 +71,31 @@ spec:
             secretKeyRef:
               name: kkium-secret
               key: GEMINI_API_KEY
+        - name: NOTION_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: kkium-secret
+              key: NOTION_CLIENT_ID
+        - name: NOTION_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: kkium-secret
+              key: NOTION_CLIENT_SECRET
+        - name: NOTION_REDIRECT_URI
+          valueFrom:
+            secretKeyRef:
+              name: kkium-secret
+              key: NOTION_REDIRECT_URI
+        - name: NOTION_FRONTEND_REDIRECT_URI
+          valueFrom:
+            secretKeyRef:
+              name: kkium-secret
+              key: NOTION_FRONTEND_REDIRECT_URI
+        - name: AES_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: kkium-secret
+              key: AES_SECRET_KEY
         - name: OPENAI_API_KEY
           valueFrom:
             secretKeyRef:

--- a/src/main/java/com/kusitms/kkium/global/config/AesEncryptConverter.java
+++ b/src/main/java/com/kusitms/kkium/global/config/AesEncryptConverter.java
@@ -1,47 +1,65 @@
 package com.kusitms.kkium.global.config;
 
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import javax.crypto.Cipher;
-import javax.crypto.spec.SecretKeySpec;
-import java.util.Base64;
-
 @Converter
 @Component
 public class AesEncryptConverter implements AttributeConverter<String, String> {
 
-    @Value("${notion.aes-secret-key}")
-    private String secretKey;
+  @Value("${notion.aes-secret-key}")
+  private String secretKey;
 
-    private static final String ALGORITHM = "AES";
+  private static final String ALGORITHM = "AES/CBC/PKCS5Padding";
+  private static final int IV_SIZE = 16;
 
-    @Override
-    public String convertToDatabaseColumn(String attribute) {
-        if (attribute == null) return null;
-        try {
-            SecretKeySpec keySpec = new SecretKeySpec(secretKey.getBytes(), ALGORITHM);
-            Cipher cipher = Cipher.getInstance(ALGORITHM);
-            cipher.init(Cipher.ENCRYPT_MODE, keySpec);
-            return Base64.getEncoder().encodeToString(cipher.doFinal(attribute.getBytes()));
-        } catch (Exception e) {
-            throw new RuntimeException("암호화 실패", e);
-        }
+  @Override
+  public String convertToDatabaseColumn(String attribute) {
+    if (attribute == null) return null;
+    try {
+      byte[] iv = new byte[IV_SIZE];
+      new SecureRandom().nextBytes(iv);
+      IvParameterSpec ivSpec = new IvParameterSpec(iv);
+      SecretKeySpec keySpec = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), "AES");
+      Cipher cipher = Cipher.getInstance(ALGORITHM);
+      cipher.init(Cipher.ENCRYPT_MODE, keySpec, ivSpec);
+      byte[] encrypted = cipher.doFinal(attribute.getBytes(StandardCharsets.UTF_8));
+      byte[] combined = new byte[IV_SIZE + encrypted.length];
+      System.arraycopy(iv, 0, combined, 0, IV_SIZE);
+      System.arraycopy(encrypted, 0, combined, IV_SIZE, encrypted.length);
+      return Base64.getEncoder().encodeToString(combined);
+    } catch (Exception e) {
+      throw new RuntimeException("암호화 실패", e);
     }
+  }
 
-    @Override
-    public String convertToEntityAttribute(String dbData) {
-        if (dbData == null) return null;
-        try {
-            SecretKeySpec keySpec = new SecretKeySpec(secretKey.getBytes(), ALGORITHM);
-            Cipher cipher = Cipher.getInstance(ALGORITHM);
-            cipher.init(Cipher.DECRYPT_MODE, keySpec);
-            return new String(cipher.doFinal(Base64.getDecoder().decode(dbData)));
-        } catch (Exception e) {
-            throw new RuntimeException("복호화 실패", e);
-        }
+  @Override
+  public String convertToEntityAttribute(String dbData) {
+    if (dbData == null) return null;
+    try {
+      byte[] combined = Base64.getDecoder().decode(dbData);
+      byte[] iv = new byte[IV_SIZE];
+      byte[] encrypted = new byte[combined.length - IV_SIZE];
+      System.arraycopy(combined, 0, iv, 0, IV_SIZE);
+      System.arraycopy(combined, IV_SIZE, encrypted, 0, encrypted.length);
+      IvParameterSpec ivSpec = new IvParameterSpec(iv);
+      SecretKeySpec keySpec = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), "AES");
+      Cipher cipher = Cipher.getInstance(ALGORITHM);
+      cipher.init(Cipher.DECRYPT_MODE, keySpec, ivSpec);
+      return new String(cipher.doFinal(encrypted), StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      throw new RuntimeException("복호화 실패", e);
     }
+  }
 }

--- a/src/main/java/com/kusitms/kkium/global/config/AesEncryptConverter.java
+++ b/src/main/java/com/kusitms/kkium/global/config/AesEncryptConverter.java
@@ -1,0 +1,47 @@
+package com.kusitms.kkium.global.config;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+
+@Converter
+@Component
+public class AesEncryptConverter implements AttributeConverter<String, String> {
+
+    @Value("${notion.aes-secret-key}")
+    private String secretKey;
+
+    private static final String ALGORITHM = "AES";
+
+    @Override
+    public String convertToDatabaseColumn(String attribute) {
+        if (attribute == null) return null;
+        try {
+            SecretKeySpec keySpec = new SecretKeySpec(secretKey.getBytes(), ALGORITHM);
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec);
+            return Base64.getEncoder().encodeToString(cipher.doFinal(attribute.getBytes()));
+        } catch (Exception e) {
+            throw new RuntimeException("암호화 실패", e);
+        }
+    }
+
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        try {
+            SecretKeySpec keySpec = new SecretKeySpec(secretKey.getBytes(), ALGORITHM);
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, keySpec);
+            return new String(cipher.doFinal(Base64.getDecoder().decode(dbData)));
+        } catch (Exception e) {
+            throw new RuntimeException("복호화 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/kusitms/kkium/global/config/SecurityConfig.java
+++ b/src/main/java/com/kusitms/kkium/global/config/SecurityConfig.java
@@ -56,6 +56,8 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers("/api/v1/auth/**")
                     .permitAll()
+                    .requestMatchers("/api/v1/notion/callback")
+                    .permitAll()
                     .anyRequest()
                     .authenticated())
         .exceptionHandling(

--- a/src/main/java/com/kusitms/kkium/global/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/kusitms/kkium/global/exception/errorcode/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
   // notion
   NOTION_TOKEN_FAILED(HttpStatus.UNAUTHORIZED, "N001", "Notion 토큰 발급에 실패했습니다."),
   NOTION_NOT_CONNECTED(HttpStatus.UNAUTHORIZED, "N002", "Notion 연결이 필요합니다."),
+  NOTION_INVALID_STATE(HttpStatus.BAD_REQUEST, "N003", "유효하지 않은 Notion state 값입니다."),
 
   // experience
   INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "E001", "PDF 파일만 업로드 가능합니다."),

--- a/src/main/java/com/kusitms/kkium/global/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/kusitms/kkium/global/exception/errorcode/ErrorCode.java
@@ -29,6 +29,10 @@ public enum ErrorCode {
   JD_NOT_FOUND(HttpStatus.NOT_FOUND, "J001", "존재하지 않는 공고입니다."),
   JD_SCRAPE_FAILED(HttpStatus.BAD_GATEWAY, "J002", "채용공고 내용을 가져오는데 실패했습니다."),
 
+  // notion
+  NOTION_TOKEN_FAILED(HttpStatus.UNAUTHORIZED, "N001", "Notion 토큰 발급에 실패했습니다."),
+  NOTION_NOT_CONNECTED(HttpStatus.UNAUTHORIZED, "N002", "Notion 연결이 필요합니다."),
+
   // experience
   INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "E001", "PDF 파일만 업로드 가능합니다."),
   FILE_ALREADY_UPLOADED(HttpStatus.CONFLICT, "E002", "이미 업로드된 자료가 있습니다. 다시 업로드하면 초기화됩니다."),

--- a/src/main/java/com/kusitms/kkium/notion/controller/NotionController.java
+++ b/src/main/java/com/kusitms/kkium/notion/controller/NotionController.java
@@ -1,0 +1,41 @@
+package com.kusitms.kkium.notion.controller;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import com.kusitms.kkium.user.utils.CustomUserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import com.kusitms.kkium.global.response.ApiResponse;
+import com.kusitms.kkium.notion.service.NotionService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@Tag(name = "Notion", description = "Notion 연동 API")
+@RequiredArgsConstructor
+public class NotionController {
+
+    private final NotionService notionService;
+
+    @Operation(summary = "Notion OAuth 인증 URL 반환", description = "Notion 연결을 위한 OAuth 인증 URL을 반환합니다.")
+    @GetMapping("/api/v1/experiences/notion/auth")
+    public ResponseEntity<ApiResponse<String>> getAuthorizationUrl(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getId();
+        String authUrl = notionService.getAuthorizationUrl(userId);
+        return ResponseEntity.ok(ApiResponse.success(authUrl));
+    }
+
+    @Operation(summary = "Notion OAuth 콜백 처리", description = "Notion이 전달한 code로 access_token을 저장하고 프론트로 redirect합니다.")
+    @GetMapping("/api/v1/notion/callback")
+    public ResponseEntity<Void> callback(
+            @RequestParam String code,
+            @RequestParam String state) {
+        String redirectUrl = notionService.handleCallback(code, state);
+        return ResponseEntity.status(302).location(URI.create(redirectUrl)).build();
+    }
+}

--- a/src/main/java/com/kusitms/kkium/notion/controller/NotionController.java
+++ b/src/main/java/com/kusitms/kkium/notion/controller/NotionController.java
@@ -4,11 +4,11 @@ import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import com.kusitms.kkium.user.utils.CustomUserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import com.kusitms.kkium.global.response.ApiResponse;
 import com.kusitms.kkium.notion.service.NotionService;
+import com.kusitms.kkium.user.utils.CustomUserDetails;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,23 +19,23 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class NotionController {
 
-    private final NotionService notionService;
+  private final NotionService notionService;
 
-    @Operation(summary = "Notion OAuth 인증 URL 반환", description = "Notion 연결을 위한 OAuth 인증 URL을 반환합니다.")
-    @GetMapping("/api/v1/experiences/notion/auth")
-    public ResponseEntity<ApiResponse<String>> getAuthorizationUrl(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long userId = userDetails.getId();
-        String authUrl = notionService.getAuthorizationUrl(userId);
-        return ResponseEntity.ok(ApiResponse.success(authUrl));
-    }
+  @Operation(summary = "Notion OAuth 인증 URL 반환", description = "Notion 연결을 위한 OAuth 인증 URL을 반환합니다.")
+  @GetMapping("/api/v1/experiences/notion/auth")
+  public ResponseEntity<ApiResponse<String>> getAuthorizationUrl(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    Long userId = userDetails.getId();
+    String authUrl = notionService.getAuthorizationUrl(userId);
+    return ResponseEntity.ok(ApiResponse.success(authUrl));
+  }
 
-    @Operation(summary = "Notion OAuth 콜백 처리", description = "Notion이 전달한 code로 access_token을 저장하고 프론트로 redirect합니다.")
-    @GetMapping("/api/v1/notion/callback")
-    public ResponseEntity<Void> callback(
-            @RequestParam String code,
-            @RequestParam String state) {
-        String redirectUrl = notionService.handleCallback(code, state);
-        return ResponseEntity.status(302).location(URI.create(redirectUrl)).build();
-    }
+  @Operation(
+      summary = "Notion OAuth 콜백 처리",
+      description = "Notion이 전달한 code로 access_token을 저장하고 프론트로 redirect합니다.")
+  @GetMapping("/api/v1/notion/callback")
+  public ResponseEntity<Void> callback(@RequestParam String code, @RequestParam String state) {
+    String redirectUrl = notionService.handleCallback(code, state);
+    return ResponseEntity.status(302).location(URI.create(redirectUrl)).build();
+  }
 }

--- a/src/main/java/com/kusitms/kkium/notion/domain/NotionConnection.java
+++ b/src/main/java/com/kusitms/kkium/notion/domain/NotionConnection.java
@@ -1,0 +1,55 @@
+package com.kusitms.kkium.notion.domain;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+import com.kusitms.kkium.global.config.AesEncryptConverter;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notion_connection")
+public class NotionConnection {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Convert(converter = AesEncryptConverter.class)
+    @Column(name = "access_token", nullable = false)
+    private String accessToken;
+
+    @Column(name = "workspace_id")
+    private String workspaceId;
+
+    @Column(name = "workspace_name")
+    private String workspaceName;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Builder
+    public NotionConnection(String accessToken, String workspaceId, String workspaceName, Long userId) {
+        this.accessToken = accessToken;
+        this.workspaceId = workspaceId;
+        this.workspaceName = workspaceName;
+        this.userId = userId;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void updateToken(String accessToken, String workspaceId, String workspaceName) {
+        this.accessToken = accessToken;
+        this.workspaceId = workspaceId;
+        this.workspaceName = workspaceName;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/kusitms/kkium/notion/domain/NotionConnection.java
+++ b/src/main/java/com/kusitms/kkium/notion/domain/NotionConnection.java
@@ -1,8 +1,8 @@
 package com.kusitms.kkium.notion.domain;
 
-import jakarta.persistence.*;
-
 import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
 
 import com.kusitms.kkium.global.config.AesEncryptConverter;
 
@@ -17,39 +17,40 @@ import lombok.NoArgsConstructor;
 @Table(name = "notion_connection")
 public class NotionConnection {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @Convert(converter = AesEncryptConverter.class)
-    @Column(name = "access_token", nullable = false)
-    private String accessToken;
+  @Convert(converter = AesEncryptConverter.class)
+  @Column(name = "access_token", nullable = false)
+  private String accessToken;
 
-    @Column(name = "workspace_id")
-    private String workspaceId;
+  @Column(name = "workspace_id")
+  private String workspaceId;
 
-    @Column(name = "workspace_name")
-    private String workspaceName;
+  @Column(name = "workspace_name")
+  private String workspaceName;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
 
-    @Builder
-    public NotionConnection(String accessToken, String workspaceId, String workspaceName, Long userId) {
-        this.accessToken = accessToken;
-        this.workspaceId = workspaceId;
-        this.workspaceName = workspaceName;
-        this.userId = userId;
-        this.createdAt = LocalDateTime.now();
-    }
+  @Builder
+  public NotionConnection(
+      String accessToken, String workspaceId, String workspaceName, Long userId) {
+    this.accessToken = accessToken;
+    this.workspaceId = workspaceId;
+    this.workspaceName = workspaceName;
+    this.userId = userId;
+    this.createdAt = LocalDateTime.now();
+  }
 
-    public void updateToken(String accessToken, String workspaceId, String workspaceName) {
-        this.accessToken = accessToken;
-        this.workspaceId = workspaceId;
-        this.workspaceName = workspaceName;
-        this.createdAt = LocalDateTime.now();
-    }
+  public void updateToken(String accessToken, String workspaceId, String workspaceName) {
+    this.accessToken = accessToken;
+    this.workspaceId = workspaceId;
+    this.workspaceName = workspaceName;
+    this.createdAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/com/kusitms/kkium/notion/dto/response/NotionTokenResponse.java
+++ b/src/main/java/com/kusitms/kkium/notion/dto/response/NotionTokenResponse.java
@@ -1,0 +1,9 @@
+package com.kusitms.kkium.notion.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record NotionTokenResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("workspace_id") String workspaceId,
+        @JsonProperty("workspace_name") String workspaceName
+) {}

--- a/src/main/java/com/kusitms/kkium/notion/dto/response/NotionTokenResponse.java
+++ b/src/main/java/com/kusitms/kkium/notion/dto/response/NotionTokenResponse.java
@@ -3,7 +3,6 @@ package com.kusitms.kkium.notion.dto.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record NotionTokenResponse(
-        @JsonProperty("access_token") String accessToken,
-        @JsonProperty("workspace_id") String workspaceId,
-        @JsonProperty("workspace_name") String workspaceName
-) {}
+    @JsonProperty("access_token") String accessToken,
+    @JsonProperty("workspace_id") String workspaceId,
+    @JsonProperty("workspace_name") String workspaceName) {}

--- a/src/main/java/com/kusitms/kkium/notion/repository/NotionConnectionRepository.java
+++ b/src/main/java/com/kusitms/kkium/notion/repository/NotionConnectionRepository.java
@@ -1,0 +1,12 @@
+package com.kusitms.kkium.notion.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kusitms.kkium.notion.domain.NotionConnection;
+
+public interface NotionConnectionRepository extends JpaRepository<NotionConnection, Long> {
+
+    Optional<NotionConnection> findByUserId(Long userId);
+}

--- a/src/main/java/com/kusitms/kkium/notion/repository/NotionConnectionRepository.java
+++ b/src/main/java/com/kusitms/kkium/notion/repository/NotionConnectionRepository.java
@@ -8,5 +8,5 @@ import com.kusitms.kkium.notion.domain.NotionConnection;
 
 public interface NotionConnectionRepository extends JpaRepository<NotionConnection, Long> {
 
-    Optional<NotionConnection> findByUserId(Long userId);
+  Optional<NotionConnection> findByUserId(Long userId);
 }

--- a/src/main/java/com/kusitms/kkium/notion/service/NotionService.java
+++ b/src/main/java/com/kusitms/kkium/notion/service/NotionService.java
@@ -1,9 +1,16 @@
 package com.kusitms.kkium.notion.service;
 
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.NOTION_INVALID_STATE;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kusitms.kkium.global.exception.BaseException;
 import com.kusitms.kkium.notion.domain.NotionConnection;
 import com.kusitms.kkium.notion.dto.response.NotionTokenResponse;
 import com.kusitms.kkium.notion.repository.NotionConnectionRepository;
@@ -11,56 +18,70 @@ import com.kusitms.kkium.notion.utils.NotionApiClient;
 
 import lombok.RequiredArgsConstructor;
 
-import java.util.UUID;
-
 @Service
 @RequiredArgsConstructor
 public class NotionService {
 
-    private final NotionApiClient notionApiClient;
-    private final NotionConnectionRepository notionConnectionRepository;
+  private final NotionApiClient notionApiClient;
+  private final NotionConnectionRepository notionConnectionRepository;
+  private final StringRedisTemplate redisTemplate;
 
-    @Value("${notion.frontend-redirect-uri}")
-    private String frontendRedirectUri;
+  private static final String STATE_PREFIX = "notion:state:";
+  private static final long STATE_TTL_MINUTES = 10;
 
-    // OAuth 인증 URL 반환 (state에 userId 담아서 CSRF 방지 겸 사용자 식별)
-    public String getAuthorizationUrl(Long userId) {
-        String state = userId + ":" + UUID.randomUUID();
-        return notionApiClient.getAuthorizationUrl(state);
+  @Value("${notion.frontend-redirect-uri}")
+  private String frontendRedirectUri;
+
+  // OAuth 인증 URL 반환 (state Redis 저장 후 CSRF 검증용)
+  public String getAuthorizationUrl(Long userId) {
+    String stateValue = UUID.randomUUID().toString();
+    String state = userId + ":" + stateValue;
+    redisTemplate.opsForValue().set(STATE_PREFIX + stateValue, String.valueOf(userId), STATE_TTL_MINUTES, TimeUnit.MINUTES);
+    return notionApiClient.getAuthorizationUrl(state);
+  }
+
+  // 콜백 처리 - state 검증 후 access_token 저장 및 프론트 redirect URL 반환
+  @Transactional
+  public String handleCallback(String code, String state) {
+    validateState(state);
+    Long userId = parseUserIdFromState(state);
+
+    NotionTokenResponse tokenResponse = notionApiClient.getAccessToken(code);
+
+    notionConnectionRepository
+        .findByUserId(userId)
+        .ifPresentOrElse(
+            connection ->
+                connection.updateToken(
+                    tokenResponse.accessToken(),
+                    tokenResponse.workspaceId(),
+                    tokenResponse.workspaceName()),
+            () ->
+                notionConnectionRepository.save(
+                    NotionConnection.builder()
+                        .userId(userId)
+                        .accessToken(tokenResponse.accessToken())
+                        .workspaceId(tokenResponse.workspaceId())
+                        .workspaceName(tokenResponse.workspaceName())
+                        .build()));
+
+    return frontendRedirectUri + "?success=true";
+  }
+
+  private void validateState(String state) {
+    String stateValue = state.split(":")[1];
+    String savedUserId = redisTemplate.opsForValue().get(STATE_PREFIX + stateValue);
+    if (savedUserId == null) {
+      throw new BaseException(NOTION_INVALID_STATE);
     }
+    redisTemplate.delete(STATE_PREFIX + stateValue);
+  }
 
-    // 콜백 처리 - access_token 저장 후 프론트 redirect URL 반환
-    @Transactional
-    public String handleCallback(String code, String state) {
-        Long userId = parseUserIdFromState(state);
-
-        NotionTokenResponse tokenResponse = notionApiClient.getAccessToken(code);
-
-        notionConnectionRepository.findByUserId(userId)
-                .ifPresentOrElse(
-                        connection -> connection.updateToken(
-                                tokenResponse.accessToken(),
-                                tokenResponse.workspaceId(),
-                                tokenResponse.workspaceName()
-                        ),
-                        () -> notionConnectionRepository.save(
-                                NotionConnection.builder()
-                                        .userId(userId)
-                                        .accessToken(tokenResponse.accessToken())
-                                        .workspaceId(tokenResponse.workspaceId())
-                                        .workspaceName(tokenResponse.workspaceName())
-                                        .build()
-                        )
-                );
-
-        return frontendRedirectUri + "?success=true";
+  private Long parseUserIdFromState(String state) {
+    try {
+      return Long.parseLong(state.split(":")[0]);
+    } catch (Exception e) {
+      throw new BaseException(NOTION_INVALID_STATE);
     }
-
-    private Long parseUserIdFromState(String state) {
-        try {
-            return Long.parseLong(state.split(":")[0]);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("유효하지 않은 state 값입니다.");
-        }
-    }
+  }
 }

--- a/src/main/java/com/kusitms/kkium/notion/service/NotionService.java
+++ b/src/main/java/com/kusitms/kkium/notion/service/NotionService.java
@@ -1,0 +1,66 @@
+package com.kusitms.kkium.notion.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kusitms.kkium.notion.domain.NotionConnection;
+import com.kusitms.kkium.notion.dto.response.NotionTokenResponse;
+import com.kusitms.kkium.notion.repository.NotionConnectionRepository;
+import com.kusitms.kkium.notion.utils.NotionApiClient;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class NotionService {
+
+    private final NotionApiClient notionApiClient;
+    private final NotionConnectionRepository notionConnectionRepository;
+
+    @Value("${notion.frontend-redirect-uri}")
+    private String frontendRedirectUri;
+
+    // OAuth 인증 URL 반환 (state에 userId 담아서 CSRF 방지 겸 사용자 식별)
+    public String getAuthorizationUrl(Long userId) {
+        String state = userId + ":" + UUID.randomUUID();
+        return notionApiClient.getAuthorizationUrl(state);
+    }
+
+    // 콜백 처리 - access_token 저장 후 프론트 redirect URL 반환
+    @Transactional
+    public String handleCallback(String code, String state) {
+        Long userId = parseUserIdFromState(state);
+
+        NotionTokenResponse tokenResponse = notionApiClient.getAccessToken(code);
+
+        notionConnectionRepository.findByUserId(userId)
+                .ifPresentOrElse(
+                        connection -> connection.updateToken(
+                                tokenResponse.accessToken(),
+                                tokenResponse.workspaceId(),
+                                tokenResponse.workspaceName()
+                        ),
+                        () -> notionConnectionRepository.save(
+                                NotionConnection.builder()
+                                        .userId(userId)
+                                        .accessToken(tokenResponse.accessToken())
+                                        .workspaceId(tokenResponse.workspaceId())
+                                        .workspaceName(tokenResponse.workspaceName())
+                                        .build()
+                        )
+                );
+
+        return frontendRedirectUri + "?success=true";
+    }
+
+    private Long parseUserIdFromState(String state) {
+        try {
+            return Long.parseLong(state.split(":")[0]);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("유효하지 않은 state 값입니다.");
+        }
+    }
+}

--- a/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
+++ b/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
@@ -1,0 +1,75 @@
+package com.kusitms.kkium.notion.utils;
+
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.NOTION_TOKEN_FAILED;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.notion.dto.response.NotionTokenResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+import java.util.Base64;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class NotionApiClient {
+
+    private final WebClient webClient;
+
+    private static final String TOKEN_URI = "https://api.notion.com/v1/oauth/token";
+
+    @Value("${notion.client-id}")
+    private String clientId;
+
+    @Value("${notion.client-secret}")
+    private String clientSecret;
+
+    @Value("${notion.redirect-uri}")
+    private String redirectUri;
+
+    // 인가 코드 → access_token 교환
+    public NotionTokenResponse getAccessToken(String code) {
+        String credentials = Base64.getEncoder().encodeToString((clientId + ":" + clientSecret).getBytes());
+
+        return webClient
+                .post()
+                .uri(TOKEN_URI)
+                .header("Authorization", "Basic " + credentials)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Map.of(
+                        "grant_type", "authorization_code",
+                        "code", code,
+                        "redirect_uri", redirectUri
+                ))
+                .exchangeToMono(response -> {
+                    if (response.statusCode().is2xxSuccessful()) {
+                        return response.bodyToMono(NotionTokenResponse.class);
+                    } else {
+                        return response.bodyToMono(String.class)
+                                .flatMap(errorBody -> {
+                                    log.error("Notion 토큰 발급 실패 - status: {}, body: {}", response.statusCode(), errorBody);
+                                    return Mono.error(new BaseException(NOTION_TOKEN_FAILED));
+                                });
+                    }
+                })
+                .block();
+    }
+
+    // OAuth 인증 URL 생성
+    public String getAuthorizationUrl(String state) {
+        return "https://api.notion.com/v1/oauth/authorize"
+                + "?client_id=" + clientId
+                + "&response_type=code"
+                + "&owner=user"
+                + "&redirect_uri=" + redirectUri
+                + "&state=" + state;
+    }
+}

--- a/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
+++ b/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
@@ -2,10 +2,15 @@ package com.kusitms.kkium.notion.utils;
 
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.NOTION_TOKEN_FAILED;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import com.kusitms.kkium.global.exception.BaseException;
 import com.kusitms.kkium.notion.dto.response.NotionTokenResponse;
@@ -14,62 +19,69 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
-import java.util.Base64;
-import java.util.Map;
-
 @Slf4j
 @RequiredArgsConstructor
 @Component
 public class NotionApiClient {
 
-    private final WebClient webClient;
+  private final WebClient webClient;
 
-    private static final String TOKEN_URI = "https://api.notion.com/v1/oauth/token";
+  private static final String TOKEN_URI = "https://api.notion.com/v1/oauth/token";
 
-    @Value("${notion.client-id}")
-    private String clientId;
+  @Value("${notion.client-id}")
+  private String clientId;
 
-    @Value("${notion.client-secret}")
-    private String clientSecret;
+  @Value("${notion.client-secret}")
+  private String clientSecret;
 
-    @Value("${notion.redirect-uri}")
-    private String redirectUri;
+  @Value("${notion.redirect-uri}")
+  private String redirectUri;
 
-    // 인가 코드 → access_token 교환
-    public NotionTokenResponse getAccessToken(String code) {
-        String credentials = Base64.getEncoder().encodeToString((clientId + ":" + clientSecret).getBytes());
+  // 인가 코드 → access_token 교환
+  public NotionTokenResponse getAccessToken(String code) {
+    String credentials =
+        Base64.getEncoder()
+            .encodeToString((clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8));
 
-        return webClient
-                .post()
-                .uri(TOKEN_URI)
-                .header("Authorization", "Basic " + credentials)
-                .contentType(MediaType.APPLICATION_JSON)
-                .bodyValue(Map.of(
-                        "grant_type", "authorization_code",
-                        "code", code,
-                        "redirect_uri", redirectUri
-                ))
-                .exchangeToMono(response -> {
-                    if (response.statusCode().is2xxSuccessful()) {
-                        return response.bodyToMono(NotionTokenResponse.class);
-                    } else {
-                        return response.bodyToMono(String.class)
-                                .flatMap(errorBody -> {
-                                    log.error("Notion 토큰 발급 실패 - status: {}, body: {}", response.statusCode(), errorBody);
-                                    return Mono.error(new BaseException(NOTION_TOKEN_FAILED));
-                                });
-                    }
-                })
-                .block();
-    }
+    return webClient
+        .post()
+        .uri(TOKEN_URI)
+        .header("Authorization", "Basic " + credentials)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            Map.of(
+                "grant_type", "authorization_code",
+                "code", code,
+                "redirect_uri", redirectUri))
+        .exchangeToMono(
+            response -> {
+              if (response.statusCode().is2xxSuccessful()) {
+                return response.bodyToMono(NotionTokenResponse.class);
+              } else {
+                return response
+                    .bodyToMono(String.class)
+                    .flatMap(
+                        errorBody -> {
+                          log.error(
+                              "Notion 토큰 발급 실패 - status: {}, body: {}",
+                              response.statusCode(),
+                              errorBody);
+                          return Mono.error(new BaseException(NOTION_TOKEN_FAILED));
+                        });
+              }
+            })
+        .block();
+  }
 
-    // OAuth 인증 URL 생성
-    public String getAuthorizationUrl(String state) {
-        return "https://api.notion.com/v1/oauth/authorize"
-                + "?client_id=" + clientId
-                + "&response_type=code"
-                + "&owner=user"
-                + "&redirect_uri=" + redirectUri
-                + "&state=" + state;
-    }
+  // OAuth 인증 URL 생성
+  public String getAuthorizationUrl(String state) {
+    return UriComponentsBuilder.fromUriString("https://api.notion.com/v1/oauth/authorize")
+        .queryParam("client_id", clientId)
+        .queryParam("response_type", "code")
+        .queryParam("owner", "user")
+        .queryParam("redirect_uri", redirectUri)
+        .queryParam("state", state)
+        .build()
+        .toUriString();
+  }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,13 @@ kakao:
   redirect-uri: ${KAKAO_REDIRECT_URI}
   client-secret: ${KAKAO_CLIENT_SECRET}
 
+notion:
+  client-id: ${NOTION_CLIENT_ID}
+  client-secret: ${NOTION_CLIENT_SECRET}
+  redirect-uri: ${NOTION_REDIRECT_URI}
+  frontend-redirect-uri: ${NOTION_FRONTEND_REDIRECT_URI}
+  aes-secret-key: ${AES_SECRET_KEY}
+
 openai:
   api:
     key: ${OPENAI_API_KEY}


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #33 

## ✏️ 작업 내용

- `NotionConnection` 엔티티 및 레포지토리 생성
- AES 암호화 유틸(`AesEncryptConverter`) 작성 — access_token 암호화 저장
- Notion OAuth Authorization URL 생성 API (`GET /api/v1/experiences/notion/auth`)
- Notion OAuth Callback 처리 API (`GET /api/v1/notion/callback`) — access_token 암호화 저장 후 프론트 redirect
- WebClient 기반 `NotionApiClient` 공통 모듈 작성
- `application.yml` Notion 환경변수 추가
- `k8s/secret.yaml`, `k8s/app/deployment.yaml` Notion 관련 키 추가

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
