### PR TITLE
[FEAT} LLM 분석 결과에 기술 및 역량 태그 추출 추가

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/dto/response/ExperienceAnalyzeResponse.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/response/ExperienceAnalyzeResponse.java
@@ -1,6 +1,9 @@
 package com.kusitms.kkium.experience.dto.response;
 
 import java.time.LocalDate;
+import java.util.List;
+
+import com.kusitms.kkium.experience.domain.type.TagCategory;
 
 public record ExperienceAnalyzeResponse(
     // 공통 (Experience 테이블)
@@ -17,7 +20,10 @@ public record ExperienceAnalyzeResponse(
     String task,
     String act,
     String result,
-    String taken) {
+    String taken,
+
+    // 태그
+    List<TagResponse> tags) {
 
   // Activity 테이블
   public record ActivityInfo(
@@ -39,4 +45,7 @@ public record ExperienceAnalyzeResponse(
   // Education 테이블
   public record EducationInfo(
       String organizationName, String name, LocalDate startDate, LocalDate endDate) {}
+
+  // Tag
+  public record TagResponse(TagCategory category, String field) {}
 }

--- a/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
@@ -41,9 +41,9 @@ public class GeminiLlmService implements LlmService {
   private String buildPrompt(String extractedText) {
     return """
         아래 경험 자료를 분석하여 JSON 형식으로만 응답해주세요.
-        모든 응답은 반드시 한국어로 작성해주세요.
+        모든 응답은 기본적으로 한국어로 작성하되, TECH 태그 등 기술 용어는 영어로 작성해주세요.
         JSON 외 다른 텍스트는 절대 포함하지 마세요.
-        모든 필드는 반드시 포함해야 하며, 값이 없으면 null로 채워주세요. 필드를 생략하지 마세요.
+        모든 필드는 반드시 포함해야 하며, 값이 없으면 null로 채워주세요(단, tags는 빈 배열 []로 채워주세요). 필드를 생략하지 마세요.
 
         경험 자료:
         %s

--- a/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
@@ -43,7 +43,6 @@ public class GeminiLlmService implements LlmService {
         아래 경험 자료를 분석하여 JSON 형식으로만 응답해주세요.
         모든 응답은 반드시 한국어로 작성해주세요.
         JSON 외 다른 텍스트는 절대 포함하지 마세요.
-
         모든 필드는 반드시 포함해야 하며, 값이 없으면 null로 채워주세요. 필드를 생략하지 마세요.
 
         경험 자료:
@@ -78,8 +77,24 @@ public class GeminiLlmService implements LlmService {
           "task": "해결 과제",
           "act": "실제 행동",
           "result": "결과 및 성과",
-          "taken": "배운 점"
+          "taken": "배운 점",
+          "tags": [
+            { "category": "TECH", "field": "사용한 기술 (예: SpringBoot, React 등)" },
+            { "category": "COMPETENCY", "field": "발휘한 역량 (예: 문제 해결, 협업 등)" }
+          ]
         }
+
+        tags 작성 규칙:
+        - category는 반드시 TECH 또는 COMPETENCY 중 하나만 사용
+        - TECH: 경험에서 사용한 기술, 툴, 언어, 프레임워크 (영어로 작성, 예: SpringBoot, React, Figma)
+        - COMPETENCY: 경험에서 발휘한 역량, 소프트스킬 (한국어로 작성, 예: 문제 해결, 협업, 리더십)
+        - TECH, COMPETENCY 각각 최대 5개
+        - 중복 태그 포함 금지
+        - 기술명은 구체적으로 작성 (예: "백엔드" 대신 "SpringBoot", "Java")
+        - 버전 정보 제외 (예: "Java 21" 대신 "Java")
+        - 약어 사용 금지, 공식 명칭 사용 (예: "JS" 대신 "JavaScript", "SB" 대신 "SpringBoot")
+        - 경험 내용에 명시된 내용만 태그로 포함, 추측 금지
+        - tags가 없으면 빈 배열 [] 반환
         """
         .formatted(extractedText);
   }

--- a/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
@@ -87,7 +87,9 @@ public class GeminiLlmService implements LlmService {
         tags 작성 규칙:
         - category는 반드시 TECH 또는 COMPETENCY 중 하나만 사용
         - TECH: 경험에서 사용한 기술, 툴, 언어, 프레임워크 (영어로 작성, 예: SpringBoot, React, Figma)
-        - COMPETENCY: 경험에서 발휘한 역량, 소프트스킬 (한국어로 작성, 예: 문제 해결, 협업, 리더십)
+        - COMPETENCY: 경험에서 발휘한 역량, 소프트스킬 (한국어로 작성)
+          - 올바른 예시: 문제 해결, 협업, 리더십, 커뮤니케이션, 자기주도, 창의성, 유연성
+          - 잘못된 예시 (포함 금지): 알고리즘 개발, 알고리즘 설계, 시스템 설계, API 개발, 데이터 분석, 코드 구현, 성능 최적화, 백엔드 개발, 프론트엔드 개발
         - TECH, COMPETENCY 각각 최대 5개
         - 중복 태그 포함 금지
         - 기술명은 구체적으로 작성 (예: "백엔드" 대신 "SpringBoot", "Java")


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #47 

## ✏️ 작업 내용

- ExperienceAnalyzeResponse에 TagResponse 필드 추가 (category: TECH | COMPETENCY, field: String)
- GeminiLlmService 프롬프트에 태그 추출 지시 및 응답 형식 추가
- 태그 프롬프트 규칙 상세화
  - TECH: 영어로 작성, 버전 제외, 약어 금지, 최대 5개
  - COMPETENCY: 한국어로 작성, 소프트스킬만 포함, 최대 5개
  - 올바른/잘못된 예시 추가로 LLM 혼동 방지
  - 중복 태그 금지, 명시된 내용만 포함

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
