### PR TITLE
[FIX] Notion OAuth 취소 시 error 파라미터 처리 추가

### DIFF
--- a/src/main/java/com/kusitms/kkium/notion/controller/NotionController.java
+++ b/src/main/java/com/kusitms/kkium/notion/controller/NotionController.java
@@ -36,7 +36,15 @@ public class NotionController {
       summary = "Notion OAuth 콜백 처리",
       description = "Notion이 전달한 code로 access_token을 저장하고 프론트로 redirect합니다.")
   @GetMapping("/api/v1/notion/callback")
-  public ResponseEntity<Void> callback(@RequestParam String code, @RequestParam String state) {
+  public ResponseEntity<Void> callback(
+      @RequestParam(required = false) String code,
+      @RequestParam(required = false) String error,
+      @RequestParam String state) {
+    if (error != null) {
+      return ResponseEntity.status(302)
+          .location(URI.create("https://kkium.com/experience/add?success=false"))
+          .build();
+    }
     String redirectUrl = notionService.handleCallback(code, state);
     return ResponseEntity.status(302).location(URI.create(redirectUrl)).build();
   }


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #

## ✏️ 작업 내용

- Notion OAuth 취소 시 code 파라미터 없이 error=access_denied만 전달되어 400 에러 발생하는 문제 수정
- code를 required = false로 변경, error 파라미터 추가
- 취소 시 https://kkium.com/experience/add?success=false로 302 redirect 처리

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [ ]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
