### PR TITLE
[FEAT] 경험 카드 위치 재배열 기능 구현

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -109,7 +109,8 @@ public class ExperienceController {
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 
-  @Operation(summary = "경험 저장",
+  @Operation(
+      summary = "경험 저장",
       description =
           "type에 따라 필요한 필드가 다릅니다. ACTIVITY: name/teamNum/role/contributionRate, CAREER: company/employmentStatus, EDUCATION: organizationName/name, ETC: 추가 필드 없음")
   @PostMapping

--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,6 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.kusitms.kkium.experience.domain.type.PieceType;
 import com.kusitms.kkium.experience.dto.request.ExperienceCreateRequest;
+import com.kusitms.kkium.experience.dto.request.ExperienceOrderUpdateRequest;
 import com.kusitms.kkium.experience.dto.response.ExperienceAnalyzeResponse;
 import com.kusitms.kkium.experience.dto.response.ExperienceDetailResponse;
 import com.kusitms.kkium.experience.dto.response.ExperienceListResponse;
@@ -107,8 +109,7 @@ public class ExperienceController {
     return ResponseEntity.ok(ApiResponse.success(response));
   }
 
-  @Operation(
-      summary = "경험 저장",
+  @Operation(summary = "경험 저장",
       description =
           "type에 따라 필요한 필드가 다릅니다. ACTIVITY: name/teamNum/role/contributionRate, CAREER: company/employmentStatus, EDUCATION: organizationName/name, ETC: 추가 필드 없음")
   @PostMapping
@@ -116,6 +117,15 @@ public class ExperienceController {
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @Valid @RequestBody ExperienceCreateRequest request) {
     experienceService.save(userDetails.getId(), request);
+    return ResponseEntity.ok(ApiResponse.successWithNoContent());
+  }
+
+  @Operation(summary = "경험 카드 순서 변경", description = "드래그 앤 드롭으로 카드 순서를 변경합니다.")
+  @PatchMapping("/order")
+  public ResponseEntity<ApiResponse<Void>> updateOrder(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @Valid @RequestBody ExperienceOrderUpdateRequest request) {
+    experienceService.updateOrder(request, userDetails.getId());
     return ResponseEntity.ok(ApiResponse.successWithNoContent());
   }
 }

--- a/src/main/java/com/kusitms/kkium/experience/domain/ExperienceOrder.java
+++ b/src/main/java/com/kusitms/kkium/experience/domain/ExperienceOrder.java
@@ -1,0 +1,54 @@
+package com.kusitms.kkium.experience.domain;
+
+import jakarta.persistence.*;
+
+import com.kusitms.kkium.experience.domain.type.PieceType;
+import com.kusitms.kkium.user.domain.User;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(
+    name = "experience_order",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uq_experience_order",
+          columnNames = {"user_id", "experience_id", "piece_type"})
+    })
+@Entity
+@Getter
+@NoArgsConstructor
+public class ExperienceOrder {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "sort_order", nullable = false)
+  private Integer sortOrder;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "piece_type", nullable = false)
+  private PieceType pieceType;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "experience_id", nullable = false)
+  private Experience experience;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Builder
+  public ExperienceOrder(Integer sortOrder, PieceType pieceType, Experience experience, User user) {
+    this.sortOrder = sortOrder;
+    this.pieceType = pieceType;
+    this.experience = experience;
+    this.user = user;
+  }
+
+  public void updateSortOrder(Integer sortOrder) {
+    this.sortOrder = sortOrder;
+  }
+}

