### PR TITLE
[CHORE] CORS 허용 Origin에 프로덕션 도메인 추가

### DIFF
--- a/src/main/java/com/kusitms/kkium/global/config/SecurityConfig.java
+++ b/src/main/java/com/kusitms/kkium/global/config/SecurityConfig.java
@@ -76,7 +76,11 @@ public class SecurityConfig {
     CorsConfiguration configuration = new CorsConfiguration();
 
     configuration.setAllowedOrigins(
-        Arrays.asList("http://localhost:3000", "http://localhost:8080"));
+        Arrays.asList(
+            "http://localhost:3000",
+            "http://localhost:8080",
+            "https://www.kkium.com",
+            "https://kkium.com"));
     configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
     configuration.setAllowedHeaders(
         Arrays.asList("X-Requested-With", "Content-Type", "Authorization", "X-XSRF-token"));


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #78

## ✏️ 작업 내용

- CORS 허용 Origin에 프로덕션 도메인 추가

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
