### PR TITLE
[FEAT] 자기소개서 저장 기능 구현

### DIFF
--- a/src/main/java/com/kusitms/kkium/global/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/kusitms/kkium/global/exception/errorcode/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
   JD_TARGET_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "J003", "목표 공고는 최대 5개까지 등록 가능합니다."),
   JD_SCRAPE_FAILED(HttpStatus.BAD_GATEWAY, "J002", "채용공고 내용을 가져오는데 실패했습니다."),
   QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "J004", "존재하지 않는 문항입니다."),
+  INVALID_QUESTION_FOR_JD(HttpStatus.FORBIDDEN, "J007", "해당 공고에 속하지 않는 문항입니다."),
   EXPERIENCE_SELECTION_LIMIT(HttpStatus.BAD_REQUEST, "J005", "경험은 최소 1개 이상, 최대 3개까지 선택 가능합니다."),
   AI_DRAFT_ALREADY_EXISTS(HttpStatus.CONFLICT, "J006", "AI 초안은 문항당 한 번만 생성 가능합니다."),
 

--- a/src/main/java/com/kusitms/kkium/jd/repository/JdAnswerRepository.java
+++ b/src/main/java/com/kusitms/kkium/jd/repository/JdAnswerRepository.java
@@ -1,5 +1,6 @@
 package com.kusitms.kkium.jd.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ import com.kusitms.kkium.user.domain.User;
 
 public interface JdAnswerRepository extends JpaRepository<JdAnswer, Long> {
   Optional<JdAnswer> findByJdQuestionAndUser(JdQuestion jdQuestion, User user);
+
+  List<JdAnswer> findAllByJdQuestionInAndUser(List<JdQuestion> questions, User user);
 }

--- a/src/main/java/com/kusitms/kkium/jd/repository/JdQuestionRepository.java
+++ b/src/main/java/com/kusitms/kkium/jd/repository/JdQuestionRepository.java
@@ -9,4 +9,6 @@ import com.kusitms.kkium.jd.domain.JdQuestion;
 
 public interface JdQuestionRepository extends JpaRepository<JdQuestion, Long> {
   List<JdQuestion> findByJdOrderByOrderNum(Jd jd);
+
+  List<JdQuestion> findAllByIdInAndJdId(List<Long> ids, Long jdId);
 }

--- a/src/main/java/com/kusitms/kkium/resume/controller/ResumeController.java
+++ b/src/main/java/com/kusitms/kkium/resume/controller/ResumeController.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kusitms.kkium.global.response.ApiResponse;
+import com.kusitms.kkium.resume.dto.request.ResumeAnswerSaveRequest;
+import com.kusitms.kkium.resume.service.ResumeAnswerService;
 import com.kusitms.kkium.resume.dto.request.AiDraftRequest;
 import com.kusitms.kkium.resume.dto.response.AiDraftResponse;
 import com.kusitms.kkium.resume.dto.response.ResumeQuestionExperienceResponse;
