### PR TITLE
[FEAT] 경험  제목 수정, 전체 수정, 삭제 API 구현

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -129,6 +130,14 @@ public class ExperienceController {
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @Valid @RequestBody ExperienceOrderUpdateRequest request) {
     experienceService.updateOrder(request, userDetails.getId());
+    return ResponseEntity.ok(ApiResponse.successWithNoContent());
+  }
+
+  @Operation(summary = "경험 삭제", description = "경험을 소프트 삭제합니다.")
+  @DeleteMapping("/{experienceId}")
+  public ResponseEntity<ApiResponse<Void>> delete(
+      @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long experienceId) {
+    experienceService.delete(userDetails.getId(), experienceId);
     return ResponseEntity.ok(ApiResponse.successWithNoContent());
   }
 

--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -22,6 +22,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.kusitms.kkium.experience.domain.type.PieceType;
 import com.kusitms.kkium.experience.dto.request.ExperienceCreateRequest;
 import com.kusitms.kkium.experience.dto.request.ExperienceOrderUpdateRequest;
+import com.kusitms.kkium.experience.dto.request.ExperienceTitleUpdateRequest;
 import com.kusitms.kkium.experience.dto.response.ExperienceAnalyzeResponse;
 import com.kusitms.kkium.experience.dto.response.ExperienceDetailResponse;
 import com.kusitms.kkium.experience.dto.response.ExperienceListResponse;
@@ -127,6 +128,16 @@ public class ExperienceController {
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @Valid @RequestBody ExperienceOrderUpdateRequest request) {
     experienceService.updateOrder(request, userDetails.getId());
+    return ResponseEntity.ok(ApiResponse.successWithNoContent());
+  }
+
+  @Operation(summary = "경험 제목 수정", description = "경험 카드의 제목을 수정합니다.")
+  @PatchMapping("/{experienceId}/title")
+  public ResponseEntity<ApiResponse<Void>> updateTitle(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long experienceId,
+      @Valid @RequestBody ExperienceTitleUpdateRequest request) {
+    experienceService.updateTitle(userDetails.getId(), experienceId, request.title());
     return ResponseEntity.ok(ApiResponse.successWithNoContent());
   }
 }

--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -23,6 +23,7 @@ import com.kusitms.kkium.experience.domain.type.PieceType;
 import com.kusitms.kkium.experience.dto.request.ExperienceCreateRequest;
 import com.kusitms.kkium.experience.dto.request.ExperienceOrderUpdateRequest;
 import com.kusitms.kkium.experience.dto.request.ExperienceTitleUpdateRequest;
+import com.kusitms.kkium.experience.dto.request.ExperienceUpdateRequest;
 import com.kusitms.kkium.experience.dto.response.ExperienceAnalyzeResponse;
 import com.kusitms.kkium.experience.dto.response.ExperienceDetailResponse;
 import com.kusitms.kkium.experience.dto.response.ExperienceListResponse;
@@ -128,6 +129,16 @@ public class ExperienceController {
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @Valid @RequestBody ExperienceOrderUpdateRequest request) {
     experienceService.updateOrder(request, userDetails.getId());
+    return ResponseEntity.ok(ApiResponse.successWithNoContent());
+  }
+
+  @Operation(summary = "경험 수정", description = "경험 상세 정보를 수정합니다. 경험 유형은 변경할 수 없습니다.")
+  @PatchMapping("/{experienceId}")
+  public ResponseEntity<ApiResponse<Void>> update(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long experienceId,
+      @Valid @RequestBody ExperienceUpdateRequest request) {
+    experienceService.update(userDetails.getId(), experienceId, request);
     return ResponseEntity.ok(ApiResponse.successWithNoContent());
   }
 

--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -141,7 +141,17 @@ public class ExperienceController {
     return ResponseEntity.ok(ApiResponse.successWithNoContent());
   }
 
