### PR TITLE
[FEAT] 경험 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -58,7 +58,7 @@ public class ExperienceController {
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 
-  @Operation(summary = "경험 단건 조회", description = "경험 ID로 상세 정보를 조회합니다.")
+  @Operation(summary = "경험 상세 조회", description = "경험 ID로 상세 정보를 조회합니다.")
   @GetMapping("/{experienceId}")
   public ResponseEntity<ApiResponse<ExperienceDetailResponse>> getDetail(
       @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -61,8 +61,7 @@ public class ExperienceController {
   @Operation(summary = "경험 상세 조회", description = "경험 ID로 상세 정보를 조회합니다.")
   @GetMapping("/{experienceId}")
   public ResponseEntity<ApiResponse<ExperienceDetailResponse>> getDetail(
-      @AuthenticationPrincipal CustomUserDetails userDetails,
-      @PathVariable Long experienceId) {
+      @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long experienceId) {
     ExperienceDetailResponse response =
         experienceService.getDetail(userDetails.getId(), experienceId);
     return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.kusitms.kkium.experience.domain.type.PieceType;
 import com.kusitms.kkium.experience.dto.request.ExperienceCreateRequest;
 import com.kusitms.kkium.experience.dto.response.ExperienceAnalyzeResponse;
+import com.kusitms.kkium.experience.dto.response.ExperienceDetailResponse;
 import com.kusitms.kkium.experience.dto.response.ExperienceListResponse;
 import com.kusitms.kkium.experience.service.ExperienceService;
 import com.kusitms.kkium.experience.service.analyze.ExperienceAnalyzeService;
@@ -53,6 +55,16 @@ public class ExperienceController {
       @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size) {
     ExperienceListResponse response =
         experienceService.getList(userDetails.getId(), type, cursor, size);
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+
+  @Operation(summary = "경험 단건 조회", description = "경험 ID로 상세 정보를 조회합니다.")
+  @GetMapping("/{experienceId}")
+  public ResponseEntity<ApiResponse<ExperienceDetailResponse>> getDetail(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long experienceId) {
+    ExperienceDetailResponse response =
+        experienceService.getDetail(userDetails.getId(), experienceId);
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 

--- a/src/main/java/com/kusitms/kkium/experience/dto/response/ExperienceDetailResponse.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/response/ExperienceDetailResponse.java
@@ -2,6 +2,7 @@ package com.kusitms.kkium.experience.dto.response;
 
 import java.util.List;
 
+import com.kusitms.kkium.experience.domain.Experience;
 import com.kusitms.kkium.experience.domain.type.PieceType;
 
 public record ExperienceDetailResponse(
@@ -16,4 +17,22 @@ public record ExperienceDetailResponse(
     String act,
     String result,
     String taken,
-    Object detail) {}
+    Object detail) {
+
+  public static ExperienceDetailResponse of(
+      Experience experience, List<TagResponse> tags, Object detail) {
+    return new ExperienceDetailResponse(
+        experience.getPiece().getId(),
+        experience.getId(),
+        experience.getPiece().getType(),
+        experience.getTitle(),
+        experience.getOneLineIntro(),
+        tags,
+        experience.getSituation(),
+        experience.getTask(),
+        experience.getAct(),
+        experience.getResult(),
+        experience.getTaken(),
+        detail);
+  }
+}

--- a/src/main/java/com/kusitms/kkium/experience/dto/response/ExperienceDetailResponse.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/response/ExperienceDetailResponse.java
@@ -1,0 +1,19 @@
+package com.kusitms.kkium.experience.dto.response;
+
+import java.util.List;
+
+import com.kusitms.kkium.experience.domain.type.PieceType;
+
+public record ExperienceDetailResponse(
+    Long pieceId,
+    Long experienceId,
+    PieceType type,
+    String title,
+    String oneLineIntro,
+    List<TagResponse> tags,
+    String situation,
+    String task,
+    String act,
+    String result,
+    String taken,
+    Object detail) {}

--- a/src/main/java/com/kusitms/kkium/experience/dto/response/detail/ActivityDetail.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/response/detail/ActivityDetail.java
@@ -1,0 +1,24 @@
+package com.kusitms.kkium.experience.dto.response.detail;
+
+import java.time.LocalDate;
+
+import com.kusitms.kkium.experience.domain.Activity;
+
+public record ActivityDetail(
+    String name,
+    Integer teamNum,
+    String role,
+    Integer contributionRate,
+    LocalDate startDate,
+    LocalDate endDate) {
+
+  public static ActivityDetail from(Activity activity) {
+    return new ActivityDetail(
+        activity.getName(),
+        activity.getTeamNum(),
+        activity.getRole(),
+        activity.getContributionRate(),
+        activity.getStartDate(),
+        activity.getEndDate());
+  }
+}

--- a/src/main/java/com/kusitms/kkium/experience/dto/response/detail/CareerDetail.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/response/detail/CareerDetail.java
@@ -1,0 +1,22 @@
+package com.kusitms.kkium.experience.dto.response.detail;
+
+import java.time.LocalDate;
+
+import com.kusitms.kkium.experience.domain.Career;
+
+public record CareerDetail(
+    String name,
+    String company,
+    String employmentStatus,
+    LocalDate startDate,
+    LocalDate endDate) {
+
+  public static CareerDetail from(Career career) {
+    return new CareerDetail(
+        career.getName(),
+        career.getCompany(),
+        career.getEmploymentStatus(),
+        career.getStartDate(),
+        career.getEndDate());
+  }
+}

--- a/src/main/java/com/kusitms/kkium/experience/dto/response/detail/CareerDetail.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/response/detail/CareerDetail.java
@@ -5,11 +5,7 @@ import java.time.LocalDate;
 import com.kusitms.kkium.experience.domain.Career;
 
 public record CareerDetail(
-    String name,
-    String company,
-    String employmentStatus,
-    LocalDate startDate,
-    LocalDate endDate) {
+    String name, String company, String employmentStatus, LocalDate startDate, LocalDate endDate) {
 
   public static CareerDetail from(Career career) {
     return new CareerDetail(

--- a/src/main/java/com/kusitms/kkium/experience/dto/response/detail/EducationDetail.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/response/detail/EducationDetail.java
@@ -1,0 +1,17 @@
+package com.kusitms.kkium.experience.dto.response.detail;
+
+import java.time.LocalDate;
+
+import com.kusitms.kkium.experience.domain.Education;
+
+public record EducationDetail(
+    String organizationName, String name, LocalDate startDate, LocalDate endDate) {
+
+  public static EducationDetail from(Education education) {
+    return new EducationDetail(
+        education.getOrganizationName(),
+        education.getName(),
+        education.getStartDate(),
+        education.getEndDate());
+  }
+}

--- a/src/main/java/com/kusitms/kkium/experience/dto/response/detail/EtcDetail.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/response/detail/EtcDetail.java
@@ -1,0 +1,12 @@
+package com.kusitms.kkium.experience.dto.response.detail;
+
+import java.time.LocalDate;
+
+import com.kusitms.kkium.experience.domain.Etc;
+
+public record EtcDetail(LocalDate startDate, LocalDate endDate) {
+
+  public static EtcDetail from(Etc etc) {
+    return new EtcDetail(etc.getStartDate(), etc.getEndDate());
+  }
+}

--- a/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
@@ -1,6 +1,7 @@
 package com.kusitms.kkium.experience.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,6 +12,9 @@ import com.kusitms.kkium.experience.domain.Experience;
 import com.kusitms.kkium.experience.domain.type.PieceType;
 
 public interface ExperienceRepository extends JpaRepository<Experience, Long> {
+
+  @Query("SELECT e FROM Experience e JOIN FETCH e.piece p WHERE e.id = :experienceId")
+  Optional<Experience> findByIdWithPiece(@Param("experienceId") Long experienceId);
 
   // 전체 조회 (cursor 없음, 첫 페이지)
   @Query(

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -1,6 +1,8 @@
 package com.kusitms.kkium.experience.service;
 
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.USER_NOT_FOUND;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_NOT_FOUND;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.FORBIDDEN;
 
 import java.time.LocalDate;
 import java.util.HashMap;
@@ -20,8 +22,13 @@ import com.kusitms.kkium.experience.domain.type.PieceType;
 import com.kusitms.kkium.experience.dto.request.ExperienceCreateRequest;
 import com.kusitms.kkium.experience.dto.request.TagCreateRequest;
 import com.kusitms.kkium.experience.dto.response.ExperienceCardResponse;
+import com.kusitms.kkium.experience.dto.response.ExperienceDetailResponse;
 import com.kusitms.kkium.experience.dto.response.ExperienceListResponse;
 import com.kusitms.kkium.experience.dto.response.TagResponse;
+import com.kusitms.kkium.experience.dto.response.detail.ActivityDetail;
+import com.kusitms.kkium.experience.dto.response.detail.CareerDetail;
+import com.kusitms.kkium.experience.dto.response.detail.EducationDetail;
+import com.kusitms.kkium.experience.dto.response.detail.EtcDetail;
 import com.kusitms.kkium.experience.repository.*;
 import com.kusitms.kkium.global.exception.BaseException;
 import com.kusitms.kkium.user.domain.User;
@@ -44,6 +51,69 @@ public class ExperienceService {
   private final EtcRepository etcRepository;
   private final TagRepository tagRepository;
   private final ExperienceEmbeddingService experienceEmbeddingService;
+
+  @Transactional(readOnly = true)
+  public ExperienceDetailResponse getDetail(Long userId, Long experienceId) {
+    Experience experience =
+        experienceRepository
+            .findByIdWithPiece(experienceId)
+            .orElseThrow(() -> new BaseException(EXPERIENCE_NOT_FOUND));
+
+    if (!experience.getPiece().getUser().getId().equals(userId)) {
+      throw new BaseException(FORBIDDEN);
+    }
+
+    List<TagResponse> tags =
+        tagRepository.findByExperienceIdIn(List.of(experienceId)).stream()
+            .map(t -> new TagResponse(t.getCategory(), t.getField()))
+            .toList();
+
+    Object detail =
+        switch (experience.getPiece().getType()) {
+          case ACTIVITY ->
+              activityRepository
+                  .findByExperienceIdIn(List.of(experienceId))
+                  .stream()
+                  .findFirst()
+                  .map(ActivityDetail::from)
+                  .orElse(null);
+          case CAREER ->
+              careerRepository
+                  .findByExperienceIdIn(List.of(experienceId))
+                  .stream()
+                  .findFirst()
+                  .map(CareerDetail::from)
+                  .orElse(null);
+          case EDUCATION ->
+              educationRepository
+                  .findByExperienceIdIn(List.of(experienceId))
+                  .stream()
+                  .findFirst()
+                  .map(EducationDetail::from)
+                  .orElse(null);
+          case ETC ->
+              etcRepository
+                  .findByExperienceIdIn(List.of(experienceId))
+                  .stream()
+                  .findFirst()
+                  .map(EtcDetail::from)
+                  .orElse(null);
+        };
+
+    return new ExperienceDetailResponse(
+        experience.getPiece().getId(),
+        experience.getId(),
+        experience.getPiece().getType(),
+        experience.getTitle(),
+        experience.getOneLineIntro(),
+        tags,
+        experience.getSituation(),
+        experience.getTask(),
+        experience.getAct(),
+        experience.getResult(),
+        experience.getTaken(),
+        detail);
+  }
 
   @Transactional(readOnly = true)
   public ExperienceListResponse getList(Long userId, PieceType type, Long cursor, int size) {

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -70,49 +70,13 @@ public class ExperienceService {
 
     Object detail =
         switch (experience.getPiece().getType()) {
-          case ACTIVITY ->
-              activityRepository
-                  .findByExperienceIdIn(List.of(experienceId))
-                  .stream()
-                  .findFirst()
-                  .map(ActivityDetail::from)
-                  .orElse(null);
-          case CAREER ->
-              careerRepository
-                  .findByExperienceIdIn(List.of(experienceId))
-                  .stream()
-                  .findFirst()
-                  .map(CareerDetail::from)
-                  .orElse(null);
-          case EDUCATION ->
-              educationRepository
-                  .findByExperienceIdIn(List.of(experienceId))
-                  .stream()
-                  .findFirst()
-                  .map(EducationDetail::from)
-                  .orElse(null);
-          case ETC ->
-              etcRepository
-                  .findByExperienceIdIn(List.of(experienceId))
-                  .stream()
-                  .findFirst()
-                  .map(EtcDetail::from)
-                  .orElse(null);
+          case ACTIVITY -> activityRepository.findByExperienceId(experienceId).map(ActivityDetail::from).orElse(null);
+          case CAREER -> careerRepository.findByExperienceId(experienceId).map(CareerDetail::from).orElse(null);
+          case EDUCATION -> educationRepository.findByExperienceId(experienceId).map(EducationDetail::from).orElse(null);
+          case ETC -> etcRepository.findByExperienceId(experienceId).map(EtcDetail::from).orElse(null);
         };
 
-    return new ExperienceDetailResponse(
-        experience.getPiece().getId(),
-        experience.getId(),
-        experience.getPiece().getType(),
-        experience.getTitle(),
-        experience.getOneLineIntro(),
-        tags,
-        experience.getSituation(),
-        experience.getTask(),
-        experience.getAct(),
-        experience.getResult(),
-        experience.getTaken(),
-        detail);
+    return ExperienceDetailResponse.of(experience, tags, detail);
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -1,8 +1,8 @@
 package com.kusitms.kkium.experience.service;
 
-import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.USER_NOT_FOUND;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_NOT_FOUND;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.FORBIDDEN;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.USER_NOT_FOUND;
 
 import java.time.LocalDate;
 import java.util.HashMap;
@@ -70,10 +70,23 @@ public class ExperienceService {
 
     Object detail =
         switch (experience.getPiece().getType()) {
-          case ACTIVITY -> activityRepository.findByExperienceId(experienceId).map(ActivityDetail::from).orElse(null);
-          case CAREER -> careerRepository.findByExperienceId(experienceId).map(CareerDetail::from).orElse(null);
-          case EDUCATION -> educationRepository.findByExperienceId(experienceId).map(EducationDetail::from).orElse(null);
-          case ETC -> etcRepository.findByExperienceId(experienceId).map(EtcDetail::from).orElse(null);
+          case ACTIVITY ->
+              activityRepository
+                  .findByExperienceId(experienceId)
+                  .map(ActivityDetail::from)
+                  .orElse(null);
+          case CAREER ->
+              careerRepository
+                  .findByExperienceId(experienceId)
+                  .map(CareerDetail::from)
+                  .orElse(null);
+          case EDUCATION ->
+              educationRepository
+                  .findByExperienceId(experienceId)
+                  .map(EducationDetail::from)
+                  .orElse(null);
+          case ETC ->
+              etcRepository.findByExperienceId(experienceId).map(EtcDetail::from).orElse(null);
         };
 
     return ExperienceDetailResponse.of(experience, tags, detail);

--- a/src/main/java/com/kusitms/kkium/global/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/kusitms/kkium/global/exception/errorcode/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
   NOTION_BLOCK_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "N005", "Notion 블록 콘텐츠 파싱에 실패했습니다."),
 
   // experience
+  EXPERIENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "E005", "존재하지 않는 경험입니다."),
   INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "E001", "PDF 파일만 업로드 가능합니다."),
   FILE_ALREADY_UPLOADED(HttpStatus.CONFLICT, "E002", "이미 업로드된 자료가 있습니다. 다시 업로드하면 초기화됩니다."),
   PDF_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "E003", "PDF 파일 파싱에 실패했습니다."),


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #52 

## ✏️ 작업 내용

- type별 detail DTO 추가 (ActivityDetail, CareerDetail, EducationDetail, EtcDetail)
- ExperienceDetailResponse 추가
- ExperienceRepository 단건 조회 쿼리 추가 (findByIdWithPiece)
- ExperienceService.getDetail() 구현
- ExperienceController GET /api/v1/experiences/{experienceId} 엔드포인트 추가
- ErrorCode EXPERIENCE_NOT_FOUND 추가

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