@@ -37,6 +39,7 @@ public class ResumeController {
   private final ResumeQuestionExperienceService resumeQuestionExperienceService;
   private final ResumeWritingGuideService resumeWritingGuideService;
   private final ResumeAiDraftService resumeAiDraftService;
+  private final ResumeAnswerService resumeAnswerService;
 
   @Operation(
       summary = "[자소서 작성] 문항별 경험 목록 & 활용 적합도 조회",
@@ -65,6 +68,18 @@ public class ResumeController {
         ApiResponse.success(
             resumeWritingGuideService.generateGuide(
                 jdId, questionId, experienceIds, userDetails.getId())));
+  }
+
+  @Operation(
+      summary = "[자소서 작성] 자소서 저장",
+      description = "문항별 초안 텍스트와 선택 경험을 저장합니다. 기존 저장 데이터가 있으면 덮어씁니다.")
+  @PostMapping("/{jdId}")
+  public ResponseEntity<ApiResponse<Void>> saveAnswers(
+      @PathVariable Long jdId,
+      @Valid @RequestBody ResumeAnswerSaveRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    resumeAnswerService.saveAnswers(jdId, userDetails.getId(), request);
+    return ResponseEntity.ok(ApiResponse.successWithNoContent());
   }
 
   @Operation(

--- a/src/main/java/com/kusitms/kkium/resume/controller/ResumeController.java
+++ b/src/main/java/com/kusitms/kkium/resume/controller/ResumeController.java
@@ -15,13 +15,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kusitms.kkium.global.response.ApiResponse;
-import com.kusitms.kkium.resume.dto.request.ResumeAnswerSaveRequest;
-import com.kusitms.kkium.resume.service.ResumeAnswerService;
 import com.kusitms.kkium.resume.dto.request.AiDraftRequest;
+import com.kusitms.kkium.resume.dto.request.ResumeAnswerSaveRequest;
 import com.kusitms.kkium.resume.dto.response.AiDraftResponse;
 import com.kusitms.kkium.resume.dto.response.ResumeQuestionExperienceResponse;
 import com.kusitms.kkium.resume.dto.response.ResumeWritingGuideResponse;
 import com.kusitms.kkium.resume.service.ResumeAiDraftService;
+import com.kusitms.kkium.resume.service.ResumeAnswerService;
 import com.kusitms.kkium.resume.service.ResumeQuestionExperienceService;
 import com.kusitms.kkium.resume.service.ResumeWritingGuideService;
 import com.kusitms.kkium.user.utils.CustomUserDetails;

--- a/src/main/java/com/kusitms/kkium/resume/domain/AnswerExperience.java
+++ b/src/main/java/com/kusitms/kkium/resume/domain/AnswerExperience.java
@@ -1,0 +1,39 @@
+package com.kusitms.kkium.resume.domain;
+
+import com.kusitms.kkium.jd.domain.JdAnswer;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "answer_experiences")
+@Entity
+@Getter
+@NoArgsConstructor
+public class AnswerExperience {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "answer_id", nullable = false)
+  private JdAnswer jdAnswer;
+
+  @Column(name = "experience_id", nullable = false)
+  private Long experienceId;
+
+  @Builder
+  public AnswerExperience(JdAnswer jdAnswer, Long experienceId) {
+    this.jdAnswer = jdAnswer;
+    this.experienceId = experienceId;
+  }
+}

--- a/src/main/java/com/kusitms/kkium/resume/domain/AnswerExperience.java
+++ b/src/main/java/com/kusitms/kkium/resume/domain/AnswerExperience.java
@@ -1,6 +1,5 @@
 package com.kusitms.kkium.resume.domain;
 
-import com.kusitms.kkium.jd.domain.JdAnswer;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,6 +9,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+
+import com.kusitms.kkium.jd.domain.JdAnswer;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/kusitms/kkium/resume/dto/request/ResumeAnswerSaveRequest.java
+++ b/src/main/java/com/kusitms/kkium/resume/dto/request/ResumeAnswerSaveRequest.java
@@ -1,9 +1,10 @@
 package com.kusitms.kkium.resume.dto.request;
 
