### PR TITLE
[FEAT] 경험 키워드 검색 기능 구현

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -46,15 +46,21 @@ public class ExperienceController {
   private final ExperienceAnalyzeService experienceAnalyzeService;
   private final ExperienceService experienceService;
 
-  @Operation(summary = "경험 목록 조회", description = "커서 기반 페이지네이션으로 경험 목록을 조회합니다. type 없으면 전체 조회.")
+  @Operation(
+      summary = "경험 목록 조회",
+      description =
+          "커서 기반 페이지네이션으로 경험 목록을 조회합니다. "
+              + "keyword가 있으면 경험 제목·기술태그·역량태그를 통합 검색합니다. "
+              + "type 없으면 전체 조회.")
   @GetMapping
   public ResponseEntity<ApiResponse<ExperienceListResponse>> getList(
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @RequestParam(required = false) PieceType type,
+      @RequestParam(required = false) String keyword,
       @RequestParam(required = false) Long cursor,
       @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size) {
     ExperienceListResponse response =
-        experienceService.getList(userDetails.getId(), type, cursor, size);
+        experienceService.getList(userDetails.getId(), type, cursor, size, keyword);
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 

--- a/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
@@ -54,7 +54,7 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long> {
   @Query(
       "SELECT DISTINCT e.id FROM Experience e JOIN e.piece p LEFT JOIN Tag t ON t.experience = e "
           + "WHERE p.user.id = :userId "
-          + "AND (e.title LIKE CONCAT('%', :keyword, '%') OR t.field LIKE CONCAT('%', :keyword, '%')) "
+          + "AND (LOWER(e.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(t.field) LIKE LOWER(CONCAT('%', :keyword, '%'))) "
           + "ORDER BY e.id DESC")
   List<Long> findIdsByKeyword(
       @Param("userId") Long userId, @Param("keyword") String keyword, Pageable pageable);
@@ -64,7 +64,7 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long> {
       "SELECT DISTINCT e.id FROM Experience e JOIN e.piece p LEFT JOIN Tag t ON t.experience = e "
           + "WHERE p.user.id = :userId "
           + "AND e.id < :cursor "
-          + "AND (e.title LIKE CONCAT('%', :keyword, '%') OR t.field LIKE CONCAT('%', :keyword, '%')) "
+          + "AND (LOWER(e.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(t.field) LIKE LOWER(CONCAT('%', :keyword, '%'))) "
           + "ORDER BY e.id DESC")
   List<Long> findIdsByKeywordAndCursor(
       @Param("userId") Long userId,

--- a/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
@@ -73,7 +73,6 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long> {
       Pageable pageable);
 
   // 키워드 검색 - Step 2: id IN으로 fetch
-  @Query(
-      "SELECT e FROM Experience e JOIN FETCH e.piece p WHERE e.id IN :ids ORDER BY e.id DESC")
+  @Query("SELECT e FROM Experience e JOIN FETCH e.piece p WHERE e.id IN :ids ORDER BY e.id DESC")
   List<Experience> findAllByIdIn(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
@@ -49,4 +49,31 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long> {
       @Param("type") PieceType type,
       @Param("cursor") Long cursor,
       Pageable pageable);
+
+  // 키워드 검색 - Step 1: id 목록 추출 (cursor 없음)
+  @Query(
+      "SELECT DISTINCT e.id FROM Experience e JOIN e.piece p LEFT JOIN Tag t ON t.experience = e "
+          + "WHERE p.user.id = :userId "
+          + "AND (e.title LIKE CONCAT('%', :keyword, '%') OR t.field LIKE CONCAT('%', :keyword, '%')) "
+          + "ORDER BY e.id DESC")
+  List<Long> findIdsByKeyword(
+      @Param("userId") Long userId, @Param("keyword") String keyword, Pageable pageable);
+
+  // 키워드 검색 - Step 1: id 목록 추출 (cursor 있음)
+  @Query(
+      "SELECT DISTINCT e.id FROM Experience e JOIN e.piece p LEFT JOIN Tag t ON t.experience = e "
+          + "WHERE p.user.id = :userId "
+          + "AND e.id < :cursor "
+          + "AND (e.title LIKE CONCAT('%', :keyword, '%') OR t.field LIKE CONCAT('%', :keyword, '%')) "
+          + "ORDER BY e.id DESC")
+  List<Long> findIdsByKeywordAndCursor(
+      @Param("userId") Long userId,
+      @Param("keyword") String keyword,
+      @Param("cursor") Long cursor,
+      Pageable pageable);
+
+  // 키워드 검색 - Step 2: id IN으로 fetch
+  @Query(
+      "SELECT e FROM Experience e JOIN FETCH e.piece p WHERE e.id IN :ids ORDER BY e.id DESC")
+  List<Experience> findAllByIdIn(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
@@ -54,21 +54,27 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long> {
   @Query(
       "SELECT DISTINCT e.id FROM Experience e JOIN e.piece p LEFT JOIN Tag t ON t.experience = e "
           + "WHERE p.user.id = :userId "
+          + "AND (:type IS NULL OR p.type = :type) "
           + "AND (LOWER(e.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(t.field) LIKE LOWER(CONCAT('%', :keyword, '%'))) "
           + "ORDER BY e.id DESC")
   List<Long> findIdsByKeyword(
-      @Param("userId") Long userId, @Param("keyword") String keyword, Pageable pageable);
+      @Param("userId") Long userId,
+      @Param("keyword") String keyword,
+      @Param("type") PieceType type,
+      Pageable pageable);
 
   // 키워드 검색 - Step 1: id 목록 추출 (cursor 있음)
   @Query(
       "SELECT DISTINCT e.id FROM Experience e JOIN e.piece p LEFT JOIN Tag t ON t.experience = e "
           + "WHERE p.user.id = :userId "
           + "AND e.id < :cursor "
+          + "AND (:type IS NULL OR p.type = :type) "
           + "AND (LOWER(e.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(t.field) LIKE LOWER(CONCAT('%', :keyword, '%'))) "
           + "ORDER BY e.id DESC")
   List<Long> findIdsByKeywordAndCursor(
       @Param("userId") Long userId,
       @Param("keyword") String keyword,
+      @Param("type") PieceType type,
       @Param("cursor") Long cursor,
       Pageable pageable);
 

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -93,11 +93,19 @@ public class ExperienceService {
   }
 
   @Transactional(readOnly = true)
-  public ExperienceListResponse getList(Long userId, PieceType type, Long cursor, int size) {
+  public ExperienceListResponse getList(Long userId, PieceType type, Long cursor, int size, String keyword) {
     Pageable pageable = PageRequest.of(0, size + 1);
 
     List<Experience> experiences;
-    if (type == null) {
+
+    if (keyword != null && !keyword.isBlank()) {
+      // 키워드 검색: 2-step (id 추출 → fetch)
+      List<Long> ids =
+          cursor == null
+              ? experienceRepository.findIdsByKeyword(userId, keyword, pageable)
+              : experienceRepository.findIdsByKeywordAndCursor(userId, keyword, cursor, pageable);
+      experiences = experienceRepository.findAllByIdIn(ids);
+    } else if (type == null) {
       experiences =
           cursor == null
               ? experienceRepository.findAllByUserId(userId, pageable)
@@ -106,8 +114,7 @@ public class ExperienceService {
       experiences =
           cursor == null
               ? experienceRepository.findAllByUserIdAndType(userId, type, pageable)
-              : experienceRepository.findAllByUserIdAndTypeAndCursor(
-                  userId, type, cursor, pageable);
+              : experienceRepository.findAllByUserIdAndTypeAndCursor(userId, type, cursor, pageable);
     }
 
     boolean hasNext = experiences.size() > size;

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -104,7 +104,8 @@ public class ExperienceService {
       List<Long> ids =
           cursor == null
               ? experienceRepository.findIdsByKeyword(userId, keyword, type, pageable)
-              : experienceRepository.findIdsByKeywordAndCursor(userId, keyword, type, cursor, pageable);
+              : experienceRepository.findIdsByKeywordAndCursor(
+                  userId, keyword, type, cursor, pageable);
       if (ids.isEmpty()) {
         return new ExperienceListResponse(false, null, List.of());
       }

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -103,8 +103,8 @@ public class ExperienceService {
       // 키워드 검색: 2-step (id 추출 → fetch)
       List<Long> ids =
           cursor == null
-              ? experienceRepository.findIdsByKeyword(userId, keyword, pageable)
-              : experienceRepository.findIdsByKeywordAndCursor(userId, keyword, cursor, pageable);
+              ? experienceRepository.findIdsByKeyword(userId, keyword, type, pageable)
+              : experienceRepository.findIdsByKeywordAndCursor(userId, keyword, type, cursor, pageable);
       if (ids.isEmpty()) {
         return new ExperienceListResponse(false, null, List.of());
       }

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -105,6 +105,9 @@ public class ExperienceService {
           cursor == null
               ? experienceRepository.findIdsByKeyword(userId, keyword, pageable)
               : experienceRepository.findIdsByKeywordAndCursor(userId, keyword, cursor, pageable);
+      if (ids.isEmpty()) {
+        return new ExperienceListResponse(false, null, List.of());
+      }
       experiences = experienceRepository.findAllByIdIn(ids);
     } else if (type == null) {
       experiences =

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -93,7 +93,8 @@ public class ExperienceService {
   }
 
   @Transactional(readOnly = true)
-  public ExperienceListResponse getList(Long userId, PieceType type, Long cursor, int size, String keyword) {
+  public ExperienceListResponse getList(
+      Long userId, PieceType type, Long cursor, int size, String keyword) {
     Pageable pageable = PageRequest.of(0, size + 1);
 
     List<Experience> experiences;
@@ -114,7 +115,8 @@ public class ExperienceService {
       experiences =
           cursor == null
               ? experienceRepository.findAllByUserIdAndType(userId, type, pageable)
-              : experienceRepository.findAllByUserIdAndTypeAndCursor(userId, type, cursor, pageable);
+              : experienceRepository.findAllByUserIdAndTypeAndCursor(
+                  userId, type, cursor, pageable);
     }
 
     boolean hasNext = experiences.size() > size;


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #54

## ✏️ 작업 내용

- GET /api/v1/experiences에 keyword 쿼리 파라미터 추가
- ExperienceRepository에 키워드 기반 id 추출 쿼리 추가
  - Experience.title OR Tag.field LIKE 검색, 대소문자 구분 없음
  - cursor 유무에 따라 쿼리 분리
- ExperienceService.getList()에 keyword 분기 로직 추가
- ExperienceController.getList()에 keyword 파라미터 추가

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