--- a/src/main/java/com/kusitms/kkium/experience/domain/type/PieceType.java
+++ b/src/main/java/com/kusitms/kkium/experience/domain/type/PieceType.java
@@ -1,6 +1,7 @@
 package com.kusitms.kkium.experience.domain.type;
 
 public enum PieceType {
+  ALL("전체"),
   ACTIVITY("학내외활동"),
   CAREER("인턴/직무경력"),
   EDUCATION("수강/교육"),

--- a/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceOrderUpdateRequest.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceOrderUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.kusitms.kkium.experience.dto.request;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import com.kusitms.kkium.experience.domain.type.PieceType;
+
+public record ExperienceOrderUpdateRequest(
+    @NotNull(message = "type은 필수입니다.") PieceType type,
+    @NotEmpty(message = "experienceIds는 비어있을 수 없습니다.") List<Long> experienceIds) {}

--- a/src/main/java/com/kusitms/kkium/experience/repository/ExperienceOrderRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/ExperienceOrderRepository.java
@@ -3,6 +3,8 @@ package com.kusitms.kkium.experience.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.kusitms.kkium.experience.domain.ExperienceOrder;
 import com.kusitms.kkium.experience.domain.type.PieceType;
@@ -12,7 +14,8 @@ public interface ExperienceOrderRepository extends JpaRepository<ExperienceOrder
   List<ExperienceOrder> findAllByUserIdAndPieceTypeAndExperienceIdIn(
       Long userId, PieceType pieceType, List<Long> experienceIds);
 
-  int countByUserIdAndPieceType(Long userId, PieceType pieceType);
+  @Query("SELECT COALESCE(MAX(eo.sortOrder), 0) FROM ExperienceOrder eo WHERE eo.user.id = :userId AND eo.pieceType = :pieceType")
+  int findMaxSortOrderByUserIdAndPieceType(@Param("userId") Long userId, @Param("pieceType") PieceType pieceType);
 
   void deleteAllByExperienceId(Long experienceId);
 }

--- a/src/main/java/com/kusitms/kkium/experience/repository/ExperienceOrderRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/ExperienceOrderRepository.java
@@ -1,0 +1,18 @@
+package com.kusitms.kkium.experience.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kusitms.kkium.experience.domain.ExperienceOrder;
+import com.kusitms.kkium.experience.domain.type.PieceType;
+
+public interface ExperienceOrderRepository extends JpaRepository<ExperienceOrder, Long> {
+
+  List<ExperienceOrder> findAllByUserIdAndPieceTypeAndExperienceIdIn(
+      Long userId, PieceType pieceType, List<Long> experienceIds);
+
+  int countByUserIdAndPieceType(Long userId, PieceType pieceType);
+
+  void deleteAllByExperienceId(Long experienceId);
+}

--- a/src/main/java/com/kusitms/kkium/experience/repository/ExperienceOrderRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/ExperienceOrderRepository.java
@@ -14,8 +14,10 @@ public interface ExperienceOrderRepository extends JpaRepository<ExperienceOrder
   List<ExperienceOrder> findAllByUserIdAndPieceTypeAndExperienceIdIn(
       Long userId, PieceType pieceType, List<Long> experienceIds);
 
-  @Query("SELECT COALESCE(MAX(eo.sortOrder), 0) FROM ExperienceOrder eo WHERE eo.user.id = :userId AND eo.pieceType = :pieceType")
-  int findMaxSortOrderByUserIdAndPieceType(@Param("userId") Long userId, @Param("pieceType") PieceType pieceType);
+  @Query(
+      "SELECT COALESCE(MAX(eo.sortOrder), 0) FROM ExperienceOrder eo WHERE eo.user.id = :userId AND eo.pieceType = :pieceType")
+  int findMaxSortOrderByUserIdAndPieceType(
+      @Param("userId") Long userId, @Param("pieceType") PieceType pieceType);
 
   void deleteAllByExperienceId(Long experienceId);
 }

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -11,6 +11,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -360,13 +362,15 @@ public class ExperienceService {
           }
         });
 