-  @Operation(summary = "경험 수정", description = "경험 상세 정보를 수정합니다. 경험 유형은 변경할 수 없습니다.")
+  @Operation(
+      summary = "경험 수정",
+      description =
+          """
+          경험 상세 정보를 수정합니다.
+          type에 따라 detail 필드가 다릅니다.
+          - ACTIVITY: name, teamNum, role, contributionRate, startDate, endDate
+          - CAREER: name, company, employmentStatus, startDate, endDate
+          - EDUCATION: name, organizationName, startDate, endDate
+          - ETC: startDate, endDate
+          """)
   @PatchMapping("/{experienceId}")
   public ResponseEntity<ApiResponse<Void>> update(
       @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
+++ b/src/main/java/com/kusitms/kkium/experience/controller/ExperienceController.java
@@ -148,7 +148,7 @@ public class ExperienceController {
           경험 상세 정보를 수정합니다.
           type에 따라 detail 필드가 다릅니다.
           - ACTIVITY: name, teamNum, role, contributionRate, startDate, endDate
-          - CAREER: name, company, employmentStatus, startDate, endDate
+          - CAREER: company, employmentStatus, startDate, endDate
           - EDUCATION: name, organizationName, startDate, endDate
           - ETC: startDate, endDate
           """)

--- a/src/main/java/com/kusitms/kkium/experience/domain/Activity.java
+++ b/src/main/java/com/kusitms/kkium/experience/domain/Activity.java
@@ -59,4 +59,19 @@ public class Activity extends BaseEntity {
     this.role = role;
     this.experience = experience;
   }
+
+  public void update(
+      String name,
+      Integer teamNum,
+      String role,
+      Integer contributionRate,
+      LocalDate startDate,
+      LocalDate endDate) {
+    this.name = name;
+    this.teamNum = teamNum;
+    this.role = role;
+    this.contributionRate = contributionRate;
+    this.startDate = startDate;
+    this.endDate = endDate;
+  }
 }

--- a/src/main/java/com/kusitms/kkium/experience/domain/Career.java
+++ b/src/main/java/com/kusitms/kkium/experience/domain/Career.java
@@ -54,4 +54,17 @@ public class Career extends BaseEntity {
     this.endDate = endDate;
     this.experience = experience;
   }
+
+  public void update(
+      String name,
+      String company,
+      String employmentStatus,
+      LocalDate startDate,
+      LocalDate endDate) {
+    this.name = name;
+    this.company = company;
+    this.employmentStatus = employmentStatus;
+    this.startDate = startDate;
+    this.endDate = endDate;
+  }
 }

--- a/src/main/java/com/kusitms/kkium/experience/domain/Education.java
+++ b/src/main/java/com/kusitms/kkium/experience/domain/Education.java
@@ -49,4 +49,11 @@ public class Education extends BaseEntity {
     this.endDate = endDate;
     this.experience = experience;
   }
+
+  public void update(String organizationName, String name, LocalDate startDate, LocalDate endDate) {
+    this.organizationName = organizationName;
+    this.name = name;
+    this.startDate = startDate;
+    this.endDate = endDate;
+  }
 }

--- a/src/main/java/com/kusitms/kkium/experience/domain/Etc.java
+++ b/src/main/java/com/kusitms/kkium/experience/domain/Etc.java
@@ -36,4 +36,9 @@ public class Etc extends BaseEntity {
     this.endDate = endDate;
     this.experience = experience;
   }
+
+  public void update(LocalDate startDate, LocalDate endDate) {
+    this.startDate = startDate;
+    this.endDate = endDate;
+  }
 }

--- a/src/main/java/com/kusitms/kkium/experience/domain/Experience.java
+++ b/src/main/java/com/kusitms/kkium/experience/domain/Experience.java
@@ -47,6 +47,23 @@ public class Experience extends BaseEntity {
     this.title = title;
   }
 
+  public void update(
+      String title,
+      String oneLineIntro,
+      String situation,
+      String task,
+      String act,
+      String result,
+      String taken) {
+    this.title = title;
+    this.oneLineIntro = oneLineIntro;
+    this.situation = situation;
+    this.task = task;
+    this.act = act;
+    this.result = result;
+    this.taken = taken;
+  }
+
   @Builder
   public Experience(
       String situation,

--- a/src/main/java/com/kusitms/kkium/experience/domain/Experience.java
+++ b/src/main/java/com/kusitms/kkium/experience/domain/Experience.java
@@ -43,6 +43,10 @@ public class Experience extends BaseEntity {
   @JoinColumn(name = "piece_id", nullable = false)
   private Piece piece;
 
+  public void updateTitle(String title) {
+    this.title = title;
+  }
+
   @Builder
   public Experience(
       String situation,

--- a/src/main/java/com/kusitms/kkium/experience/domain/Piece.java
+++ b/src/main/java/com/kusitms/kkium/experience/domain/Piece.java
@@ -1,5 +1,7 @@
 package com.kusitms.kkium.experience.domain;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.*;
 
 import com.kusitms.kkium.experience.domain.type.PieceType;
@@ -28,9 +30,16 @@ public class Piece extends BaseEntity {
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
+  @Column(name = "delete_at", nullable = true)
+  private LocalDateTime deleteAt;
+
   @Builder
   public Piece(PieceType type, User user) {
     this.type = type;
     this.user = user;
+  }
+
+  public void delete() {
+    this.deleteAt = LocalDateTime.now();
   }
 }

--- a/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceTitleUpdateRequest.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceTitleUpdateRequest.java
@@ -1,0 +1,5 @@
+package com.kusitms.kkium.experience.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ExperienceTitleUpdateRequest(@NotBlank(message = "제목을 입력해주세요.") String title) {}

--- a/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceUpdateRequest.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceUpdateRequest.java
@@ -18,7 +18,7 @@ public record ExperienceUpdateRequest(
     @NotNull Detail detail) {
 
   public record Detail(
-      // ACTIVITY, CAREER, EDUCATION 공통
+      // ACTIVITY, EDUCATION 공통
       String name,
 
       // ACTIVITY 전용

--- a/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceUpdateRequest.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceUpdateRequest.java
@@ -1,0 +1,39 @@
+package com.kusitms.kkium.experience.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ExperienceUpdateRequest(
+    @NotBlank String title,
+    @NotBlank String oneLineIntro,
+    @NotNull List<TagCreateRequest> tags,
+    String situation,
+    String task,
+    String act,
+    String result,
+    String taken,
+    @NotNull Detail detail) {
+
+  public record Detail(
+      // ACTIVITY, CAREER, EDUCATION 공통
+      String name,
+
+      // ACTIVITY 전용
+      Integer teamNum,
+      String role,
+      Integer contributionRate,
+
+      // CAREER 전용
+      String company,
+      String employmentStatus,
+
+      // EDUCATION 전용
+      String organizationName,
+
+      // 공통 (기간)
+      @NotNull LocalDate startDate,
+      @NotNull LocalDate endDate) {}
+}

--- a/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
@@ -13,24 +13,28 @@ import com.kusitms.kkium.experience.domain.type.PieceType;
 
 public interface ExperienceRepository extends JpaRepository<Experience, Long> {
 
-  @Query("SELECT e FROM Experience e JOIN FETCH e.piece p WHERE e.id = :experienceId")
+  @Query(
+      "SELECT e FROM Experience e JOIN FETCH e.piece p WHERE e.id = :experienceId AND p.deleteAt IS NULL")
   Optional<Experience> findByIdWithPiece(@Param("experienceId") Long experienceId);
 
   // 전체 조회 (cursor 없음, 첫 페이지)
   @Query(
       "SELECT e FROM Experience e JOIN FETCH e.piece p WHERE p.user.id = :userId "
+          + "AND p.deleteAt IS NULL "
           + "ORDER BY e.id DESC")
   List<Experience> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
 
   // 공고분석용 전체 조회 (페이지네이션 없음)
   @Query(
       "SELECT e FROM Experience e JOIN FETCH e.piece p WHERE p.user.id = :userId "
+          + "AND p.deleteAt IS NULL "
           + "ORDER BY e.id DESC")
   List<Experience> findAllByUserIdNoPage(@Param("userId") Long userId);
 
   // 전체 조회 (cursor 있음)
   @Query(
       "SELECT e FROM Experience e JOIN FETCH e.piece p WHERE p.user.id = :userId "
+          + "AND p.deleteAt IS NULL "
           + "AND e.id < :cursor "
           + "ORDER BY e.id DESC")
   List<Experience> findAllByUserIdAndCursor(
@@ -39,6 +43,7 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long> {
   // type 필터 조회 (cursor 없음, 첫 페이지)
   @Query(
       "SELECT e FROM Experience e JOIN FETCH e.piece p WHERE p.user.id = :userId "
+          + "AND p.deleteAt IS NULL "
           + "AND p.type = :type "
           + "ORDER BY e.id DESC")
   List<Experience> findAllByUserIdAndType(
@@ -47,6 +52,7 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long> {
   // type 필터 조회 (cursor 있음)
   @Query(
       "SELECT e FROM Experience e JOIN FETCH e.piece p WHERE p.user.id = :userId "
+          + "AND p.deleteAt IS NULL "
           + "AND p.type = :type "
           + "AND e.id < :cursor "
           + "ORDER BY e.id DESC")
@@ -60,6 +66,7 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long> {
   @Query(
       "SELECT DISTINCT e.id FROM Experience e JOIN e.piece p LEFT JOIN Tag t ON t.experience = e "
           + "WHERE p.user.id = :userId "
+          + "AND p.deleteAt IS NULL "
           + "AND (:type IS NULL OR p.type = :type) "
           + "AND (LOWER(e.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(t.field) LIKE LOWER(CONCAT('%', :keyword, '%'))) "
           + "ORDER BY e.id DESC")
@@ -73,6 +80,7 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long> {
   @Query(
       "SELECT DISTINCT e.id FROM Experience e JOIN e.piece p LEFT JOIN Tag t ON t.experience = e "
           + "WHERE p.user.id = :userId "
+          + "AND p.deleteAt IS NULL "
           + "AND e.id < :cursor "
           + "AND (:type IS NULL OR p.type = :type) "
           + "AND (LOWER(e.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR LOWER(t.field) LIKE LOWER(CONCAT('%', :keyword, '%'))) "
@@ -85,6 +93,7 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long> {
       Pageable pageable);
 
   // 키워드 검색 - Step 2: id IN으로 fetch
-  @Query("SELECT e FROM Experience e JOIN FETCH e.piece p WHERE e.id IN :ids ORDER BY e.id DESC")
+  @Query(
+      "SELECT e FROM Experience e JOIN FETCH e.piece p WHERE e.id IN :ids AND p.deleteAt IS NULL ORDER BY e.id DESC")
   List<Experience> findAllByIdIn(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/kusitms/kkium/experience/repository/PieceRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/PieceRepository.java
@@ -1,6 +1,7 @@
 package com.kusitms.kkium.experience.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,6 @@ import com.kusitms.kkium.experience.domain.Piece;
 
 public interface PieceRepository extends JpaRepository<Piece, Long> {
   List<Piece> findByUserId(Long userId);
+
+  Optional<Piece> findByIdAndDeleteAtIsNull(Long id);
 }

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -447,9 +447,7 @@ public class ExperienceService {
                         detail.endDate()));
       }
       case CAREER -> {
-        if (detail.name() == null
-            || detail.company() == null
-            || detail.employmentStatus() == null) {
+        if (detail.company() == null || detail.employmentStatus() == null) {
           throw new BaseException(INVALID_INPUT_VALUE);
         }
         careerRepository
@@ -457,7 +455,7 @@ public class ExperienceService {
             .ifPresent(
                 c ->
                     c.update(
-                        detail.name(),
+                        request.title(),
                         detail.company(),
                         detail.employmentStatus(),
                         detail.startDate(),
@@ -543,7 +541,8 @@ public class ExperienceService {
       case CAREER -> {
         var c = careerRepository.findByExperienceId(experienceId).orElse(null);
         if (c != null) {
-          name = c.getName();
+          c.update(
+              title, c.getCompany(), c.getEmploymentStatus(), c.getStartDate(), c.getEndDate());
           company = c.getCompany();
           employmentStatus = c.getEmploymentStatus();
         }

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -374,6 +374,20 @@ public class ExperienceService {
   }
 
   @Transactional
+  public void delete(Long userId, Long experienceId) {
+    Experience experience =
+        experienceRepository
+            .findByIdWithPiece(experienceId)
+            .orElseThrow(() -> new BaseException(EXPERIENCE_NOT_FOUND));
+
+    if (!experience.getPiece().getUser().getId().equals(userId)) {
+      throw new BaseException(FORBIDDEN);
+    }
+
+    experience.getPiece().delete();
+  }
+
+  @Transactional
   public void update(Long userId, Long experienceId, ExperienceUpdateRequest request) {
     Experience experience =
         experienceRepository

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -23,6 +23,7 @@ import com.kusitms.kkium.experience.domain.*;
 import com.kusitms.kkium.experience.domain.type.PieceType;
 import com.kusitms.kkium.experience.dto.request.ExperienceCreateRequest;
 import com.kusitms.kkium.experience.dto.request.ExperienceOrderUpdateRequest;
+import com.kusitms.kkium.experience.dto.request.ExperienceUpdateRequest;
 import com.kusitms.kkium.experience.dto.request.TagCreateRequest;
 import com.kusitms.kkium.experience.dto.response.ExperienceCardResponse;
 import com.kusitms.kkium.experience.dto.response.ExperienceDetailResponse;
@@ -369,6 +370,86 @@ public class ExperienceService {
       if (order != null) {
         order.updateSortOrder(i + 1);
       }
+    }
+  }
+
+  @Transactional
+  public void update(Long userId, Long experienceId, ExperienceUpdateRequest request) {
+    Experience experience =
+        experienceRepository
+            .findByIdWithPiece(experienceId)
+            .orElseThrow(() -> new BaseException(EXPERIENCE_NOT_FOUND));
+
+    if (!experience.getPiece().getUser().getId().equals(userId)) {
+      throw new BaseException(FORBIDDEN);
+    }
+
+    // 1. Experience 공통 필드 수정
+    experience.update(
+        request.title(),
+        request.oneLineIntro(),
+        request.situation(),
+        request.task(),
+        request.act(),
+        request.result(),
+        request.taken());
+
+    // 2. 태그 전체 삭제 후 재삽입
+    tagRepository.deleteAll(tagRepository.findByExperienceId(experienceId));
+    List<Tag> newTags =
+        request.tags().stream()
+            .map(
+                t ->
+                    Tag.builder()
+                        .category(t.category())
+                        .field(t.field())
+                        .experience(experience)
+                        .build())
+            .collect(Collectors.toList());
+    tagRepository.saveAll(newTags);
+
+    // 3. 유형별 detail 수정
+    PieceType type = experience.getPiece().getType();
+    ExperienceUpdateRequest.Detail detail = request.detail();
+
+    switch (type) {
+      case ACTIVITY ->
+          activityRepository
+              .findByExperienceId(experienceId)
+              .ifPresent(
+                  a ->
+                      a.update(
+                          detail.name(),
+                          detail.teamNum(),
+                          detail.role(),
+                          detail.contributionRate(),
+                          detail.startDate(),
+                          detail.endDate()));
+      case CAREER ->
+          careerRepository
+              .findByExperienceId(experienceId)
+              .ifPresent(
+                  c ->
+                      c.update(
+                          detail.name(),
+                          detail.company(),
+                          detail.employmentStatus(),
+                          detail.startDate(),
+                          detail.endDate()));
+      case EDUCATION ->
+          educationRepository
+              .findByExperienceId(experienceId)
+              .ifPresent(
+                  e ->
+                      e.update(
+                          detail.organizationName(),
+                          detail.name(),
+                          detail.startDate(),
+                          detail.endDate()));
+      case ETC ->
+          etcRepository
+              .findByExperienceId(experienceId)
+              .ifPresent(e -> e.update(detail.startDate(), detail.endDate()));
     }
   }
 

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -371,4 +371,18 @@ public class ExperienceService {
       }
     }
   }
+
+  @Transactional
+  public void updateTitle(Long userId, Long experienceId, String title) {
+    Experience experience =
+        experienceRepository
+            .findByIdWithPiece(experienceId)
+            .orElseThrow(() -> new BaseException(EXPERIENCE_NOT_FOUND));
+
+    if (!experience.getPiece().getUser().getId().equals(userId)) {
+      throw new BaseException(FORBIDDEN);
+    }
+
+    experience.updateTitle(title);
+  }
 }

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -427,39 +427,56 @@ public class ExperienceService {
     ExperienceUpdateRequest.Detail detail = request.detail();
 
     switch (type) {
-      case ACTIVITY ->
-          activityRepository
-              .findByExperienceId(experienceId)
-              .ifPresent(
-                  a ->
-                      a.update(
-                          detail.name(),
-                          detail.teamNum(),
-                          detail.role(),
-                          detail.contributionRate(),
-                          detail.startDate(),
-                          detail.endDate()));
-      case CAREER ->
-          careerRepository
-              .findByExperienceId(experienceId)
-              .ifPresent(
-                  c ->
-                      c.update(
-                          detail.name(),
-                          detail.company(),
-                          detail.employmentStatus(),
-                          detail.startDate(),
-                          detail.endDate()));
-      case EDUCATION ->
-          educationRepository
-              .findByExperienceId(experienceId)
-              .ifPresent(
-                  e ->
-                      e.update(
-                          detail.organizationName(),
-                          detail.name(),
-                          detail.startDate(),
-                          detail.endDate()));
+      case ACTIVITY -> {
+        if (detail.name() == null
+            || detail.teamNum() == null
+            || detail.role() == null
+            || detail.contributionRate() == null) {
+          throw new BaseException(INVALID_INPUT_VALUE);
+        }
+        activityRepository
+            .findByExperienceId(experienceId)
+            .ifPresent(
+                a ->
+                    a.update(
+                        detail.name(),
+                        detail.teamNum(),
+                        detail.role(),
+                        detail.contributionRate(),
+                        detail.startDate(),
+                        detail.endDate()));
+      }
+      case CAREER -> {
+        if (detail.name() == null
+            || detail.company() == null
+            || detail.employmentStatus() == null) {
+          throw new BaseException(INVALID_INPUT_VALUE);
+        }
+        careerRepository
+            .findByExperienceId(experienceId)
+            .ifPresent(
+                c ->
+                    c.update(
+                        detail.name(),
+                        detail.company(),
+                        detail.employmentStatus(),
+                        detail.startDate(),
+                        detail.endDate()));
+      }
+      case EDUCATION -> {
+        if (detail.organizationName() == null || detail.name() == null) {
+          throw new BaseException(INVALID_INPUT_VALUE);
+        }
+        educationRepository
+            .findByExperienceId(experienceId)
+            .ifPresent(
+                e ->
+                    e.update(
+                        detail.organizationName(),
+                        detail.name(),
+                        detail.startDate(),
+                        detail.endDate()));
+      }
       case ETC ->
           etcRepository
               .findByExperienceId(experienceId)

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -385,6 +385,7 @@ public class ExperienceService {
     }
 
     experience.getPiece().delete();
+    experienceOrderRepository.deleteAllByExperienceId(experienceId);
   }
 
   @Transactional

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -465,6 +465,29 @@ public class ExperienceService {
               .findByExperienceId(experienceId)
               .ifPresent(e -> e.update(detail.startDate(), detail.endDate()));
     }
+
+    Long pieceId = experience.getPiece().getId();
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            experienceEmbeddingService.embedPiece(
+                pieceId,
+                request.title(),
+                request.oneLineIntro(),
+                request.situation(),
+                request.task(),
+                request.act(),
+                request.result(),
+                request.taken(),
+                request.detail().name(),
+                request.detail().role(),
+                request.detail().company(),
+                request.detail().employmentStatus(),
+                request.detail().organizationName(),
+                request.tags());
+          }
+        });
   }
 
   @Transactional
@@ -479,5 +502,72 @@ public class ExperienceService {
     }
 
     experience.updateTitle(title);
+
+    Long pieceId = experience.getPiece().getId();
+    PieceType type = experience.getPiece().getType();
+    List<TagCreateRequest> tags =
+        tagRepository.findByExperienceId(experienceId).stream()
+            .map(t -> new TagCreateRequest(t.getCategory(), t.getField()))
+            .toList();
+
+    String name = null,
+        role = null,
+        company = null,
+        employmentStatus = null,
+        organizationName = null;
+    switch (type) {
+      case ACTIVITY -> {
+        var a = activityRepository.findByExperienceId(experienceId).orElse(null);
+        if (a != null) {
+          name = a.getName();
+          role = a.getRole();
+        }
+      }
+      case CAREER -> {
+        var c = careerRepository.findByExperienceId(experienceId).orElse(null);
+        if (c != null) {
+          name = c.getName();
+          company = c.getCompany();
+          employmentStatus = c.getEmploymentStatus();
+        }
+      }
+      case EDUCATION -> {
+        var e = educationRepository.findByExperienceId(experienceId).orElse(null);
+        if (e != null) {
+          name = e.getName();
+          organizationName = e.getOrganizationName();
+        }
+      }
+      default -> {}
+    }
+
+    String finalName = name,
+        finalRole = role,
+        finalCompany = company,
+        finalEmploymentStatus = employmentStatus,
+        finalOrganizationName = organizationName;
+    Long finalPieceId = pieceId;
+
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            experienceEmbeddingService.embedPiece(
+                finalPieceId,
+                title,
+                experience.getOneLineIntro(),
+                experience.getSituation(),
+                experience.getTask(),
+                experience.getAct(),
+                experience.getResult(),
+                experience.getTaken(),
+                finalName,
+                finalRole,
+                finalCompany,
+                finalEmploymentStatus,
+                finalOrganizationName,
+                tags);
+          }
+        });
   }
 }


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #74 

## ✏️ 작업 내용

- 경험 제목 수정 (EM002-1)
- 경험 상세 수정 (EM-005-2)
  - 수정 시 임베딩 벡터도 갱신 
- 경험 소프트 삭제 (EM002-1)
- 소프트 삭제 관련
  - 경험 관련 전체 조회 쿼리에 deleteAt IS NULL 조건 추가
  - 순서테이블에서도 해당 id 삭제

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