+import java.util.List;
+
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import java.util.List;
 
 public record ResumeAnswerSaveRequest(@NotNull @Valid List<AnswerRequest> answers) {
 

--- a/src/main/java/com/kusitms/kkium/resume/dto/request/ResumeAnswerSaveRequest.java
+++ b/src/main/java/com/kusitms/kkium/resume/dto/request/ResumeAnswerSaveRequest.java
@@ -1,0 +1,14 @@
+package com.kusitms.kkium.resume.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record ResumeAnswerSaveRequest(@NotNull @Valid List<AnswerRequest> answers) {
+
+  public record AnswerRequest(
+      @NotNull Long jdQuestionId,
+      @Size(max = 2000) String answerText,
+      @Size(max = 3) List<Long> experienceIds) {}
+}

--- a/src/main/java/com/kusitms/kkium/resume/repository/AnswerExperienceRepository.java
+++ b/src/main/java/com/kusitms/kkium/resume/repository/AnswerExperienceRepository.java
@@ -1,0 +1,12 @@
+package com.kusitms.kkium.resume.repository;
+
+import com.kusitms.kkium.resume.domain.AnswerExperience;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnswerExperienceRepository extends JpaRepository<AnswerExperience, Long> {
+
+  List<AnswerExperience> findByJdAnswerId(Long jdAnswerId);
+
+  void deleteByJdAnswerId(Long jdAnswerId);
+}

--- a/src/main/java/com/kusitms/kkium/resume/repository/AnswerExperienceRepository.java
+++ b/src/main/java/com/kusitms/kkium/resume/repository/AnswerExperienceRepository.java
@@ -1,8 +1,10 @@
 package com.kusitms.kkium.resume.repository;
 
-import com.kusitms.kkium.resume.domain.AnswerExperience;
 import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kusitms.kkium.resume.domain.AnswerExperience;
 
 public interface AnswerExperienceRepository extends JpaRepository<AnswerExperience, Long> {
 

--- a/src/main/java/com/kusitms/kkium/resume/repository/AnswerExperienceRepository.java
+++ b/src/main/java/com/kusitms/kkium/resume/repository/AnswerExperienceRepository.java
@@ -3,6 +3,9 @@ package com.kusitms.kkium.resume.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.kusitms.kkium.resume.domain.AnswerExperience;
 
@@ -10,5 +13,7 @@ public interface AnswerExperienceRepository extends JpaRepository<AnswerExperien
 
   List<AnswerExperience> findByJdAnswerId(Long jdAnswerId);
 
-  void deleteByJdAnswerId(Long jdAnswerId);
+  @Modifying
+  @Query("DELETE FROM AnswerExperience ae WHERE ae.jdAnswer.id IN :answerIds")
+  void deleteAllByJdAnswerIdIn(@Param("answerIds") List<Long> answerIds);
 }

--- a/src/main/java/com/kusitms/kkium/resume/service/ResumeAnswerService.java
+++ b/src/main/java/com/kusitms/kkium/resume/service/ResumeAnswerService.java
@@ -1,0 +1,67 @@
+package com.kusitms.kkium.resume.service;
+
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.QUESTION_NOT_FOUND;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.USER_NOT_FOUND;
+
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.jd.domain.JdAnswer;
+import com.kusitms.kkium.jd.domain.JdQuestion;
+import com.kusitms.kkium.jd.repository.JdAnswerRepository;
+import com.kusitms.kkium.jd.repository.JdQuestionRepository;
+import com.kusitms.kkium.resume.domain.AnswerExperience;
+import com.kusitms.kkium.resume.dto.request.ResumeAnswerSaveRequest;
+import com.kusitms.kkium.resume.repository.AnswerExperienceRepository;
+import com.kusitms.kkium.user.domain.User;
+import com.kusitms.kkium.user.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ResumeAnswerService {
+
+  private final JdAnswerRepository jdAnswerRepository;
+  private final JdQuestionRepository jdQuestionRepository;
+  private final AnswerExperienceRepository answerExperienceRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public void saveAnswers(Long jdId, Long userId, ResumeAnswerSaveRequest request) {
+    User user = userRepository.findById(userId).orElseThrow(() -> new BaseException(USER_NOT_FOUND));
+
+    for (ResumeAnswerSaveRequest.AnswerRequest answerRequest : request.answers()) {
+      JdQuestion question =
+          jdQuestionRepository
+              .findById(answerRequest.jdQuestionId())
+              .orElseThrow(() -> new BaseException(QUESTION_NOT_FOUND));
+
+      // upsert: 기존 답변 있으면 update, 없으면 insert
+      JdAnswer jdAnswer =
+          jdAnswerRepository
+              .findByJdQuestionAndUser(question, user)
+              .orElseGet(
+                  () ->
+                      jdAnswerRepository.save(
+                          JdAnswer.builder()
+                              .jdQuestion(question)
+                              .user(user)
+                              .content(answerRequest.answerText() != null ? answerRequest.answerText() : "")
+                              .build()));
+
+      jdAnswer.updateContent(answerRequest.answerText() != null ? answerRequest.answerText() : "");
+
+      // AnswerExperience delete → insert
+      answerExperienceRepository.deleteByJdAnswerId(jdAnswer.getId());
+
+      if (answerRequest.experienceIds() != null) {
+        List<AnswerExperience> experiences =
+            answerRequest.experienceIds().stream()
+                .map(expId -> AnswerExperience.builder().jdAnswer(jdAnswer).experienceId(expId).build())
+                .toList();
+        answerExperienceRepository.saveAll(experiences);
+      }
+    }
+  }
+}

--- a/src/main/java/com/kusitms/kkium/resume/service/ResumeAnswerService.java
+++ b/src/main/java/com/kusitms/kkium/resume/service/ResumeAnswerService.java
@@ -3,6 +3,11 @@ package com.kusitms.kkium.resume.service;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.QUESTION_NOT_FOUND;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.USER_NOT_FOUND;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.kusitms.kkium.global.exception.BaseException;
 import com.kusitms.kkium.jd.domain.JdAnswer;
 import com.kusitms.kkium.jd.domain.JdQuestion;
@@ -13,10 +18,8 @@ import com.kusitms.kkium.resume.dto.request.ResumeAnswerSaveRequest;
 import com.kusitms.kkium.resume.repository.AnswerExperienceRepository;
 import com.kusitms.kkium.user.domain.User;
 import com.kusitms.kkium.user.repository.UserRepository;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +32,8 @@ public class ResumeAnswerService {
 
   @Transactional
   public void saveAnswers(Long jdId, Long userId, ResumeAnswerSaveRequest request) {
-    User user = userRepository.findById(userId).orElseThrow(() -> new BaseException(USER_NOT_FOUND));
+    User user =
+        userRepository.findById(userId).orElseThrow(() -> new BaseException(USER_NOT_FOUND));
 
     for (ResumeAnswerSaveRequest.AnswerRequest answerRequest : request.answers()) {
       JdQuestion question =
@@ -47,7 +51,10 @@ public class ResumeAnswerService {
                           JdAnswer.builder()
                               .jdQuestion(question)
                               .user(user)
-                              .content(answerRequest.answerText() != null ? answerRequest.answerText() : "")
+                              .content(
+                                  answerRequest.answerText() != null
+                                      ? answerRequest.answerText()
+                                      : "")
                               .build()));
 
       jdAnswer.updateContent(answerRequest.answerText() != null ? answerRequest.answerText() : "");
@@ -58,7 +65,9 @@ public class ResumeAnswerService {
       if (answerRequest.experienceIds() != null) {
         List<AnswerExperience> experiences =
             answerRequest.experienceIds().stream()
-                .map(expId -> AnswerExperience.builder().jdAnswer(jdAnswer).experienceId(expId).build())
+                .map(
+                    expId ->
+                        AnswerExperience.builder().jdAnswer(jdAnswer).experienceId(expId).build())
                 .toList();
         answerExperienceRepository.saveAll(experiences);
       }

--- a/src/main/java/com/kusitms/kkium/resume/service/ResumeAnswerService.java
+++ b/src/main/java/com/kusitms/kkium/resume/service/ResumeAnswerService.java
@@ -1,9 +1,12 @@
 package com.kusitms.kkium.resume.service;
 
-import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.QUESTION_NOT_FOUND;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.INVALID_QUESTION_FOR_JD;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.USER_NOT_FOUND;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,42 +38,63 @@ public class ResumeAnswerService {
     User user =
         userRepository.findById(userId).orElseThrow(() -> new BaseException(USER_NOT_FOUND));
 
-    for (ResumeAnswerSaveRequest.AnswerRequest answerRequest : request.answers()) {
-      JdQuestion question =
-          jdQuestionRepository
-              .findById(answerRequest.jdQuestionId())
-              .orElseThrow(() -> new BaseException(QUESTION_NOT_FOUND));
+    // 1. 요청된 questionId 목록 추출
+    List<Long> questionIds =
+        request.answers().stream().map(ResumeAnswerSaveRequest.AnswerRequest::jdQuestionId).toList();
 
-      // upsert: 기존 답변 있으면 update, 없으면 insert
-      JdAnswer jdAnswer =
-          jdAnswerRepository
-              .findByJdQuestionAndUser(question, user)
-              .orElseGet(
-                  () ->
-                      jdAnswerRepository.save(
-                          JdAnswer.builder()
-                              .jdQuestion(question)
-                              .user(user)
-                              .content(
-                                  answerRequest.answerText() != null
-                                      ? answerRequest.answerText()
-                                      : "")
-                              .build()));
-
-      jdAnswer.updateContent(answerRequest.answerText() != null ? answerRequest.answerText() : "");
-
-      // AnswerExperience delete → insert
-      answerExperienceRepository.deleteByJdAnswerId(jdAnswer.getId());
-
-      if (answerRequest.experienceIds() != null) {
-        List<AnswerExperience> experiences =
-            answerRequest.experienceIds().stream()
-                .map(
-                    expId ->
-                        AnswerExperience.builder().jdAnswer(jdAnswer).experienceId(expId).build())
-                .toList();
-        answerExperienceRepository.saveAll(experiences);
-      }
+    // 2. jdId 검증 포함하여 한 번에 조회 (Security: 다른 공고 문항 접근 방지)
+    List<JdQuestion> questions = jdQuestionRepository.findAllByIdInAndJdId(questionIds, jdId);
+    if (questions.size() != questionIds.size()) {
+      throw new BaseException(INVALID_QUESTION_FOR_JD);
     }
+    Map<Long, JdQuestion> questionMap =
+        questions.stream().collect(Collectors.toMap(JdQuestion::getId, Function.identity()));
+
+    // 3. 기존 답변 한 번에 조회 후 Map으로 변환 (N+1 방지)
+    List<JdAnswer> existingAnswers = jdAnswerRepository.findAllByJdQuestionInAndUser(questions, user);
+    Map<Long, JdAnswer> answerMap =
+        existingAnswers.stream()
+            .collect(Collectors.toMap(a -> a.getJdQuestion().getId(), Function.identity()));
+
+    // 4. upsert 처리
+    List<JdAnswer> savedAnswers =
+        request.answers().stream()
+            .map(
+                answerRequest -> {
+                  JdQuestion question = questionMap.get(answerRequest.jdQuestionId());
+                  String content = answerRequest.answerText() != null ? answerRequest.answerText() : "";
+
+                  JdAnswer jdAnswer = answerMap.get(answerRequest.jdQuestionId());
+                  if (jdAnswer == null) {
+                    jdAnswer = jdAnswerRepository.save(
+                        JdAnswer.builder().jdQuestion(question).user(user).content(content).build());
+                  } else {
+                    jdAnswer.updateContent(content);
+                  }
+                  return jdAnswer;
+                })
+            .toList();
+
+    // 5. AnswerExperience 벌크 삭제 → insert (N+1 방지)
+    List<Long> savedAnswerIds = savedAnswers.stream().map(JdAnswer::getId).toList();
+    answerExperienceRepository.deleteAllByJdAnswerIdIn(savedAnswerIds);
+
+    List<AnswerExperience> newExperiences =
+        request.answers().stream()
+            .filter(a -> a.experienceIds() != null)
+            .flatMap(
+                a -> {
+                  JdAnswer jdAnswer = answerMap.getOrDefault(
+                      a.jdQuestionId(),
+                      savedAnswers.stream()
+                          .filter(sa -> sa.getJdQuestion().getId().equals(a.jdQuestionId()))
+                          .findFirst()
+                          .orElseThrow());
+                  return a.experienceIds().stream()
+                      .map(expId -> AnswerExperience.builder().jdAnswer(jdAnswer).experienceId(expId).build());
+                })
+            .toList();
+
+    answerExperienceRepository.saveAll(newExperiences);
   }
 }


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #68 

## ✏️ 작업 내용

- `AnswerExperience` 엔티티 및 레포지토리 추가 (`answer_experiences` 테이블)
- `ResumeAnswerSaveRequest` DTO 추가 (문항당 최대 3개 경험 제한)
- `ResumeAnswerService` 구현 - 문항별 답변 upsert 및 경험 연결 저장
- `ResumeController`에 `POST /api/v1/resume/{jdId}` 엔드포인트 추가

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
