### PR TITLE
feat: PDF & Notion 통합 분석 API 구현

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -14,6 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.kusitms.kkium.experience.dto.response.ExperienceAnalyzeResponse;
 import com.kusitms.kkium.experience.dto.response.request.NotionAnalyzeRequest;
+import com.kusitms.kkium.experience.service.ExperienceAnalyzeService;
 import com.kusitms.kkium.experience.service.NotionAnalyzeService;
 import com.kusitms.kkium.experience.service.PdfAnalyzeService;
 import com.kusitms.kkium.global.response.ApiResponse;
@@ -31,6 +32,7 @@ public class ExperienceController {
 
   private final PdfAnalyzeService pdfAnalyzeService;
   private final NotionAnalyzeService notionAnalyzeService;
+  private final ExperienceAnalyzeService experienceAnalyzeService;
 
   @Operation(
       summary = "PDF 자료 분석",
@@ -52,6 +54,19 @@ public class ExperienceController {
       @Valid @RequestBody NotionAnalyzeRequest request) {
     ExperienceAnalyzeResponse response =
         notionAnalyzeService.analyze(userDetails.getId(), request.pageId());
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+
+  @Operation(
+      summary = "[테스트] PDF + Notion 통합 분석",
+      description = "PDF와 Notion 페이지 내용을 합쳐서 AI가 한 번에 경험을 분석합니다. 둘 중 하나 이상 필수.")
+  @PostMapping(value = "/analyze", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<ApiResponse<ExperienceAnalyzeResponse>> analyzeMerge(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @RequestPart(value = "file", required = false) MultipartFile file,
+      @RequestPart(value = "pageId", required = false) String pageId) {
+    ExperienceAnalyzeResponse response =
+        experienceAnalyzeService.analyze(userDetails.getId(), file, pageId);
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 }

--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -47,10 +47,8 @@ public class ExperienceController {
       description = "선택한 Notion 페이지의 콘텐츠를 추출하여 AI가 경험을 분석합니다.")
   @PostMapping("/analyze/notion")
   public ResponseEntity<ApiResponse<ExperienceAnalyzeResponse>> analyzeNotion(
-      @AuthenticationPrincipal CustomUserDetails userDetails,
-      @RequestParam String pageId) {
-    ExperienceAnalyzeResponse response =
-        notionAnalyzeService.analyze(userDetails.getId(), pageId);
+      @AuthenticationPrincipal CustomUserDetails userDetails, @RequestParam String pageId) {
+    ExperienceAnalyzeResponse response = notionAnalyzeService.analyze(userDetails.getId(), pageId);
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 

--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -1,19 +1,16 @@
 package com.kusitms.kkium.experience.controller;
 
-import jakarta.validation.Valid;
-
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.kusitms.kkium.experience.dto.response.ExperienceAnalyzeResponse;
-import com.kusitms.kkium.experience.dto.response.request.NotionAnalyzeRequest;
 import com.kusitms.kkium.experience.service.ExperienceAnalyzeService;
 import com.kusitms.kkium.experience.service.NotionAnalyzeService;
 import com.kusitms.kkium.experience.service.PdfAnalyzeService;
@@ -51,9 +48,9 @@ public class ExperienceController {
   @PostMapping("/analyze/notion")
   public ResponseEntity<ApiResponse<ExperienceAnalyzeResponse>> analyzeNotion(
       @AuthenticationPrincipal CustomUserDetails userDetails,
-      @Valid @RequestBody NotionAnalyzeRequest request) {
+      @RequestParam String pageId) {
     ExperienceAnalyzeResponse response =
-        notionAnalyzeService.analyze(userDetails.getId(), request.pageId());
+        notionAnalyzeService.analyze(userDetails.getId(), pageId);
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 

--- a/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceAnalyzeRequest.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceAnalyzeRequest.java
@@ -1,3 +1,0 @@
-package com.kusitms.kkium.experience.dto.request;
-
-public record ExperienceAnalyzeRequest(String pageId) {}

--- a/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceAnalyzeRequest.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceAnalyzeRequest.java
@@ -1,0 +1,3 @@
+package com.kusitms.kkium.experience.dto.request;
+
+public record ExperienceAnalyzeRequest(String pageId) {}

--- a/src/main/java/com/kusitms/kkium/experience/dto/response/request/NotionAnalyzeRequest.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/response/request/NotionAnalyzeRequest.java
@@ -1,5 +1,0 @@
-package com.kusitms.kkium.experience.dto.response.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record NotionAnalyzeRequest(@NotBlank String pageId) {}

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceAnalyzeService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceAnalyzeService.java
@@ -1,0 +1,62 @@
+package com.kusitms.kkium.experience.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.kusitms.kkium.experience.dto.response.ExperienceAnalyzeResponse;
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
+import com.kusitms.kkium.notion.domain.NotionConnection;
+import com.kusitms.kkium.notion.repository.NotionConnectionRepository;
+import com.kusitms.kkium.notion.utils.NotionApiClient;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ExperienceAnalyzeService {
+
+  private final PdfAnalyzeService pdfAnalyzeService;
+  private final NotionApiClient notionApiClient;
+  private final NotionConnectionRepository notionConnectionRepository;
+  private final LlmService llmService;
+
+  public ExperienceAnalyzeResponse analyze(Long userId, MultipartFile file, String pageId) {
+    validateAtLeastOne(file, pageId);
+
+    StringBuilder combined = new StringBuilder();
+
+    // PDF 텍스트 추출
+    if (file != null && !file.isEmpty()) {
+      String pdfText = pdfAnalyzeService.extractText(file);
+      combined.append("[PDF 자료]\n").append(pdfText).append("\n\n");
+    }
+
+    // Notion 텍스트 추출
+    if (pageId != null && !pageId.isBlank()) {
+      String accessToken = getAccessToken(userId);
+      String notionText = notionApiClient.getPageContent(accessToken, pageId);
+      combined.append("[Notion 페이지]\n").append(notionText);
+    }
+
+    return llmService.analyze(userId, combined.toString());
+  }
+
+  private void validateAtLeastOne(MultipartFile file, String pageId) {
+    boolean hasPdf = file != null && !file.isEmpty();
+    boolean hasNotion = pageId != null && !pageId.isBlank();
+    if (!hasPdf && !hasNotion) {
+      throw new BaseException(ErrorCode.INVALID_INPUT_VALUE);
+    }
+  }
+
+  private String getAccessToken(Long userId) {
+    NotionConnection connection =
+        notionConnectionRepository
+            .findByUserId(userId)
+            .orElseThrow(() -> new BaseException(ErrorCode.NOTION_NOT_CONNECTED));
+    return connection.getAccessToken();
+  }
+}

--- a/src/main/java/com/kusitms/kkium/experience/service/PdfAnalyzeService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/PdfAnalyzeService.java
@@ -39,6 +39,7 @@ public class PdfAnalyzeService {
   }
 
   public String extractText(MultipartFile file) {
+    validatePdfFile(file);
     try (PDDocument document = Loader.loadPDF(new RandomAccessReadBuffer(file.getInputStream()))) {
       PDFTextStripper stripper = new PDFTextStripper();
       return stripper.getText(document);

--- a/src/main/java/com/kusitms/kkium/experience/service/PdfAnalyzeService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/PdfAnalyzeService.java
@@ -38,7 +38,7 @@ public class PdfAnalyzeService {
     }
   }
 
-  private String extractText(MultipartFile file) {
+  public String extractText(MultipartFile file) {
     try (PDDocument document = Loader.loadPDF(new RandomAccessReadBuffer(file.getInputStream()))) {
       PDFTextStripper stripper = new PDFTextStripper();
       return stripper.getText(document);


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #40 

## ✏️ 작업 내용

- POST /api/v1/experiences/analyze - PDF + Notion 통합 분석 API 구현
- ExperienceAnalyzeMergeService 구현 (PDF 텍스트 & Notion 텍스트 합쳐서 LLM 1회 호출)

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
