### PR TITLE
[FEAT] 공고 분석, 경험 카드 상세 분석 기능

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
@@ -22,6 +22,12 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long> {
           + "ORDER BY e.id DESC")
   List<Experience> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
 
+  // 공고분석용 전체 조회 (페이지네이션 없음)
+  @Query(
+      "SELECT e FROM Experience e JOIN FETCH e.piece p WHERE p.user.id = :userId "
+          + "ORDER BY e.id DESC")
+  List<Experience> findAllByUserIdNoPage(@Param("userId") Long userId);
+
   // 전체 조회 (cursor 있음)
   @Query(
       "SELECT e FROM Experience e JOIN FETCH e.piece p WHERE p.user.id = :userId "

--- a/src/main/java/com/kusitms/kkium/global/config/WebClientConfig.java
+++ b/src/main/java/com/kusitms/kkium/global/config/WebClientConfig.java
@@ -38,12 +38,12 @@ public class WebClientConfig {
         client ->
             HttpClient.create()
                 .compress(true) // gzip/br 응답 자동 디코딩
-                .responseTimeout(Duration.ofSeconds(30))
+                .responseTimeout(Duration.ofSeconds(120))
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
                 .doOnConnected(
                     connection ->
                         connection
-                            .addHandlerLast(new ReadTimeoutHandler(60))
+                            .addHandlerLast(new ReadTimeoutHandler(120))
                             .addHandlerLast(new WriteTimeoutHandler(10)));
 
     // HTTP 클라이언트와 연결

--- a/src/main/java/com/kusitms/kkium/jd/controller/JdController.java
+++ b/src/main/java/com/kusitms/kkium/jd/controller/JdController.java
@@ -23,9 +23,11 @@ import com.kusitms.kkium.jd.dto.request.JdUpdateRequest;
 import com.kusitms.kkium.jd.dto.response.JdAnalysisResponse;
 import com.kusitms.kkium.jd.dto.response.JdFetchResponse;
 import com.kusitms.kkium.jd.dto.response.JdListPageResponse;
+import com.kusitms.kkium.jd.dto.response.JdMatchAnalysisResponse;
 import com.kusitms.kkium.jd.dto.response.JdResponse;
 import com.kusitms.kkium.jd.dto.response.JdSaveResponse;
 import com.kusitms.kkium.jd.service.JdEmbeddingService;
+import com.kusitms.kkium.jd.service.JdMatchService;
 import com.kusitms.kkium.jd.service.JdScrapService;
 import com.kusitms.kkium.jd.service.JdService;
 import com.kusitms.kkium.user.utils.CustomUserDetails;
@@ -43,6 +45,7 @@ public class JdController {
   private final JdService jdService;
   private final JdScrapService jdScrapService;
   private final JdEmbeddingService jdAnalysisService;
+  private final JdMatchService jdMatchService;
 
   @Operation(summary = "[공고등록] 채용공고 URL 파싱", description = "링크를 입력하면 공고 내용을 파싱해 반환합니다.")
   @PostMapping("/url")
@@ -140,5 +143,13 @@ public class JdController {
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     jdService.updateOrder(request, userDetails);
     return ResponseEntity.ok(ApiResponse.successWithNoContent());
+  }
+
+  @Operation(summary = "[공고분석] 공고 분석 및 경험 매칭", description = "공고 분석 결과와 경험별 활용 적합도, 지원 적합도를 반환합니다.")
+  @GetMapping("/{jdId}/analysis")
+  public ResponseEntity<ApiResponse<JdMatchAnalysisResponse>> getMatchAnalysis(
+      @PathVariable Long jdId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    return ResponseEntity.ok(
+        ApiResponse.success(jdMatchService.analyze(jdId, userDetails.getId())));
   }
 }

--- a/src/main/java/com/kusitms/kkium/jd/controller/JdController.java
+++ b/src/main/java/com/kusitms/kkium/jd/controller/JdController.java
@@ -21,12 +21,14 @@ import com.kusitms.kkium.jd.dto.request.JdSaveRequest;
 import com.kusitms.kkium.jd.dto.request.JdTitleUpdateRequest;
 import com.kusitms.kkium.jd.dto.request.JdUpdateRequest;
 import com.kusitms.kkium.jd.dto.response.JdAnalysisResponse;
+import com.kusitms.kkium.jd.dto.response.JdExperienceAnalysisResponse;
 import com.kusitms.kkium.jd.dto.response.JdFetchResponse;
 import com.kusitms.kkium.jd.dto.response.JdListPageResponse;
 import com.kusitms.kkium.jd.dto.response.JdMatchAnalysisResponse;
 import com.kusitms.kkium.jd.dto.response.JdResponse;
 import com.kusitms.kkium.jd.dto.response.JdSaveResponse;
 import com.kusitms.kkium.jd.service.JdEmbeddingService;
+import com.kusitms.kkium.jd.service.JdExperienceAnalysisService;
 import com.kusitms.kkium.jd.service.JdMatchService;
 import com.kusitms.kkium.jd.service.JdScrapService;
 import com.kusitms.kkium.jd.service.JdService;
@@ -46,6 +48,7 @@ public class JdController {
   private final JdScrapService jdScrapService;
   private final JdEmbeddingService jdAnalysisService;
   private final JdMatchService jdMatchService;
+  private final JdExperienceAnalysisService jdExperienceAnalysisService;
 
   @Operation(summary = "[공고등록] 채용공고 URL 파싱", description = "링크를 입력하면 공고 내용을 파싱해 반환합니다.")
   @PostMapping("/url")
@@ -151,5 +154,15 @@ public class JdController {
       @PathVariable Long jdId, @AuthenticationPrincipal CustomUserDetails userDetails) {
     return ResponseEntity.ok(
         ApiResponse.success(jdMatchService.analyze(jdId, userDetails.getId())));
+  }
+
+  @Operation(
+      summary = "[공고분석] 경험 카드 상세 분석",
+      description = "경험 카드 클릭 시 좋은 점 / 부족한 점 / 활용 가이드 / 하이라이팅 키워드를 반환합니다.")
+  @GetMapping("/{jdId}/analysis/experiences/{experienceId}")
+  public ResponseEntity<ApiResponse<JdExperienceAnalysisResponse>> getExperienceAnalysis(
+      @PathVariable Long jdId, @PathVariable Long experienceId) {
+    return ResponseEntity.ok(
+        ApiResponse.success(jdExperienceAnalysisService.analyze(jdId, experienceId)));
   }
 }

--- a/src/main/java/com/kusitms/kkium/jd/dto/response/JdExperienceAnalysisResponse.java
+++ b/src/main/java/com/kusitms/kkium/jd/dto/response/JdExperienceAnalysisResponse.java
@@ -1,0 +1,9 @@
+package com.kusitms.kkium.jd.dto.response;
+
+import java.util.List;
+
+public record JdExperienceAnalysisResponse(Long experienceId, ExperienceAnalysis analysis) {
+
+  public record ExperienceAnalysis(
+      String strengths, String weaknesses, String usageGuide, List<String> highlightKeywords) {}
+}

--- a/src/main/java/com/kusitms/kkium/jd/dto/response/JdMatchAnalysisResponse.java
+++ b/src/main/java/com/kusitms/kkium/jd/dto/response/JdMatchAnalysisResponse.java
@@ -1,0 +1,34 @@
+package com.kusitms.kkium.jd.dto.response;
+
+import java.util.List;
+
+import com.kusitms.kkium.experience.domain.type.PieceType;
+import com.kusitms.kkium.experience.dto.response.TagResponse;
+import com.kusitms.kkium.jd.domain.type.AnalysisStatus;
+
+public record JdMatchAnalysisResponse(
+    AnalysisStatus analysisStatus, JdInfo jdInfo, MatchResult matchResult) {
+
+  public record JdInfo(
+      String companyName,
+      String recruitmentField,
+      String startDate,
+      String endDate,
+      List<String> hardSkills,
+      List<String> softSkills,
+      String mainResponsibilities,
+      String requiredQualifications,
+      String preferredQualifications) {}
+
+  public record MatchResult(
+      int applicationFitScore, int usableExperienceCount, List<ExperienceMatchCard> experiences) {}
+
+  public record ExperienceMatchCard(
+      Long pieceId,
+      Long experienceId,
+      PieceType type,
+      String title,
+      String oneLineIntro,
+      List<TagResponse> tags,
+      int usageFitScore) {}
+}

--- a/src/main/java/com/kusitms/kkium/jd/dto/response/JdMatchAnalysisResponse.java
+++ b/src/main/java/com/kusitms/kkium/jd/dto/response/JdMatchAnalysisResponse.java
@@ -21,8 +21,7 @@ public record JdMatchAnalysisResponse(
       String requiredQualifications,
       String preferredQualifications) {}
 
-  public record MatchResult(
-      int applicationFitScore, int usableExperienceCount, List<ExperienceMatchCard> experiences) {}
+  public record MatchResult(int applicationFitScore, List<ExperienceMatchCard> experiences) {}
 
   public record ExperienceMatchCard(
       Long pieceId,

--- a/src/main/java/com/kusitms/kkium/jd/dto/response/JdMatchAnalysisResponse.java
+++ b/src/main/java/com/kusitms/kkium/jd/dto/response/JdMatchAnalysisResponse.java
@@ -10,6 +10,7 @@ public record JdMatchAnalysisResponse(
     AnalysisStatus analysisStatus, JdInfo jdInfo, MatchResult matchResult) {
 
   public record JdInfo(
+      String postingTitle,
       String companyName,
       String recruitmentField,
       String startDate,

--- a/src/main/java/com/kusitms/kkium/jd/repository/JdMatchRepository.java
+++ b/src/main/java/com/kusitms/kkium/jd/repository/JdMatchRepository.java
@@ -1,0 +1,43 @@
+package com.kusitms.kkium.jd.repository;
+
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class JdMatchRepository {
+
+  private final JdbcTemplate jdbcTemplate;
+
+  /**
+   * JD 임베딩 vs 유저의 전체 Piece 임베딩 코사인 유사도 계산 pgvector의 <=> 연산자는 코사인 거리(0~2)를 반환하므로 1 - distance =
+   * 유사도(-1~1) 이를 0~100으로 정규화: (유사도 + 1) / 2 * 100
+   */
+  public List<PieceSimilarity> findSimilaritiesByJdAndUser(Long jdId, Long userId) {
+    String sql =
+        """
+        SELECT p.id AS piece_id,
+               CAST(((1 - (p.embedding <=> j.embedding) + 1) / 2.0 * 100) AS INTEGER) AS similarity_score
+        FROM pieces p, jds j
+        WHERE j.id = ?
+          AND p.user_id = ?
+          AND p.embedding IS NOT NULL
+          AND j.embedding IS NOT NULL
+        ORDER BY similarity_score DESC
+        """;
+
+    return jdbcTemplate.query(
+        sql,
+        (rs, rowNum) -> new PieceSimilarity(rs.getLong("piece_id"), rs.getInt("similarity_score")),
+        jdId,
+        userId);
+  }
+
+  public record PieceSimilarity(Long pieceId, int similarityScore) {}
+}

--- a/src/main/java/com/kusitms/kkium/jd/service/JdExperienceAnalysisService.java
+++ b/src/main/java/com/kusitms/kkium/jd/service/JdExperienceAnalysisService.java
@@ -1,0 +1,55 @@
+package com.kusitms.kkium.jd.service;
+
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_NOT_FOUND;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.JD_NOT_FOUND;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kusitms.kkium.experience.domain.Experience;
+import com.kusitms.kkium.experience.repository.ExperienceRepository;
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.jd.domain.Jd;
+import com.kusitms.kkium.jd.dto.response.JdExperienceAnalysisResponse;
+import com.kusitms.kkium.jd.dto.response.JdExperienceAnalysisResponse.ExperienceAnalysis;
+import com.kusitms.kkium.jd.repository.JdRepository;
+import com.kusitms.kkium.jd.utils.llm.LlmMatchScoreService;
+import com.kusitms.kkium.jd.utils.llm.LlmMatchScoreService.LlmExperienceDetailResult;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class JdExperienceAnalysisService {
+
+  private final JdRepository jdRepository;
+  private final ExperienceRepository experienceRepository;
+  private final LlmMatchScoreService llmMatchScoreService;
+
+  public JdExperienceAnalysisResponse analyze(Long jdId, Long experienceId) {
+    // 1. JD 조회
+    Jd jd = jdRepository.findById(jdId).orElseThrow(() -> new BaseException(JD_NOT_FOUND));
+
+    // 2. 경험 조회
+    Experience experience =
+        experienceRepository
+            .findByIdWithPiece(experienceId)
+            .orElseThrow(() -> new BaseException(EXPERIENCE_NOT_FOUND));
+
+    // 3. LLM 호출 - 좋은 점 / 부족한 점 / 활용 가이드 / 하이라이팅 키워드
+    LlmExperienceDetailResult result = llmMatchScoreService.analyzeExperienceDetail(jd, experience);
+
+    log.info("[경험 상세 분석] experienceId={} | keywords={}", experienceId, result.highlightKeywords());
+
+    return new JdExperienceAnalysisResponse(
+        experienceId,
+        new ExperienceAnalysis(
+            result.strengths(),
+            result.weaknesses(),
+            result.usageGuide(),
+            result.highlightKeywords()));
+  }
+}

--- a/src/main/java/com/kusitms/kkium/jd/service/JdMatchService.java
+++ b/src/main/java/com/kusitms/kkium/jd/service/JdMatchService.java
@@ -39,9 +39,8 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 public class JdMatchService {
 
-  private static final int USAGE_FIT_THRESHOLD = 50; // 활용 가능 경험 임계값
-  private static final int TOP_N_FOR_CARD = 5; // 카드로 보여줄 상위 N개
-  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+  private static final DateTimeFormatter DATE_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
   private final JdRepository jdRepository;
   private final ExperienceRepository experienceRepository;
@@ -65,7 +64,7 @@ public class JdMatchService {
 
     if (allExperiences.isEmpty()) {
       return new JdMatchAnalysisResponse(
-          AnalysisStatus.COMPLETED, jdInfo, new MatchResult(0, 0, List.of()));
+          AnalysisStatus.COMPLETED, jdInfo, new MatchResult(0, List.of()));
     }
 
     // 3. 임베딩 코사인 유사도 계산 (pieceId → embeddingScore)
@@ -76,29 +75,21 @@ public class JdMatchService {
             .collect(Collectors.toMap(PieceSimilarity::pieceId, PieceSimilarity::similarityScore));
     log.info("[공고분석] 전체 임베딩 유사도 점수: {}", embeddingScoreMap);
 
-    // 4. 임베딩 점수 상위 5개 경험 추출
-    List<Experience> topExperiences =
-        allExperiences.stream()
-            .sorted(
-                Comparator.comparingInt(
-                        (Experience e) -> embeddingScoreMap.getOrDefault(e.getPiece().getId(), 0))
-                    .reversed())
-            .limit(TOP_N_FOR_CARD)
-            .toList();
+    // 4. 임베딩 점수 기준 정렬 (전체)
     log.info(
-        "[공고분석] 임베딩 상위 5개 pieceId: {}",
-        topExperiences.stream().map(e -> e.getPiece().getId()).toList());
+        "[공고분석] 전체 경험 pieceId: {}",
+        allExperiences.stream().map(e -> e.getPiece().getId()).toList());
 
-    // 5. LLM 1번 호출 - 활용 적합도 + 지원 적합도 한꺼번에
+    // 5. LLM 1번 호출 - 전체 경험에 대해 활용 적합도 + 지원 적합도 한꺼번에
     LlmMatchScoreService.LlmMatchResult llmResult =
-        llmMatchScoreService.scoreAll(jd, topExperiences);
+        llmMatchScoreService.scoreAll(jd, allExperiences);
     Map<Long, Integer> llmScoreMap = llmResult.usageScores();
     log.info("[공고분석] 활용 적합도 LLM 점수: {}", llmScoreMap);
     log.info("[공고분석] 지원 적합도 LLM 점수: {}", llmResult.applicationScore());
 
-    // 6. 활용 적합도 계산: 임베딩 × 0.7 + LLM × 0.3 (상위 5개만)
+    // 6. 활용 적합도 계산: 임베딩 × 0.7 + LLM × 0.3 (전체 경험)
     Map<Long, Integer> usageFitScoreMap = new HashMap<>();
-    for (Experience exp : topExperiences) {
+    for (Experience exp : allExperiences) {
       Long pieceId = exp.getPiece().getId();
       int embScore = embeddingScoreMap.getOrDefault(pieceId, 0);
       int llmScore = llmScoreMap.getOrDefault(pieceId, 0);
@@ -112,20 +103,13 @@ public class JdMatchService {
       usageFitScoreMap.put(pieceId, usageFitScore);
     }
 
-    // 6. 지원 적합도 계산 (LLM 점수는 이미 위에서 받음)
+    // 6. 지원 적합도 계산
     int applicationFitScore =
         calcApplicationFitScore(
-            topExperiences, embeddingScoreMap, usageFitScoreMap, llmResult.applicationScore());
+            allExperiences, embeddingScoreMap, usageFitScoreMap, llmResult.applicationScore());
 
-    // 7. 활용 가능 경험 개수 (활용 적합도 50점 이상, 상위 5개 기준)
-    int usableCount =
-        (int)
-            usageFitScoreMap.values().stream()
-                .filter(score -> score >= USAGE_FIT_THRESHOLD)
-                .count();
-
-    // 8. 태그 벌크 조회 (상위 5개만)
-    List<Long> experienceIds = topExperiences.stream().map(Experience::getId).toList();
+    // 7. 태그 벌크 조회 (전체 경험)
+    List<Long> experienceIds = allExperiences.stream().map(Experience::getId).toList();
     Map<Long, List<TagResponse>> tagMap =
         tagRepository.findByExperienceIdIn(experienceIds).stream()
             .collect(
@@ -134,9 +118,9 @@ public class JdMatchService {
                     Collectors.mapping(
                         t -> new TagResponse(t.getCategory(), t.getField()), Collectors.toList())));
 
-    // 9. 경험 카드 목록 구성 (상위 5개, 활용 적합도 내림차순)
+    // 9. 경험 카드 목록 구성 (전체, 활용 적합도 내림차순)
     List<ExperienceMatchCard> cards =
-        topExperiences.stream()
+        allExperiences.stream()
             .map(
                 exp -> {
                   Long pieceId = exp.getPiece().getId();
@@ -153,7 +137,7 @@ public class JdMatchService {
             .toList();
 
     return new JdMatchAnalysisResponse(
-        AnalysisStatus.COMPLETED, jdInfo, new MatchResult(applicationFitScore, usableCount, cards));
+        AnalysisStatus.COMPLETED, jdInfo, new MatchResult(applicationFitScore, cards));
   }
 
   /** 지원 적합도 계산 상위 5개 임베딩 점수 평균 × 0.7 + LLM 포트폴리오 점수 × 0.3 */

--- a/src/main/java/com/kusitms/kkium/jd/service/JdMatchService.java
+++ b/src/main/java/com/kusitms/kkium/jd/service/JdMatchService.java
@@ -72,7 +72,11 @@ public class JdMatchService {
         jdMatchRepository.findSimilaritiesByJdAndUser(jdId, userId);
     Map<Long, Integer> embeddingScoreMap =
         similarities.stream()
-            .collect(Collectors.toMap(PieceSimilarity::pieceId, PieceSimilarity::similarityScore));
+            .collect(
+                Collectors.toMap(
+                    PieceSimilarity::pieceId,
+                    PieceSimilarity::similarityScore,
+                    (existing, replacement) -> existing));
     log.info("[공고분석] 전체 임베딩 유사도 점수: {}", embeddingScoreMap);
 
     // 4. 임베딩 점수 기준 정렬 (전체)
@@ -81,6 +85,8 @@ public class JdMatchService {
         allExperiences.stream().map(e -> e.getPiece().getId()).toList());
 
     // 5. LLM 1번 호출 - 전체 경험에 대해 활용 적합도 + 지원 적합도 한꺼번에
+    // TODO: 경험이 많아질 경우 토큰 초과 위험 있음. 임베딩 상위 N개만 LLM에 넣고
+    //       나머지는 임베딩 점수로만 계산하는 방식으로 최적화 필요
     LlmMatchScoreService.LlmMatchResult llmResult =
         llmMatchScoreService.scoreAll(jd, allExperiences);
     Map<Long, Integer> llmScoreMap = llmResult.usageScores();
@@ -140,7 +146,7 @@ public class JdMatchService {
         AnalysisStatus.COMPLETED, jdInfo, new MatchResult(applicationFitScore, cards));
   }
 
-  /** 지원 적합도 계산 상위 5개 임베딩 점수 평균 × 0.7 + LLM 포트폴리오 점수 × 0.3 */
+  /** 지원 적합도 계산: 전체 경험 임베딩 점수 평균 × 0.7 + LLM 포트폴리오 점수 × 0.3 */
   private int calcApplicationFitScore(
       List<Experience> topExperiences,
       Map<Long, Integer> embeddingScoreMap,

--- a/src/main/java/com/kusitms/kkium/jd/service/JdMatchService.java
+++ b/src/main/java/com/kusitms/kkium/jd/service/JdMatchService.java
@@ -1,0 +1,217 @@
+package com.kusitms.kkium.jd.service;
+
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.JD_NOT_FOUND;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kusitms.kkium.experience.domain.Experience;
+import com.kusitms.kkium.experience.dto.response.TagResponse;
+import com.kusitms.kkium.experience.repository.ExperienceRepository;
+import com.kusitms.kkium.experience.repository.TagRepository;
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.jd.domain.Jd;
+import com.kusitms.kkium.jd.domain.type.AnalysisStatus;
+import com.kusitms.kkium.jd.dto.response.JdMatchAnalysisResponse;
+import com.kusitms.kkium.jd.dto.response.JdMatchAnalysisResponse.ExperienceMatchCard;
+import com.kusitms.kkium.jd.dto.response.JdMatchAnalysisResponse.JdInfo;
+import com.kusitms.kkium.jd.dto.response.JdMatchAnalysisResponse.MatchResult;
+import com.kusitms.kkium.jd.repository.JdMatchRepository;
+import com.kusitms.kkium.jd.repository.JdMatchRepository.PieceSimilarity;
+import com.kusitms.kkium.jd.repository.JdRepository;
+import com.kusitms.kkium.jd.utils.llm.LlmMatchScoreService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class JdMatchService {
+
+  private static final int USAGE_FIT_THRESHOLD = 50; // 활용 가능 경험 임계값
+  private static final int TOP_N_FOR_CARD = 5; // 카드로 보여줄 상위 N개
+  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+  private final JdRepository jdRepository;
+  private final ExperienceRepository experienceRepository;
+  private final TagRepository tagRepository;
+  private final JdMatchRepository jdMatchRepository;
+  private final LlmMatchScoreService llmMatchScoreService;
+
+  public JdMatchAnalysisResponse analyze(Long jdId, Long userId) {
+    Jd jd = jdRepository.findById(jdId).orElseThrow(() -> new BaseException(JD_NOT_FOUND));
+
+    // 분석 미완료 시 상태만 반환
+    if (jd.getAnalysisStatus() != AnalysisStatus.COMPLETED) {
+      return new JdMatchAnalysisResponse(jd.getAnalysisStatus(), null, null);
+    }
+
+    // 1. JD Info 구성
+    JdInfo jdInfo = buildJdInfo(jd);
+
+    // 2. 유저의 전체 경험 조회
+    List<Experience> allExperiences = experienceRepository.findAllByUserIdNoPage(userId);
+
+    if (allExperiences.isEmpty()) {
+      return new JdMatchAnalysisResponse(
+          AnalysisStatus.COMPLETED, jdInfo, new MatchResult(0, 0, List.of()));
+    }
+
+    // 3. 임베딩 코사인 유사도 계산 (pieceId → embeddingScore)
+    List<PieceSimilarity> similarities =
+        jdMatchRepository.findSimilaritiesByJdAndUser(jdId, userId);
+    Map<Long, Integer> embeddingScoreMap =
+        similarities.stream()
+            .collect(Collectors.toMap(PieceSimilarity::pieceId, PieceSimilarity::similarityScore));
+    log.info("[공고분석] 전체 임베딩 유사도 점수: {}", embeddingScoreMap);
+
+    // 4. 임베딩 점수 상위 5개 경험 추출
+    List<Experience> topExperiences =
+        allExperiences.stream()
+            .sorted(
+                Comparator.comparingInt(
+                        (Experience e) -> embeddingScoreMap.getOrDefault(e.getPiece().getId(), 0))
+                    .reversed())
+            .limit(TOP_N_FOR_CARD)
+            .toList();
+    log.info(
+        "[공고분석] 임베딩 상위 5개 pieceId: {}",
+        topExperiences.stream().map(e -> e.getPiece().getId()).toList());
+
+    // 5. LLM 1번 호출 - 활용 적합도 + 지원 적합도 한꺼번에
+    LlmMatchScoreService.LlmMatchResult llmResult =
+        llmMatchScoreService.scoreAll(jd, topExperiences);
+    Map<Long, Integer> llmScoreMap = llmResult.usageScores();
+    log.info("[공고분석] 활용 적합도 LLM 점수: {}", llmScoreMap);
+    log.info("[공고분석] 지원 적합도 LLM 점수: {}", llmResult.applicationScore());
+
+    // 6. 활용 적합도 계산: 임베딩 × 0.7 + LLM × 0.3 (상위 5개만)
+    Map<Long, Integer> usageFitScoreMap = new HashMap<>();
+    for (Experience exp : topExperiences) {
+      Long pieceId = exp.getPiece().getId();
+      int embScore = embeddingScoreMap.getOrDefault(pieceId, 0);
+      int llmScore = llmScoreMap.getOrDefault(pieceId, 0);
+      int usageFitScore = (int) Math.round(embScore * 0.7 + llmScore * 0.3);
+      log.info(
+          "[공고분석] pieceId={} | 임베딩={} | LLM={} | 활용적합도={}",
+          pieceId,
+          embScore,
+          llmScore,
+          usageFitScore);
+      usageFitScoreMap.put(pieceId, usageFitScore);
+    }
+
+    // 6. 지원 적합도 계산 (LLM 점수는 이미 위에서 받음)
+    int applicationFitScore =
+        calcApplicationFitScore(
+            topExperiences, embeddingScoreMap, usageFitScoreMap, llmResult.applicationScore());
+
+    // 7. 활용 가능 경험 개수 (활용 적합도 50점 이상, 상위 5개 기준)
+    int usableCount =
+        (int)
+            usageFitScoreMap.values().stream()
+                .filter(score -> score >= USAGE_FIT_THRESHOLD)
+                .count();
+
+    // 8. 태그 벌크 조회 (상위 5개만)
+    List<Long> experienceIds = topExperiences.stream().map(Experience::getId).toList();
+    Map<Long, List<TagResponse>> tagMap =
+        tagRepository.findByExperienceIdIn(experienceIds).stream()
+            .collect(
+                Collectors.groupingBy(
+                    t -> t.getExperience().getId(),
+                    Collectors.mapping(
+                        t -> new TagResponse(t.getCategory(), t.getField()), Collectors.toList())));
+
+    // 9. 경험 카드 목록 구성 (상위 5개, 활용 적합도 내림차순)
+    List<ExperienceMatchCard> cards =
+        topExperiences.stream()
+            .map(
+                exp -> {
+                  Long pieceId = exp.getPiece().getId();
+                  return new ExperienceMatchCard(
+                      pieceId,
+                      exp.getId(),
+                      exp.getPiece().getType(),
+                      exp.getTitle(),
+                      exp.getOneLineIntro(),
+                      tagMap.getOrDefault(exp.getId(), List.of()),
+                      usageFitScoreMap.getOrDefault(pieceId, 0));
+                })
+            .sorted(Comparator.comparingInt(ExperienceMatchCard::usageFitScore).reversed())
+            .toList();
+
+    return new JdMatchAnalysisResponse(
+        AnalysisStatus.COMPLETED, jdInfo, new MatchResult(applicationFitScore, usableCount, cards));
+  }
+
+  /** 지원 적합도 계산 상위 5개 임베딩 점수 평균 × 0.7 + LLM 포트폴리오 점수 × 0.3 */
+  private int calcApplicationFitScore(
+      List<Experience> topExperiences,
+      Map<Long, Integer> embeddingScoreMap,
+      Map<Long, Integer> usageFitScoreMap,
+      int llmApplicationScore) {
+
+    // 활용 적합도 기준으로 정렬
+    List<Experience> topForApp =
+        topExperiences.stream()
+            .sorted(
+                Comparator.comparingInt(
+                        (Experience e) -> usageFitScoreMap.getOrDefault(e.getPiece().getId(), 0))
+                    .reversed())
+            .toList();
+
+    // 임베딩 점수 평균
+    double avgEmbeddingScore =
+        topForApp.stream()
+            .mapToInt(e -> embeddingScoreMap.getOrDefault(e.getPiece().getId(), 0))
+            .average()
+            .orElse(0);
+
+    log.info(
+        "[공고분석] 지원 적합도 | 임베딩 평균={} | LLM={} | 최종={}",
+        avgEmbeddingScore,
+        llmApplicationScore,
+        (int) Math.round(avgEmbeddingScore * 0.7 + llmApplicationScore * 0.3));
+
+    return (int) Math.round(avgEmbeddingScore * 0.7 + llmApplicationScore * 0.3);
+  }
+
+  private JdInfo buildJdInfo(Jd jd) {
+    List<String> hardSkills = parseSkillTags(jd.getHardSkill());
+    List<String> softSkills = parseSkillTags(jd.getSoftSkill());
+
+    String startDate = jd.getStartDate() != null ? jd.getStartDate().format(DATE_FORMATTER) : null;
+    String endDate = jd.getEndDate() != null ? jd.getEndDate().format(DATE_FORMATTER) : null;
+
+    return new JdInfo(
+        jd.getCompanyName(),
+        jd.getRecruitmentField(),
+        startDate,
+        endDate,
+        hardSkills,
+        softSkills,
+        jd.getMainResponsibilities(),
+        jd.getRequiredQualifications(),
+        jd.getPreferredQualifications());
+  }
+
+  private List<String> parseSkillTags(String skillString) {
+    if (skillString == null || skillString.isBlank()) return Collections.emptyList();
+    return Arrays.stream(skillString.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isBlank())
+        .toList();
+  }
+}

--- a/src/main/java/com/kusitms/kkium/jd/service/JdMatchService.java
+++ b/src/main/java/com/kusitms/kkium/jd/service/JdMatchService.java
@@ -196,6 +196,7 @@ public class JdMatchService {
     String endDate = jd.getEndDate() != null ? jd.getEndDate().format(DATE_FORMATTER) : null;
 
     return new JdInfo(
+        jd.getPostingTitle(),
         jd.getCompanyName(),
         jd.getRecruitmentField(),
         startDate,

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
@@ -1,5 +1,7 @@
 package com.kusitms.kkium.jd.utils.llm;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -20,33 +22,42 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class LlmMatchScoreService {
 
-  private static final String GEMINI_URL =
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
+  private static final String OPENAI_URL = "https://api.openai.com/v1/chat/completions";
+  private static final String MODEL = "gpt-4o";
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private final WebClient webClient;
   private final String apiKey;
 
-  public LlmMatchScoreService(WebClient webClient, @Value("${gemini.api-key}") String apiKey) {
+  public LlmMatchScoreService(WebClient webClient, @Value("${openai.api.key}") String apiKey) {
     this.webClient = webClient;
     this.apiKey = apiKey;
   }
 
   /** LLM 1번 호출로 활용 적합도(경험별) + 지원 적합도(포트폴리오 종합)를 한꺼번에 반환 */
   public LlmMatchResult scoreAll(Jd jd, List<Experience> experiences) {
-    if (experiences.isEmpty()) {
-      return new LlmMatchResult(Map.of(), 0);
-    }
-
+    if (experiences.isEmpty()) return new LlmMatchResult(Map.of(), 0);
     String prompt = buildCombinedPrompt(jd, experiences);
-    String response = callGemini(prompt);
+    String response = callOpenAi(prompt);
     return parseCombinedResult(response, experiences);
   }
 
-  public record LlmMatchResult(
-      Map<Long, Integer> usageScores, // pieceId → 활용 적합도 LLM 점수
-      int applicationScore // 지원 적합도 LLM 점수
-      ) {}
+  public record LlmMatchResult(Map<Long, Integer> usageScores, int applicationScore) {}
+
+  /** 경험 카드 클릭 시 상세 분석 */
+  public LlmExperienceDetailResult analyzeExperienceDetail(Jd jd, Experience experience) {
+    String prompt = buildExperienceDetailPrompt(jd, experience);
+    String response = callOpenAi(prompt);
+    return parseExperienceDetailResult(response);
+  }
+
+  public record LlmExperienceDetailResult(
+      String strengths, String weaknesses, String usageGuide, List<String> highlightKeywords) {
+
+    public static LlmExperienceDetailResult empty() {
+      return new LlmExperienceDetailResult("분석에 실패했습니다.", "분석에 실패했습니다.", "분석에 실패했습니다.", List.of());
+    }
+  }
 
   private String buildCombinedPrompt(Jd jd, List<Experience> experiences) {
     String expList =
@@ -122,82 +133,6 @@ public class LlmMatchScoreService {
             expList);
   }
 
-  private String callGemini(String prompt) {
-    Map<String, Object> body =
-        Map.of(
-            "contents", List.of(Map.of("parts", List.of(Map.of("text", prompt)))),
-            "generationConfig", Map.of("responseMimeType", "application/json"));
-
-    try {
-      return webClient
-          .post()
-          .uri(GEMINI_URL + "?key=" + apiKey)
-          .header("Content-Type", "application/json")
-          .bodyValue(body)
-          .retrieve()
-          .bodyToMono(String.class)
-          .block();
-    } catch (Exception e) {
-      log.warn("Gemini 호출 실패: {}", e.getMessage());
-      return null;
-    }
-  }
-
-  private LlmMatchResult parseCombinedResult(String response, List<Experience> experiences) {
-    // 기본값: 모든 경험 50점, 지원 적합도 0점
-    Map<Long, Integer> fallbackScores =
-        experiences.stream().collect(Collectors.toMap(e -> e.getPiece().getId(), e -> 50));
-
-    if (response == null) return new LlmMatchResult(fallbackScores, 0);
-
-    try {
-      JsonNode root = OBJECT_MAPPER.readTree(response);
-      String json = extractJsonText(root);
-      JsonNode parsed = OBJECT_MAPPER.readTree(json);
-
-      // 활용 적합도 파싱
-      Map<Long, Integer> usageScores = new java.util.HashMap<>();
-      for (JsonNode item : parsed.path("usageScores")) {
-        long pieceId = item.path("pieceId").asLong();
-        int score = Math.max(0, Math.min(100, item.path("score").asInt(50)));
-        usageScores.put(pieceId, score);
-      }
-      fallbackScores.forEach(usageScores::putIfAbsent);
-
-      // 지원 적합도 파싱
-      int applicationScore = Math.max(0, Math.min(100, parsed.path("applicationScore").asInt(0)));
-
-      return new LlmMatchResult(usageScores, applicationScore);
-    } catch (Exception e) {
-      log.warn("LLM 응답 파싱 실패: {}", e.getMessage());
-      return new LlmMatchResult(fallbackScores, 0);
-    }
-  }
-
-  private String extractJsonText(JsonNode root) {
-    JsonNode textNode =
-        root.path("candidates").path(0).path("content").path("parts").path(0).path("text");
-    if (!textNode.isMissingNode() && !textNode.asText().isBlank()) {
-      return textNode.asText();
-    }
-    return root.toString();
-  }
-
-  /** 경험 카드 클릭 시 상세 분석: 좋은 점 / 부족한 점 / 활용 가이드 / 하이라이팅 키워드 */
-  public LlmExperienceDetailResult analyzeExperienceDetail(Jd jd, Experience experience) {
-    String prompt = buildExperienceDetailPrompt(jd, experience);
-    String response = callGemini(prompt);
-    return parseExperienceDetailResult(response);
-  }
-
-  public record LlmExperienceDetailResult(
-      String strengths, String weaknesses, String usageGuide, List<String> highlightKeywords) {
-
-    public static LlmExperienceDetailResult empty() {
-      return new LlmExperienceDetailResult("분석에 실패했습니다.", "분석에 실패했습니다.", "분석에 실패했습니다.", List.of());
-    }
-  }
-
   private String buildExperienceDetailPrompt(Jd jd, Experience experience) {
     return """
         너는 채용 공고와 지원자 경험을 비교 분석하는 전문가이다.
@@ -233,6 +168,10 @@ public class LlmMatchScoreService {
         4. highlightKeywords: 공고 텍스트에서 이 경험과 직접 연관되는 핵심 키워드를 최대 5개 추출하라.
            반드시 공고의 주요 업무, 필수 역량, 우대 역량, 기술 스택, 소프트 스킬에 실제로 존재하는 단어나 구문만 반환하라.
 
+        [말투 규칙]
+        - 모든 문장은 반드시 '~합니다', '~입니다', '~습니다' 체로 통일하라.
+        - '~하십시오', '~이다', '~한다', '~세요', '~어요' 등 다른 말투는 절대 사용하지 마라.
+
         반환 형식:
         {
           "strengths": "좋은 점 서술",
@@ -258,24 +197,64 @@ public class LlmMatchScoreService {
             experience.getTaken());
   }
 
+  private String callOpenAi(String prompt) {
+    Map<String, Object> body =
+        Map.of(
+            "model", MODEL,
+            "messages", List.of(Map.of("role", "user", "content", prompt)),
+            "response_format", Map.of("type", "json_object"));
+    try {
+      String response =
+          webClient
+              .post()
+              .uri(OPENAI_URL)
+              .header("Content-Type", "application/json")
+              .header("Authorization", "Bearer " + apiKey)
+              .bodyValue(body)
+              .retrieve()
+              .bodyToMono(String.class)
+              .block();
+
+      JsonNode root = OBJECT_MAPPER.readTree(response);
+      return root.path("choices").path(0).path("message").path("content").asText();
+    } catch (Exception e) {
+      log.warn("OpenAI 호출 실패: {}", e.getMessage());
+      return null;
+    }
+  }
+
+  private LlmMatchResult parseCombinedResult(String response, List<Experience> experiences) {
+    Map<Long, Integer> fallback =
+        experiences.stream().collect(Collectors.toMap(e -> e.getPiece().getId(), e -> 50));
+    if (response == null) return new LlmMatchResult(fallback, 0);
+    try {
+      JsonNode parsed = OBJECT_MAPPER.readTree(response);
+      Map<Long, Integer> usageScores = new HashMap<>();
+      for (JsonNode item : parsed.path("usageScores")) {
+        usageScores.put(
+            item.path("pieceId").asLong(),
+            Math.max(0, Math.min(100, item.path("score").asInt(50))));
+      }
+      fallback.forEach(usageScores::putIfAbsent);
+      return new LlmMatchResult(
+          usageScores, Math.max(0, Math.min(100, parsed.path("applicationScore").asInt(0))));
+    } catch (Exception e) {
+      log.warn("LLM 응답 파싱 실패: {}", e.getMessage());
+      return new LlmMatchResult(fallback, 0);
+    }
+  }
+
   private LlmExperienceDetailResult parseExperienceDetailResult(String response) {
     if (response == null) return LlmExperienceDetailResult.empty();
-
     try {
-      JsonNode root = OBJECT_MAPPER.readTree(response);
-      String json = extractJsonText(root);
-      JsonNode parsed = OBJECT_MAPPER.readTree(json);
-
-      String strengths = parsed.path("strengths").asText("분석에 실패했습니다.");
-      String weaknesses = parsed.path("weaknesses").asText("분석에 실패했습니다.");
-      String usageGuide = parsed.path("usageGuide").asText("분석에 실패했습니다.");
-
-      List<String> highlightKeywords = new java.util.ArrayList<>();
-      for (JsonNode keyword : parsed.path("highlightKeywords")) {
-        highlightKeywords.add(keyword.asText());
-      }
-
-      return new LlmExperienceDetailResult(strengths, weaknesses, usageGuide, highlightKeywords);
+      JsonNode parsed = OBJECT_MAPPER.readTree(response);
+      List<String> keywords = new ArrayList<>();
+      for (JsonNode k : parsed.path("highlightKeywords")) keywords.add(k.asText());
+      return new LlmExperienceDetailResult(
+          parsed.path("strengths").asText("분석에 실패했습니다."),
+          parsed.path("weaknesses").asText("분석에 실패했습니다."),
+          parsed.path("usageGuide").asText("분석에 실패했습니다."),
+          keywords);
     } catch (Exception e) {
       log.warn("경험 상세 분석 LLM 응답 파싱 실패: {}", e.getMessage());
       return LlmExperienceDetailResult.empty();

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
@@ -164,7 +164,7 @@ public class LlmMatchScoreService {
         [해야 할 일]
         1. strengths: 이 경험이 공고 요구사항과 어떻게 직접적으로 연결되는지 2문장 이내로 서술하라.
         2. weaknesses: 이 경험에서 보완하면 공고에 더 잘 어필할 수 있는 점을 2문장 이내로 서술하라. 경험 자체의 아쉬운 점이 아니라 공고 관점에서 추가하면 좋을 내용을 제안하라.
-        3. usageGuide: 이 경험을 자기소개서에서 이 공고에 맞게 어떻게 어필할지 2문장 이내로 서술하라.
+        3. usageGuide: 이 경험을 자기소개서에서 어필할 때 어떤 포인트를 강조하면 좋을지 조언하는 방식으로 2문장 이내로 서술하라. "~을 강조하면 좋습니다", "~을 언급하면 효과적입니다" 처럼 조언하는 말투로 작성하라.
         4. highlightKeywords: 공고 텍스트에서 이 경험과 직접 연관되는 핵심 키워드를 최대 5개 추출하라.
            반드시 공고의 주요 업무, 필수 역량, 우대 역량, 기술 스택, 소프트 스킬에 실제로 존재하는 단어나 구문만 반환하라.
 
@@ -225,7 +225,10 @@ public class LlmMatchScoreService {
 
   private LlmMatchResult parseCombinedResult(String response, List<Experience> experiences) {
     Map<Long, Integer> fallback =
-        experiences.stream().collect(Collectors.toMap(e -> e.getPiece().getId(), e -> 50));
+        experiences.stream()
+            .collect(
+                Collectors.toMap(
+                    e -> e.getPiece().getId(), e -> 50, (existing, replacement) -> existing));
     if (response == null) return new LlmMatchResult(fallback, 0);
     try {
       JsonNode parsed = OBJECT_MAPPER.readTree(response);

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
@@ -91,6 +91,7 @@ public class LlmMatchScoreService {
         - 직무: %s
         - 주요 업무: %s
         - 필수 역량: %s
+        - 우대 역량: %s
         - 기술 스택: %s
         - 소프트 스킬: %s
 
@@ -115,6 +116,7 @@ public class LlmMatchScoreService {
             jd.getRecruitmentField(),
             jd.getMainResponsibilities(),
             jd.getRequiredQualifications(),
+            jd.getPreferredQualifications(),
             jd.getHardSkill(),
             jd.getSoftSkill(),
             expList);
@@ -179,5 +181,104 @@ public class LlmMatchScoreService {
       return textNode.asText();
     }
     return root.toString();
+  }
+
+  /** 경험 카드 클릭 시 상세 분석: 좋은 점 / 부족한 점 / 활용 가이드 / 하이라이팅 키워드 */
+  public LlmExperienceDetailResult analyzeExperienceDetail(Jd jd, Experience experience) {
+    String prompt = buildExperienceDetailPrompt(jd, experience);
+    String response = callGemini(prompt);
+    return parseExperienceDetailResult(response);
+  }
+
+  public record LlmExperienceDetailResult(
+      String strengths, String weaknesses, String usageGuide, List<String> highlightKeywords) {
+
+    public static LlmExperienceDetailResult empty() {
+      return new LlmExperienceDetailResult("분석에 실패했습니다.", "분석에 실패했습니다.", "분석에 실패했습니다.", List.of());
+    }
+  }
+
+  private String buildExperienceDetailPrompt(Jd jd, Experience experience) {
+    return """
+        너는 채용 공고와 지원자 경험을 비교 분석하는 전문가이다.
+
+        [규칙]
+        - 반드시 제공된 내용만 근거로 사용하라.
+        - 없는 내용을 추론하거나 만들어내지 마라.
+        - 반드시 JSON 형식으로만 응답하라.
+        - 한국어로 작성하라.
+
+        [공고 정보]
+        - 기업: %s
+        - 직무: %s
+        - 주요 업무: %s
+        - 필수 역량: %s
+        - 우대 역량: %s
+        - 기술 스택: %s
+        - 소프트 스킬: %s
+
+        [경험 정보]
+        - 제목: %s
+        - 한줄소개: %s
+        - Situation: %s
+        - Task: %s
+        - Action: %s
+        - Result: %s
+        - Taken: %s
+
+        [해야 할 일]
+        1. strengths: 이 경험이 공고 요구사항과 어떻게 직접적으로 연결되는지 2문장 이내로 서술하라.
+        2. weaknesses: 이 경험에서 보완하면 공고에 더 잘 어필할 수 있는 점을 2문장 이내로 서술하라. 경험 자체의 아쉬운 점이 아니라 공고 관점에서 추가하면 좋을 내용을 제안하라.
+        3. usageGuide: 이 경험을 자기소개서에서 이 공고에 맞게 어떻게 어필할지 2문장 이내로 서술하라.
+        4. highlightKeywords: 공고 텍스트에서 이 경험과 직접 연관되는 핵심 키워드를 최대 5개 추출하라.
+           반드시 공고의 주요 업무, 필수 역량, 우대 역량, 기술 스택, 소프트 스킬에 실제로 존재하는 단어나 구문만 반환하라.
+
+        반환 형식:
+        {
+          "strengths": "좋은 점 서술",
+          "weaknesses": "보완하면 좋을 점 서술",
+          "usageGuide": "자기소개서 어필 방법 서술",
+          "highlightKeywords": ["키워드1", "키워드2", ...]
+        }
+        """
+        .formatted(
+            jd.getCompanyName(),
+            jd.getRecruitmentField(),
+            jd.getMainResponsibilities(),
+            jd.getRequiredQualifications(),
+            jd.getPreferredQualifications(),
+            jd.getHardSkill(),
+            jd.getSoftSkill(),
+            experience.getTitle(),
+            experience.getOneLineIntro(),
+            experience.getSituation(),
+            experience.getTask(),
+            experience.getAct(),
+            experience.getResult(),
+            experience.getTaken());
+  }
+
+  private LlmExperienceDetailResult parseExperienceDetailResult(String response) {
+    if (response == null) return LlmExperienceDetailResult.empty();
+
+    try {
+      JsonNode root = OBJECT_MAPPER.readTree(response);
+      String json = extractJsonText(root);
+      JsonNode parsed = OBJECT_MAPPER.readTree(json);
+
+      String strengths = parsed.path("strengths").asText("분석에 실패했습니다.");
+      String weaknesses = parsed.path("weaknesses").asText("분석에 실패했습니다.");
+      String usageGuide = parsed.path("usageGuide").asText("분석에 실패했습니다.");
+
+      List<String> highlightKeywords = new java.util.ArrayList<>();
+      for (JsonNode keyword : parsed.path("highlightKeywords")) {
+        highlightKeywords.add(keyword.asText());
+      }
+
+      return new LlmExperienceDetailResult(strengths, weaknesses, usageGuide, highlightKeywords);
+    } catch (Exception e) {
+      log.warn("경험 상세 분석 LLM 응답 파싱 실패: {}", e.getMessage());
+      return LlmExperienceDetailResult.empty();
+    }
   }
 }

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
@@ -1,0 +1,183 @@
+package com.kusitms.kkium.jd.utils.llm;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kusitms.kkium.experience.domain.Experience;
+import com.kusitms.kkium.jd.domain.Jd;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class LlmMatchScoreService {
+
+  private static final String GEMINI_URL =
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final WebClient webClient;
+  private final String apiKey;
+
+  public LlmMatchScoreService(WebClient webClient, @Value("${gemini.api-key}") String apiKey) {
+    this.webClient = webClient;
+    this.apiKey = apiKey;
+  }
+
+  /** LLM 1번 호출로 활용 적합도(경험별) + 지원 적합도(포트폴리오 종합)를 한꺼번에 반환 */
+  public LlmMatchResult scoreAll(Jd jd, List<Experience> experiences) {
+    if (experiences.isEmpty()) {
+      return new LlmMatchResult(Map.of(), 0);
+    }
+
+    String prompt = buildCombinedPrompt(jd, experiences);
+    String response = callGemini(prompt);
+    return parseCombinedResult(response, experiences);
+  }
+
+  public record LlmMatchResult(
+      Map<Long, Integer> usageScores, // pieceId → 활용 적합도 LLM 점수
+      int applicationScore // 지원 적합도 LLM 점수
+      ) {}
+
+  private String buildCombinedPrompt(Jd jd, List<Experience> experiences) {
+    String expList =
+        IntStream.range(0, experiences.size())
+            .mapToObj(
+                i -> {
+                  Experience e = experiences.get(i);
+                  return """
+              경험 %d (pieceId: %d):
+              - 제목: %s
+              - 한줄소개: %s
+              - Situation: %s
+              - Task: %s
+              - Action: %s
+              - Result: %s
+              - Taken: %s
+              """
+                      .formatted(
+                          i + 1,
+                          e.getPiece().getId(),
+                          e.getTitle(),
+                          e.getOneLineIntro(),
+                          e.getSituation(),
+                          e.getTask(),
+                          e.getAct(),
+                          e.getResult(),
+                          e.getTaken());
+                })
+            .collect(Collectors.joining("\n"));
+
+    return """
+        너는 채용 공고와 경험의 적합도를 평가하는 시스템이다.
+
+        [규칙]
+        - 반드시 제공된 내용만 근거로 사용하라.
+        - 없는 내용을 추론하지 마라.
+        - 점수는 0~100 사이 정수로 반환하라.
+        - 반드시 JSON 형식으로만 응답하라.
+
+        [공고 정보]
+        - 기업: %s
+        - 직무: %s
+        - 주요 업무: %s
+        - 필수 역량: %s
+        - 기술 스택: %s
+        - 소프트 스킬: %s
+
+        [경험 목록]
+        %s
+
+        [해야 할 일]
+        1. 각 경험이 위 공고에 개별적으로 얼마나 활용 가능한지 평가하라. (usageScores)
+        2. 위 경험들을 포트폴리오 전체 관점에서 공고 요구사항을 얼마나 커버하는지 평가하라. (applicationScore)
+
+        반환 형식:
+        {
+          "usageScores": [
+            { "pieceId": 숫자, "score": 숫자 },
+            ...
+          ],
+          "applicationScore": 숫자
+        }
+        """
+        .formatted(
+            jd.getCompanyName(),
+            jd.getRecruitmentField(),
+            jd.getMainResponsibilities(),
+            jd.getRequiredQualifications(),
+            jd.getHardSkill(),
+            jd.getSoftSkill(),
+            expList);
+  }
+
+  private String callGemini(String prompt) {
+    Map<String, Object> body =
+        Map.of(
+            "contents", List.of(Map.of("parts", List.of(Map.of("text", prompt)))),
+            "generationConfig", Map.of("responseMimeType", "application/json"));
+
+    try {
+      return webClient
+          .post()
+          .uri(GEMINI_URL + "?key=" + apiKey)
+          .header("Content-Type", "application/json")
+          .bodyValue(body)
+          .retrieve()
+          .bodyToMono(String.class)
+          .block();
+    } catch (Exception e) {
+      log.warn("Gemini 호출 실패: {}", e.getMessage());
+      return null;
+    }
+  }
+
+  private LlmMatchResult parseCombinedResult(String response, List<Experience> experiences) {
+    // 기본값: 모든 경험 50점, 지원 적합도 0점
+    Map<Long, Integer> fallbackScores =
+        experiences.stream().collect(Collectors.toMap(e -> e.getPiece().getId(), e -> 50));
+
+    if (response == null) return new LlmMatchResult(fallbackScores, 0);
+
+    try {
+      JsonNode root = OBJECT_MAPPER.readTree(response);
+      String json = extractJsonText(root);
+      JsonNode parsed = OBJECT_MAPPER.readTree(json);
+
+      // 활용 적합도 파싱
+      Map<Long, Integer> usageScores = new java.util.HashMap<>();
+      for (JsonNode item : parsed.path("usageScores")) {
+        long pieceId = item.path("pieceId").asLong();
+        int score = Math.max(0, Math.min(100, item.path("score").asInt(50)));
+        usageScores.put(pieceId, score);
+      }
+      fallbackScores.forEach(usageScores::putIfAbsent);
+
+      // 지원 적합도 파싱
+      int applicationScore = Math.max(0, Math.min(100, parsed.path("applicationScore").asInt(0)));
+
+      return new LlmMatchResult(usageScores, applicationScore);
+    } catch (Exception e) {
+      log.warn("LLM 응답 파싱 실패: {}", e.getMessage());
+      return new LlmMatchResult(fallbackScores, 0);
+    }
+  }
+
+  private String extractJsonText(JsonNode root) {
+    JsonNode textNode =
+        root.path("candidates").path(0).path("content").path("parts").path(0).path("text");
+    if (!textNode.isMissingNode() && !textNode.asText().isBlank()) {
+      return textNode.asText();
+    }
+    return root.toString();
+  }
+}


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #44 

## ✏️ 작업 내용

- 공고분석 (지원적합도, 활용적합도 포함)
- 경험 카드 하나와 공고의 상세 분석

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
