### PR TITLE
[FEAT] 경험 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -47,7 +47,8 @@ public class ExperienceController {
       @RequestParam(required = false) PieceType type,
       @RequestParam(required = false) Long cursor,
       @RequestParam(defaultValue = "10") int size) {
-    ExperienceListResponse response = experienceService.getList(userDetails.getId(), type, cursor, size);
+    ExperienceListResponse response =
+        experienceService.getList(userDetails.getId(), type, cursor, size);
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 

--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,8 +14,10 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.kusitms.kkium.experience.domain.type.PieceType;
 import com.kusitms.kkium.experience.dto.request.ExperienceCreateRequest;
 import com.kusitms.kkium.experience.dto.response.ExperienceAnalyzeResponse;
+import com.kusitms.kkium.experience.dto.response.ExperienceListResponse;
 import com.kusitms.kkium.experience.service.ExperienceService;
 import com.kusitms.kkium.experience.service.analyze.ExperienceAnalyzeService;
 import com.kusitms.kkium.experience.service.analyze.NotionAnalyzeService;
@@ -36,6 +39,17 @@ public class ExperienceController {
   private final NotionAnalyzeService notionAnalyzeService;
   private final ExperienceAnalyzeService experienceAnalyzeService;
   private final ExperienceService experienceService;
+
+  @Operation(summary = "경험 목록 조회", description = "커서 기반 페이지네이션으로 경험 목록을 조회합니다. type 없으면 전체 조회.")
+  @GetMapping
+  public ResponseEntity<ApiResponse<ExperienceListResponse>> getList(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @RequestParam(required = false) PieceType type,
+      @RequestParam(required = false) Long cursor,
+      @RequestParam(defaultValue = "10") int size) {
+    ExperienceListResponse response = experienceService.getList(userDetails.getId(), type, cursor, size);
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
 
   @Operation(
       summary = "PDF 자료 분석",

--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -1,6 +1,8 @@
 package com.kusitms.kkium.experience.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import org.springframework.validation.annotation.Validated;
 
 import com.kusitms.kkium.experience.domain.type.PieceType;
 import com.kusitms.kkium.experience.dto.request.ExperienceCreateRequest;
@@ -33,6 +37,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Experience", description = "경험 관련 API")
 @RequestMapping("/api/v1/experiences")
 @RequiredArgsConstructor
+@Validated
 public class ExperienceController {
 
   private final PdfAnalyzeService pdfAnalyzeService;
@@ -46,7 +51,7 @@ public class ExperienceController {
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @RequestParam(required = false) PieceType type,
       @RequestParam(required = false) Long cursor,
-      @RequestParam(defaultValue = "10") int size) {
+      @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size) {
     ExperienceListResponse response =
         experienceService.getList(userDetails.getId(), type, cursor, size);
     return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Min;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,8 +16,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import org.springframework.validation.annotation.Validated;
 
 import com.kusitms.kkium.experience.domain.type.PieceType;
 import com.kusitms.kkium.experience.dto.request.ExperienceCreateRequest;

--- a/src/main/java/com/kusitms/kkium/experience/dto/response/ExperienceCardResponse.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/response/ExperienceCardResponse.java
@@ -1,0 +1,16 @@
+package com.kusitms.kkium.experience.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.kusitms.kkium.experience.domain.type.PieceType;
+
+public record ExperienceCardResponse(
+    Long pieceId,
+    Long experienceId,
+    PieceType type,
+    String title,
+    String oneLineIntro,
+    LocalDate startDate,
+    LocalDate endDate,
+    List<TagResponse> tags) {}

--- a/src/main/java/com/kusitms/kkium/experience/dto/response/ExperienceListResponse.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/response/ExperienceListResponse.java
@@ -2,4 +2,5 @@ package com.kusitms.kkium.experience.dto.response;
 
 import java.util.List;
 
-public record ExperienceListResponse(boolean hasNext, Long nextCursor, List<ExperienceCardResponse> experiences) {}
+public record ExperienceListResponse(
+    boolean hasNext, Long nextCursor, List<ExperienceCardResponse> experiences) {}

--- a/src/main/java/com/kusitms/kkium/experience/dto/response/ExperienceListResponse.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/response/ExperienceListResponse.java
@@ -1,0 +1,5 @@
+package com.kusitms.kkium.experience.dto.response;
+
+import java.util.List;
+
+public record ExperienceListResponse(boolean hasNext, Long nextCursor, List<ExperienceCardResponse> experiences) {}

--- a/src/main/java/com/kusitms/kkium/experience/dto/response/TagResponse.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/response/TagResponse.java
@@ -1,0 +1,5 @@
+package com.kusitms.kkium.experience.dto.response;
+
+import com.kusitms.kkium.experience.domain.type.TagCategory;
+
+public record TagResponse(TagCategory category, String field) {}

--- a/src/main/java/com/kusitms/kkium/experience/repository/ActivityRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/ActivityRepository.java
@@ -1,5 +1,6 @@
 package com.kusitms.kkium.experience.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,6 @@ import com.kusitms.kkium.experience.domain.Activity;
 
 public interface ActivityRepository extends JpaRepository<Activity, Long> {
   Optional<Activity> findByExperienceId(Long experienceId);
+
+  List<Activity> findByExperienceIdIn(List<Long> experienceIds);
 }

--- a/src/main/java/com/kusitms/kkium/experience/repository/ActivityRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/ActivityRepository.java
@@ -1,7 +1,11 @@
 package com.kusitms.kkium.experience.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.kusitms.kkium.experience.domain.Activity;
 
-public interface ActivityRepository extends JpaRepository<Activity, Long> {}
+public interface ActivityRepository extends JpaRepository<Activity, Long> {
+  Optional<Activity> findByExperienceId(Long experienceId);
+}

--- a/src/main/java/com/kusitms/kkium/experience/repository/CareerRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/CareerRepository.java
@@ -1,5 +1,6 @@
 package com.kusitms.kkium.experience.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,6 @@ import com.kusitms.kkium.experience.domain.Career;
 
 public interface CareerRepository extends JpaRepository<Career, Long> {
   Optional<Career> findByExperienceId(Long experienceId);
+
+  List<Career> findByExperienceIdIn(List<Long> experienceIds);
 }

--- a/src/main/java/com/kusitms/kkium/experience/repository/CareerRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/CareerRepository.java
@@ -1,7 +1,11 @@
 package com.kusitms.kkium.experience.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.kusitms.kkium.experience.domain.Career;
 
-public interface CareerRepository extends JpaRepository<Career, Long> {}
+public interface CareerRepository extends JpaRepository<Career, Long> {
+  Optional<Career> findByExperienceId(Long experienceId);
+}

--- a/src/main/java/com/kusitms/kkium/experience/repository/EducationRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/EducationRepository.java
@@ -1,5 +1,6 @@
 package com.kusitms.kkium.experience.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,6 @@ import com.kusitms.kkium.experience.domain.Education;
 
 public interface EducationRepository extends JpaRepository<Education, Long> {
   Optional<Education> findByExperienceId(Long experienceId);
+
+  List<Education> findByExperienceIdIn(List<Long> experienceIds);
 }

--- a/src/main/java/com/kusitms/kkium/experience/repository/EducationRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/EducationRepository.java
@@ -1,7 +1,11 @@
 package com.kusitms.kkium.experience.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.kusitms.kkium.experience.domain.Education;
 
-public interface EducationRepository extends JpaRepository<Education, Long> {}
+public interface EducationRepository extends JpaRepository<Education, Long> {
+  Optional<Education> findByExperienceId(Long experienceId);
+}

--- a/src/main/java/com/kusitms/kkium/experience/repository/EtcRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/EtcRepository.java
@@ -1,5 +1,6 @@
 package com.kusitms.kkium.experience.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,6 @@ import com.kusitms.kkium.experience.domain.Etc;
 
 public interface EtcRepository extends JpaRepository<Etc, Long> {
   Optional<Etc> findByExperienceId(Long experienceId);
+
+  List<Etc> findByExperienceIdIn(List<Long> experienceIds);
 }

--- a/src/main/java/com/kusitms/kkium/experience/repository/EtcRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/EtcRepository.java
@@ -1,7 +1,11 @@
 package com.kusitms.kkium.experience.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.kusitms.kkium.experience.domain.Etc;
 
-public interface EtcRepository extends JpaRepository<Etc, Long> {}
+public interface EtcRepository extends JpaRepository<Etc, Long> {
+  Optional<Etc> findByExperienceId(Long experienceId);
+}

--- a/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
@@ -14,32 +14,32 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long> {
 
   // 전체 조회 (cursor 없음, 첫 페이지)
   @Query(
-      "SELECT e FROM Experience e JOIN e.piece p WHERE p.user.id = :userId "
-          + "ORDER BY e.updatedDate DESC, e.createdDate DESC")
+      "SELECT e FROM Experience e JOIN FETCH e.piece p WHERE p.user.id = :userId "
+          + "ORDER BY e.id DESC")
   List<Experience> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
 
   // 전체 조회 (cursor 있음)
   @Query(
-      "SELECT e FROM Experience e JOIN e.piece p WHERE p.user.id = :userId "
+      "SELECT e FROM Experience e JOIN FETCH e.piece p WHERE p.user.id = :userId "
           + "AND e.id < :cursor "
-          + "ORDER BY e.updatedDate DESC, e.createdDate DESC")
+          + "ORDER BY e.id DESC")
   List<Experience> findAllByUserIdAndCursor(
       @Param("userId") Long userId, @Param("cursor") Long cursor, Pageable pageable);
 
   // type 필터 조회 (cursor 없음, 첫 페이지)
   @Query(
-      "SELECT e FROM Experience e JOIN e.piece p WHERE p.user.id = :userId "
+      "SELECT e FROM Experience e JOIN FETCH e.piece p WHERE p.user.id = :userId "
           + "AND p.type = :type "
-          + "ORDER BY e.updatedDate DESC, e.createdDate DESC")
+          + "ORDER BY e.id DESC")
   List<Experience> findAllByUserIdAndType(
       @Param("userId") Long userId, @Param("type") PieceType type, Pageable pageable);
 
   // type 필터 조회 (cursor 있음)
   @Query(
-      "SELECT e FROM Experience e JOIN e.piece p WHERE p.user.id = :userId "
+      "SELECT e FROM Experience e JOIN FETCH e.piece p WHERE p.user.id = :userId "
           + "AND p.type = :type "
           + "AND e.id < :cursor "
-          + "ORDER BY e.updatedDate DESC, e.createdDate DESC")
+          + "ORDER BY e.id DESC")
   List<Experience> findAllByUserIdAndTypeAndCursor(
       @Param("userId") Long userId,
       @Param("type") PieceType type,

--- a/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
@@ -1,7 +1,48 @@
 package com.kusitms.kkium.experience.repository;
 
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.kusitms.kkium.experience.domain.Experience;
+import com.kusitms.kkium.experience.domain.type.PieceType;
 
-public interface ExperienceRepository extends JpaRepository<Experience, Long> {}
+public interface ExperienceRepository extends JpaRepository<Experience, Long> {
+
+  // 전체 조회 (cursor 없음, 첫 페이지)
+  @Query(
+      "SELECT e FROM Experience e JOIN e.piece p WHERE p.user.id = :userId "
+          + "ORDER BY e.updatedDate DESC, e.createdDate DESC")
+  List<Experience> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
+
+  // 전체 조회 (cursor 있음)
+  @Query(
+      "SELECT e FROM Experience e JOIN e.piece p WHERE p.user.id = :userId "
+          + "AND e.id < :cursor "
+          + "ORDER BY e.updatedDate DESC, e.createdDate DESC")
+  List<Experience> findAllByUserIdAndCursor(
+      @Param("userId") Long userId, @Param("cursor") Long cursor, Pageable pageable);
+
+  // type 필터 조회 (cursor 없음, 첫 페이지)
+  @Query(
+      "SELECT e FROM Experience e JOIN e.piece p WHERE p.user.id = :userId "
+          + "AND p.type = :type "
+          + "ORDER BY e.updatedDate DESC, e.createdDate DESC")
+  List<Experience> findAllByUserIdAndType(
+      @Param("userId") Long userId, @Param("type") PieceType type, Pageable pageable);
+
+  // type 필터 조회 (cursor 있음)
+  @Query(
+      "SELECT e FROM Experience e JOIN e.piece p WHERE p.user.id = :userId "
+          + "AND p.type = :type "
+          + "AND e.id < :cursor "
+          + "ORDER BY e.updatedDate DESC, e.createdDate DESC")
+  List<Experience> findAllByUserIdAndTypeAndCursor(
+      @Param("userId") Long userId,
+      @Param("type") PieceType type,
+      @Param("cursor") Long cursor,
+      Pageable pageable);
+}

--- a/src/main/java/com/kusitms/kkium/experience/repository/TagRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/TagRepository.java
@@ -1,7 +1,11 @@
 package com.kusitms.kkium.experience.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.kusitms.kkium.experience.domain.Tag;
 
-public interface TagRepository extends JpaRepository<Tag, Long> {}
+public interface TagRepository extends JpaRepository<Tag, Long> {
+  List<Tag> findByExperienceId(Long experienceId);
+}

--- a/src/main/java/com/kusitms/kkium/experience/repository/TagRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/TagRepository.java
@@ -8,4 +8,6 @@ import com.kusitms.kkium.experience.domain.Tag;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
   List<Tag> findByExperienceId(Long experienceId);
+
+  List<Tag> findByExperienceIdIn(List<Long> experienceIds);
 }

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -48,35 +48,41 @@ public class ExperienceService {
 
     List<Experience> experiences;
     if (type == null) {
-      experiences = cursor == null
-          ? experienceRepository.findAllByUserId(userId, pageable)
-          : experienceRepository.findAllByUserIdAndCursor(userId, cursor, pageable);
+      experiences =
+          cursor == null
+              ? experienceRepository.findAllByUserId(userId, pageable)
+              : experienceRepository.findAllByUserIdAndCursor(userId, cursor, pageable);
     } else {
-      experiences = cursor == null
-          ? experienceRepository.findAllByUserIdAndType(userId, type, pageable)
-          : experienceRepository.findAllByUserIdAndTypeAndCursor(userId, type, cursor, pageable);
+      experiences =
+          cursor == null
+              ? experienceRepository.findAllByUserIdAndType(userId, type, pageable)
+              : experienceRepository.findAllByUserIdAndTypeAndCursor(
+                  userId, type, cursor, pageable);
     }
 
     boolean hasNext = experiences.size() > size;
     List<Experience> content = hasNext ? experiences.subList(0, size) : experiences;
 
-    List<ExperienceCardResponse> cards = content.stream()
-        .map(e -> {
-          List<TagResponse> tags = tagRepository.findByExperienceId(e.getId()).stream()
-              .map(t -> new TagResponse(t.getCategory(), t.getField()))
-              .toList();
-          LocalDate[] period = resolvePeriod(e.getPiece().getType(), e.getId());
-          return new ExperienceCardResponse(
-              e.getPiece().getId(),
-              e.getId(),
-              e.getPiece().getType(),
-              e.getTitle(),
-              e.getOneLineIntro(),
-              period[0],
-              period[1],
-              tags);
-        })
-        .toList();
+    List<ExperienceCardResponse> cards =
+        content.stream()
+            .map(
+                e -> {
+                  List<TagResponse> tags =
+                      tagRepository.findByExperienceId(e.getId()).stream()
+                          .map(t -> new TagResponse(t.getCategory(), t.getField()))
+                          .toList();
+                  LocalDate[] period = resolvePeriod(e.getPiece().getType(), e.getId());
+                  return new ExperienceCardResponse(
+                      e.getPiece().getId(),
+                      e.getId(),
+                      e.getPiece().getType(),
+                      e.getTitle(),
+                      e.getOneLineIntro(),
+                      period[0],
+                      period[1],
+                      tags);
+                })
+            .toList();
 
     Long nextCursor = hasNext ? content.get(content.size() - 1).getId() : null;
     return new ExperienceListResponse(hasNext, nextCursor, cards);
@@ -84,18 +90,26 @@ public class ExperienceService {
 
   private LocalDate[] resolvePeriod(PieceType type, Long experienceId) {
     return switch (type) {
-      case ACTIVITY -> activityRepository.findByExperienceId(experienceId)
-          .map(a -> new LocalDate[]{a.getStartDate(), a.getEndDate()})
-          .orElse(new LocalDate[]{null, null});
-      case CAREER -> careerRepository.findByExperienceId(experienceId)
-          .map(c -> new LocalDate[]{c.getStartDate(), c.getEndDate()})
-          .orElse(new LocalDate[]{null, null});
-      case EDUCATION -> educationRepository.findByExperienceId(experienceId)
-          .map(ed -> new LocalDate[]{ed.getStartDate(), ed.getEndDate()})
-          .orElse(new LocalDate[]{null, null});
-      case ETC -> etcRepository.findByExperienceId(experienceId)
-          .map(etc -> new LocalDate[]{etc.getStartDate(), etc.getEndDate()})
-          .orElse(new LocalDate[]{null, null});
+      case ACTIVITY ->
+          activityRepository
+              .findByExperienceId(experienceId)
+              .map(a -> new LocalDate[] {a.getStartDate(), a.getEndDate()})
+              .orElse(new LocalDate[] {null, null});
+      case CAREER ->
+          careerRepository
+              .findByExperienceId(experienceId)
+              .map(c -> new LocalDate[] {c.getStartDate(), c.getEndDate()})
+              .orElse(new LocalDate[] {null, null});
+      case EDUCATION ->
+          educationRepository
+              .findByExperienceId(experienceId)
+              .map(ed -> new LocalDate[] {ed.getStartDate(), ed.getEndDate()})
+              .orElse(new LocalDate[] {null, null});
+      case ETC ->
+          etcRepository
+              .findByExperienceId(experienceId)
+              .map(etc -> new LocalDate[] {etc.getStartDate(), etc.getEndDate()})
+              .orElse(new LocalDate[] {null, null});
     };
   }
 

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -3,7 +3,10 @@ package com.kusitms.kkium.experience.service;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.USER_NOT_FOUND;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -63,15 +66,27 @@ public class ExperienceService {
     boolean hasNext = experiences.size() > size;
     List<Experience> content = hasNext ? experiences.subList(0, size) : experiences;
 
+    List<Long> experienceIds = content.stream().map(Experience::getId).toList();
+
+    // 태그 벌크 조회
+    Map<Long, List<TagResponse>> tagMap =
+        tagRepository.findByExperienceIdIn(experienceIds).stream()
+            .collect(
+                Collectors.groupingBy(
+                    t -> t.getExperience().getId(),
+                    Collectors.mapping(
+                        t -> new TagResponse(t.getCategory(), t.getField()),
+                        Collectors.toList())));
+
+    // 기간 벌크 조회
+    Map<Long, LocalDate[]> periodMap = resolvePeriodBulk(content, experienceIds);
+
     List<ExperienceCardResponse> cards =
         content.stream()
             .map(
                 e -> {
-                  List<TagResponse> tags =
-                      tagRepository.findByExperienceId(e.getId()).stream()
-                          .map(t -> new TagResponse(t.getCategory(), t.getField()))
-                          .toList();
-                  LocalDate[] period = resolvePeriod(e.getPiece().getType(), e.getId());
+                  LocalDate[] period =
+                      periodMap.getOrDefault(e.getId(), new LocalDate[] {null, null});
                   return new ExperienceCardResponse(
                       e.getPiece().getId(),
                       e.getId(),
@@ -80,7 +95,7 @@ public class ExperienceService {
                       e.getOneLineIntro(),
                       period[0],
                       period[1],
-                      tags);
+                      tagMap.getOrDefault(e.getId(), List.of()));
                 })
             .toList();
 
@@ -88,29 +103,55 @@ public class ExperienceService {
     return new ExperienceListResponse(hasNext, nextCursor, cards);
   }
 
-  private LocalDate[] resolvePeriod(PieceType type, Long experienceId) {
-    return switch (type) {
-      case ACTIVITY ->
-          activityRepository
-              .findByExperienceId(experienceId)
-              .map(a -> new LocalDate[] {a.getStartDate(), a.getEndDate()})
-              .orElse(new LocalDate[] {null, null});
-      case CAREER ->
-          careerRepository
-              .findByExperienceId(experienceId)
-              .map(c -> new LocalDate[] {c.getStartDate(), c.getEndDate()})
-              .orElse(new LocalDate[] {null, null});
-      case EDUCATION ->
-          educationRepository
-              .findByExperienceId(experienceId)
-              .map(ed -> new LocalDate[] {ed.getStartDate(), ed.getEndDate()})
-              .orElse(new LocalDate[] {null, null});
-      case ETC ->
-          etcRepository
-              .findByExperienceId(experienceId)
-              .map(etc -> new LocalDate[] {etc.getStartDate(), etc.getEndDate()})
-              .orElse(new LocalDate[] {null, null});
-    };
+  private Map<Long, LocalDate[]> resolvePeriodBulk(
+      List<Experience> content, List<Long> experienceIds) {
+    Map<Long, LocalDate[]> periodMap = new HashMap<>();
+
+    Map<PieceType, List<Long>> byType =
+        content.stream()
+            .collect(
+                Collectors.groupingBy(
+                    e -> e.getPiece().getType(),
+                    Collectors.mapping(Experience::getId, Collectors.toList())));
+
+    if (byType.containsKey(PieceType.ACTIVITY)) {
+      activityRepository
+          .findByExperienceIdIn(byType.get(PieceType.ACTIVITY))
+          .forEach(
+              a ->
+                  periodMap.put(
+                      a.getExperience().getId(),
+                      new LocalDate[] {a.getStartDate(), a.getEndDate()}));
+    }
+    if (byType.containsKey(PieceType.CAREER)) {
+      careerRepository
+          .findByExperienceIdIn(byType.get(PieceType.CAREER))
+          .forEach(
+              c ->
+                  periodMap.put(
+                      c.getExperience().getId(),
+                      new LocalDate[] {c.getStartDate(), c.getEndDate()}));
+    }
+    if (byType.containsKey(PieceType.EDUCATION)) {
+      educationRepository
+          .findByExperienceIdIn(byType.get(PieceType.EDUCATION))
+          .forEach(
+              ed ->
+                  periodMap.put(
+                      ed.getExperience().getId(),
+                      new LocalDate[] {ed.getStartDate(), ed.getEndDate()}));
+    }
+    if (byType.containsKey(PieceType.ETC)) {
+      etcRepository
+          .findByExperienceIdIn(byType.get(PieceType.ETC))
+          .forEach(
+              etc ->
+                  periodMap.put(
+                      etc.getExperience().getId(),
+                      new LocalDate[] {etc.getStartDate(), etc.getEndDate()}));
+    }
+
+    return periodMap;
   }
 
   @Transactional

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -2,16 +2,23 @@ package com.kusitms.kkium.experience.service;
 
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.USER_NOT_FOUND;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import com.kusitms.kkium.experience.domain.*;
+import com.kusitms.kkium.experience.domain.type.PieceType;
 import com.kusitms.kkium.experience.dto.request.ExperienceCreateRequest;
 import com.kusitms.kkium.experience.dto.request.TagCreateRequest;
+import com.kusitms.kkium.experience.dto.response.ExperienceCardResponse;
+import com.kusitms.kkium.experience.dto.response.ExperienceListResponse;
+import com.kusitms.kkium.experience.dto.response.TagResponse;
 import com.kusitms.kkium.experience.repository.*;
 import com.kusitms.kkium.global.exception.BaseException;
 import com.kusitms.kkium.user.domain.User;
@@ -23,6 +30,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ExperienceService {
 
+  private static final int DEFAULT_PAGE_SIZE = 10;
+
   private final UserRepository userRepository;
   private final PieceRepository pieceRepository;
   private final ExperienceRepository experienceRepository;
@@ -32,6 +41,63 @@ public class ExperienceService {
   private final EtcRepository etcRepository;
   private final TagRepository tagRepository;
   private final ExperienceEmbeddingService experienceEmbeddingService;
+
+  @Transactional(readOnly = true)
+  public ExperienceListResponse getList(Long userId, PieceType type, Long cursor, int size) {
+    Pageable pageable = PageRequest.of(0, size + 1);
+
+    List<Experience> experiences;
+    if (type == null) {
+      experiences = cursor == null
+          ? experienceRepository.findAllByUserId(userId, pageable)
+          : experienceRepository.findAllByUserIdAndCursor(userId, cursor, pageable);
+    } else {
+      experiences = cursor == null
+          ? experienceRepository.findAllByUserIdAndType(userId, type, pageable)
+          : experienceRepository.findAllByUserIdAndTypeAndCursor(userId, type, cursor, pageable);
+    }
+
+    boolean hasNext = experiences.size() > size;
+    List<Experience> content = hasNext ? experiences.subList(0, size) : experiences;
+
+    List<ExperienceCardResponse> cards = content.stream()
+        .map(e -> {
+          List<TagResponse> tags = tagRepository.findByExperienceId(e.getId()).stream()
+              .map(t -> new TagResponse(t.getCategory(), t.getField()))
+              .toList();
+          LocalDate[] period = resolvePeriod(e.getPiece().getType(), e.getId());
+          return new ExperienceCardResponse(
+              e.getPiece().getId(),
+              e.getId(),
+              e.getPiece().getType(),
+              e.getTitle(),
+              e.getOneLineIntro(),
+              period[0],
+              period[1],
+              tags);
+        })
+        .toList();
+
+    Long nextCursor = hasNext ? content.get(content.size() - 1).getId() : null;
+    return new ExperienceListResponse(hasNext, nextCursor, cards);
+  }
+
+  private LocalDate[] resolvePeriod(PieceType type, Long experienceId) {
+    return switch (type) {
+      case ACTIVITY -> activityRepository.findByExperienceId(experienceId)
+          .map(a -> new LocalDate[]{a.getStartDate(), a.getEndDate()})
+          .orElse(new LocalDate[]{null, null});
+      case CAREER -> careerRepository.findByExperienceId(experienceId)
+          .map(c -> new LocalDate[]{c.getStartDate(), c.getEndDate()})
+          .orElse(new LocalDate[]{null, null});
+      case EDUCATION -> educationRepository.findByExperienceId(experienceId)
+          .map(ed -> new LocalDate[]{ed.getStartDate(), ed.getEndDate()})
+          .orElse(new LocalDate[]{null, null});
+      case ETC -> etcRepository.findByExperienceId(experienceId)
+          .map(etc -> new LocalDate[]{etc.getStartDate(), etc.getEndDate()})
+          .orElse(new LocalDate[]{null, null});
+    };
+  }
 
   @Transactional
   public void save(Long userId, ExperienceCreateRequest request) {

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -75,8 +75,7 @@ public class ExperienceService {
                 Collectors.groupingBy(
                     t -> t.getExperience().getId(),
                     Collectors.mapping(
-                        t -> new TagResponse(t.getCategory(), t.getField()),
-                        Collectors.toList())));
+                        t -> new TagResponse(t.getCategory(), t.getField()), Collectors.toList())));
 
     // 기간 벌크 조회
     Map<Long, LocalDate[]> periodMap = resolvePeriodBulk(content, experienceIds);


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #49 

## ✏️ 작업 내용

- GET /api/v1/experiences 엔드포인트 추가
- 커서 기반 페이지네이션 구현 (cursor, size)
- type 필터링 지원 (ACTIVITY | CAREER | EDUCATION | ETC), 없으면 전체 조회
- 정렬 기준 updatedDate DESC → createdDate DESC
- ExperienceListResponse, ExperienceCardResponse, TagResponse DTO 생성
- ExperienceRepository cursor 기반 JPQL 쿼리 4개 추가
- ActivityRepository, CareerRepository, EducationRepository, EtcRepository findByExperienceId 추가
- TagRepository findByExperienceId 추가

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