+    Map<Long, ExperienceOrder> orderMap =
+        orders.stream()
+            .collect(Collectors.toMap(o -> o.getExperience().getId(), o -> o));
+
     for (int i = 0; i < experienceIds.size(); i++) {
-      final int sortOrder = i + 1;
-      final Long experienceId = experienceIds.get(i);
-      orders.stream()
-          .filter(o -> o.getExperience().getId().equals(experienceId))
-          .findFirst()
-          .ifPresent(o -> o.updateSortOrder(sortOrder));
+      ExperienceOrder order = orderMap.get(experienceIds.get(i));
+      if (order != null) {
+        order.updateSortOrder(i + 1);
+      }
     }
   }
 }

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -11,8 +11,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -329,7 +327,8 @@ public class ExperienceService {
             .map(
                 pieceType -> {
                   int nextOrder =
-                      experienceOrderRepository.findMaxSortOrderByUserIdAndPieceType(user.getId(), pieceType)
+                      experienceOrderRepository.findMaxSortOrderByUserIdAndPieceType(
+                              user.getId(), pieceType)
                           + 1;
                   return ExperienceOrder.builder()
                       .sortOrder(nextOrder)
@@ -363,8 +362,7 @@ public class ExperienceService {
         });
 
     Map<Long, ExperienceOrder> orderMap =
-        orders.stream()
-            .collect(Collectors.toMap(o -> o.getExperience().getId(), o -> o));
+        orders.stream().collect(Collectors.toMap(o -> o.getExperience().getId(), o -> o));
 
     for (int i = 0; i < experienceIds.size(); i++) {
       ExperienceOrder order = orderMap.get(experienceIds.get(i));

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -277,7 +277,7 @@ public class ExperienceService {
     }
 
     saveTags(request.tags(), experience);
-    saveInitialOrders(user, experience);
+    saveInitialOrders(user, experience, request.type());
     Long pieceId = piece.getId();
     TransactionSynchronizationManager.registerSynchronization(
         new TransactionSynchronization() {
@@ -320,9 +320,10 @@ public class ExperienceService {
     tagRepository.saveAll(tagEntities);
   }
 
-  private void saveInitialOrders(User user, Experience experience) {
+  private void saveInitialOrders(User user, Experience experience, PieceType type) {
+    List<PieceType> targetTypes = List.of(PieceType.ALL, type);
     List<ExperienceOrder> orders =
-        List.of(PieceType.values()).stream()
+        targetTypes.stream()
             .map(
                 pieceType -> {
                   int nextOrder =

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -327,8 +327,7 @@ public class ExperienceService {
             .map(
                 pieceType -> {
                   int nextOrder =
-                      experienceOrderRepository.countByUserIdAndPieceType(
-                              user.getId(), pieceType)
+                      experienceOrderRepository.countByUserIdAndPieceType(user.getId(), pieceType)
                           + 1;
                   return ExperienceOrder.builder()
                       .sortOrder(nextOrder)

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -1,7 +1,9 @@
 package com.kusitms.kkium.experience.service;
 
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_NOT_FOUND;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_ORDER_NOT_FOUND;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.FORBIDDEN;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.INVALID_INPUT_VALUE;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.USER_NOT_FOUND;
 
 import java.time.LocalDate;
@@ -20,6 +22,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import com.kusitms.kkium.experience.domain.*;
 import com.kusitms.kkium.experience.domain.type.PieceType;
 import com.kusitms.kkium.experience.dto.request.ExperienceCreateRequest;
+import com.kusitms.kkium.experience.dto.request.ExperienceOrderUpdateRequest;
 import com.kusitms.kkium.experience.dto.request.TagCreateRequest;
 import com.kusitms.kkium.experience.dto.response.ExperienceCardResponse;
 import com.kusitms.kkium.experience.dto.response.ExperienceDetailResponse;
@@ -45,6 +48,7 @@ public class ExperienceService {
   private final UserRepository userRepository;
   private final PieceRepository pieceRepository;
   private final ExperienceRepository experienceRepository;
+  private final ExperienceOrderRepository experienceOrderRepository;
   private final ActivityRepository activityRepository;
   private final CareerRepository careerRepository;
   private final EducationRepository educationRepository;
@@ -87,6 +91,7 @@ public class ExperienceService {
                   .orElse(null);
           case ETC ->
               etcRepository.findByExperienceId(experienceId).map(EtcDetail::from).orElse(null);
+          default -> null;
         };
 
     return ExperienceDetailResponse.of(experience, tags, detail);
@@ -268,9 +273,11 @@ public class ExperienceService {
                   .endDate(request.endDate())
                   .experience(experience)
                   .build());
+      default -> throw new BaseException(INVALID_INPUT_VALUE);
     }
 
     saveTags(request.tags(), experience);
+    saveInitialOrders(user, experience);
     Long pieceId = piece.getId();
     TransactionSynchronizationManager.registerSynchronization(
         new TransactionSynchronization() {
@@ -311,5 +318,55 @@ public class ExperienceService {
                         .build())
             .toList();
     tagRepository.saveAll(tagEntities);
+  }
+
+  private void saveInitialOrders(User user, Experience experience) {
+    List<ExperienceOrder> orders =
+        List.of(PieceType.values()).stream()
+            .map(
+                pieceType -> {
+                  int nextOrder =
+                      experienceOrderRepository.countByUserIdAndPieceType(
+                              user.getId(), pieceType)
+                          + 1;
+                  return ExperienceOrder.builder()
+                      .sortOrder(nextOrder)
+                      .pieceType(pieceType)
+                      .experience(experience)
+                      .user(user)
+                      .build();
+                })
+            .toList();
+    experienceOrderRepository.saveAll(orders);
+  }
+
+  @Transactional
+  public void updateOrder(ExperienceOrderUpdateRequest request, Long userId) {
+    PieceType type = request.type();
+    List<Long> experienceIds = request.experienceIds();
+
+    List<ExperienceOrder> orders =
+        experienceOrderRepository.findAllByUserIdAndPieceTypeAndExperienceIdIn(
+            userId, type, experienceIds);
+
+    if (orders.size() != experienceIds.size()) {
+      throw new BaseException(EXPERIENCE_ORDER_NOT_FOUND);
+    }
+
+    orders.forEach(
+        order -> {
+          if (!order.getUser().getId().equals(userId)) {
+            throw new BaseException(FORBIDDEN);
+          }
+        });
+
+    for (int i = 0; i < experienceIds.size(); i++) {
+      final int sortOrder = i + 1;
+      final Long experienceId = experienceIds.get(i);
+      orders.stream()
+          .filter(o -> o.getExperience().getId().equals(experienceId))
+          .findFirst()
+          .ifPresent(o -> o.updateSortOrder(sortOrder));
+    }
   }
 }

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -327,7 +327,7 @@ public class ExperienceService {
             .map(
                 pieceType -> {
                   int nextOrder =
-                      experienceOrderRepository.countByUserIdAndPieceType(user.getId(), pieceType)
+                      experienceOrderRepository.findMaxSortOrderByUserIdAndPieceType(user.getId(), pieceType)
                           + 1;
                   return ExperienceOrder.builder()
                       .sortOrder(nextOrder)

--- a/src/main/java/com/kusitms/kkium/global/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/kusitms/kkium/global/exception/errorcode/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
 
   // experience
   EXPERIENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "E005", "존재하지 않는 경험입니다."),
+  EXPERIENCE_ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "E006", "경험 순서 정보가 존재하지 않습니다."),
   INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "E001", "PDF 파일만 업로드 가능합니다."),
   FILE_ALREADY_UPLOADED(HttpStatus.CONFLICT, "E002", "이미 업로드된 자료가 있습니다. 다시 업로드하면 초기화됩니다."),
   PDF_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "E003", "PDF 파일 파싱에 실패했습니다."),


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #58 

## ✏️ 작업 내용

- PieceType enum에 ALL 추가
- ExperienceOrder 엔티티 생성 — (user_id, experience_id, piece_type) 복합 유니크 제약 포함
- ExperienceOrderRepository 생성
- 경험 저장 시 ALL + 본인 타입 2개 탭에 초기 sort_order 자동 INSERT
- PATCH /api/v1/experiences/order 구현 — 탭별 독립적으로 카드 순서 변경

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
