### PR TITLE
[FEAT] Notion 페이지 목록 조회 응답 필드 추가

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/service/analyze/NotionAnalyzeService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/analyze/NotionAnalyzeService.java
@@ -25,25 +25,21 @@ public class NotionAnalyzeService {
 
   // 접근 가능한 Notion 페이지 목록 조회
   public NotionPageListResponse getPages(Long userId) {
-    NotionConnection connection = notionConnectionRepository
-        .findByUserId(userId)
-        .orElseThrow(() -> new BaseException(ErrorCode.NOTION_NOT_CONNECTED));
+    NotionConnection connection = getConnection(userId);
     List<NotionPageListResponse.NotionPageInfo> pages = notionApiClient.getPages(connection.getAccessToken());
     return new NotionPageListResponse(connection.getWorkspaceName(), pages);
   }
 
   // 선택한 페이지 콘텐츠 추출 후 LLM 분석
   public ExperienceAnalyzeResponse analyze(Long userId, String pageId) {
-    String accessToken = getAccessToken(userId);
+    String accessToken = getConnection(userId).getAccessToken();
     String content = notionApiClient.getPageContent(accessToken, pageId);
     return llmService.analyze(userId, content);
   }
 
-  private String getAccessToken(Long userId) {
-    NotionConnection connection =
-        notionConnectionRepository
-            .findByUserId(userId)
-            .orElseThrow(() -> new BaseException(ErrorCode.NOTION_NOT_CONNECTED));
-    return connection.getAccessToken();
+  private NotionConnection getConnection(Long userId) {
+    return notionConnectionRepository
+        .findByUserId(userId)
+        .orElseThrow(() -> new BaseException(ErrorCode.NOTION_NOT_CONNECTED));
   }
 }

--- a/src/main/java/com/kusitms/kkium/experience/service/analyze/NotionAnalyzeService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/analyze/NotionAnalyzeService.java
@@ -25,9 +25,11 @@ public class NotionAnalyzeService {
 
   // 접근 가능한 Notion 페이지 목록 조회
   public NotionPageListResponse getPages(Long userId) {
-    String accessToken = getAccessToken(userId);
-    List<NotionPageListResponse.NotionPageInfo> pages = notionApiClient.getPages(accessToken);
-    return new NotionPageListResponse(pages);
+    NotionConnection connection = notionConnectionRepository
+        .findByUserId(userId)
+        .orElseThrow(() -> new BaseException(ErrorCode.NOTION_NOT_CONNECTED));
+    List<NotionPageListResponse.NotionPageInfo> pages = notionApiClient.getPages(connection.getAccessToken());
+    return new NotionPageListResponse(connection.getWorkspaceName(), pages);
   }
 
   // 선택한 페이지 콘텐츠 추출 후 LLM 분석

--- a/src/main/java/com/kusitms/kkium/notion/dto/response/NotionPageListResponse.java
+++ b/src/main/java/com/kusitms/kkium/notion/dto/response/NotionPageListResponse.java
@@ -4,5 +4,5 @@ import java.util.List;
 
 public record NotionPageListResponse(String workspaceName, List<NotionPageInfo> pages) {
 
-  public record NotionPageInfo(String pageId, String title, String icon, String type, String lastEditedTime) {}
+  public record NotionPageInfo(String pageId, String title, String icon, String type, String lastEditedTime, String parentId) {}
 }

--- a/src/main/java/com/kusitms/kkium/notion/dto/response/NotionPageListResponse.java
+++ b/src/main/java/com/kusitms/kkium/notion/dto/response/NotionPageListResponse.java
@@ -2,7 +2,7 @@ package com.kusitms.kkium.notion.dto.response;
 
 import java.util.List;
 
-public record NotionPageListResponse(List<NotionPageInfo> pages) {
+public record NotionPageListResponse(String workspaceName, List<NotionPageInfo> pages) {
 
-  public record NotionPageInfo(String pageId, String title) {}
+  public record NotionPageInfo(String pageId, String title, String icon, String type, String lastEditedTime) {}
 }

--- a/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
+++ b/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
@@ -205,11 +205,27 @@ public class NotionApiClient {
         // 하위 페이지 없음 → leaf
         leafPages.add(new NotionPageListResponse.NotionPageInfo(pageId, title, icon, type, lastEditedTime, parentId));
       } else {
-        // 하위 페이지 있음 → 재귀 (child 페이지 아이콘/날짜는 /pages/{id}로 직접 조회)
-        for (JsonNode child : childPages) {
-          String childId = child.get("id").asText();
-          String childTitle = child.get("child_page").get("title").asText("제목 없음");
-          JsonNode childPage = fetchPage(accessToken, childId);
+        // 하위 페이지 있음 → fetchPage 병렬 호출 후 재귀
+        List<String> childIds = childPages.stream()
+            .map(child -> child.get("id").asText())
+            .toList();
+        List<String> childTitles = childPages.stream()
+            .map(child -> child.get("child_page").get("title").asText("제목 없음"))
+            .toList();
+
+        List<Mono<JsonNode>> fetchMonos = childIds.stream()
+            .map(childId -> fetchPageAsync(accessToken, childId))
+            .toList();
+
+        List<JsonNode> childPageNodes = Mono.zip(fetchMonos, results ->
+                java.util.Arrays.stream(results).map(r -> (JsonNode) r).toList())
+            .blockOptional()
+            .orElse(List.of());
+
+        for (int i = 0; i < childIds.size(); i++) {
+          String childId = childIds.get(i);
+          String childTitle = childTitles.get(i);
+          JsonNode childPage = i < childPageNodes.size() ? childPageNodes.get(i) : null;
           String childIcon = childPage != null ? extractIcon(childPage) : null;
           String childLastEditedTime = childPage != null && childPage.has("last_edited_time")
               ? childPage.get("last_edited_time").asText() : lastEditedTime;
@@ -329,6 +345,35 @@ public class NotionApiClient {
     } catch (Exception e) {
       log.warn("Notion DB row 파싱 실패 (databaseId={}): {}", databaseId, e.getMessage());
     }
+  }
+
+  private Mono<JsonNode> fetchPageAsync(String accessToken, String pageId) {
+    return webClient
+        .get()
+        .uri("https://api.notion.com/v1/pages/" + pageId)
+        .header("Authorization", "Bearer " + accessToken)
+        .header("Notion-Version", "2022-06-28")
+        .exchangeToMono(res -> {
+          if (res.statusCode().is2xxSuccessful()) {
+            return res.bodyToMono(String.class);
+          } else {
+            return res.bodyToMono(String.class)
+                .flatMap(err -> {
+                  log.warn("Notion 페이지 조회 실패 (pageId={}): {}", pageId, err);
+                  return Mono.just("");
+                });
+          }
+        })
+        .mapNotNull(body -> {
+          if (body == null || body.isBlank()) return null;
+          try {
+            return objectMapper.readTree(body);
+          } catch (Exception e) {
+            log.warn("Notion 페이지 파싱 실패 (pageId={}): {}", pageId, e.getMessage());
+            return null;
+          }
+        })
+        .onErrorReturn(objectMapper.createObjectNode());
   }
 
   private JsonNode fetchPage(String accessToken, String pageId) {

--- a/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
+++ b/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
@@ -132,7 +132,7 @@ public class NotionApiClient {
           String icon = extractIcon(page);
           String type = page.has("object") ? page.get("object").asText() : "page";
           String lastEditedTime = page.has("last_edited_time") ? page.get("last_edited_time").asText() : null;
-          collectLeafPages(accessToken, pageId, title, icon, type, lastEditedTime, leafPages, visitedPageIds, 0);
+          collectLeafPages(accessToken, pageId, title, icon, type, lastEditedTime, null, leafPages, visitedPageIds, 0);
         }
       }
     } catch (JsonProcessingException e) {
@@ -150,6 +150,7 @@ public class NotionApiClient {
       String icon,
       String type,
       String lastEditedTime,
+      String parentId,
       List<NotionPageListResponse.NotionPageInfo> leafPages,
       Set<String> visitedPageIds,
       int depth) {
@@ -160,7 +161,7 @@ public class NotionApiClient {
 
     // database는 자체도 leaf로 추가하고, 하위 row 페이지들도 추가
     if ("database".equals(type)) {
-      leafPages.add(new NotionPageListResponse.NotionPageInfo(pageId, title, icon, type, lastEditedTime));
+      leafPages.add(new NotionPageListResponse.NotionPageInfo(pageId, title, icon, type, lastEditedTime, parentId));
       fetchDatabaseRows(accessToken, pageId, icon, lastEditedTime, leafPages, visitedPageIds, depth);
       return;
     }
@@ -189,7 +190,7 @@ public class NotionApiClient {
     try {
       JsonNode response = objectMapper.readTree(responseBody);
       if (response == null || !response.has("results")) {
-        leafPages.add(new NotionPageListResponse.NotionPageInfo(pageId, title, icon, type, lastEditedTime));
+        leafPages.add(new NotionPageListResponse.NotionPageInfo(pageId, title, icon, type, lastEditedTime, parentId));
         return;
       }
 
@@ -202,7 +203,7 @@ public class NotionApiClient {
 
       if (childPages.isEmpty()) {
         // 하위 페이지 없음 → leaf
-        leafPages.add(new NotionPageListResponse.NotionPageInfo(pageId, title, icon, type, lastEditedTime));
+        leafPages.add(new NotionPageListResponse.NotionPageInfo(pageId, title, icon, type, lastEditedTime, parentId));
       } else {
         // 하위 페이지 있음 → 재귀 (child 페이지 아이콘/날짜는 /pages/{id}로 직접 조회)
         for (JsonNode child : childPages) {
@@ -212,7 +213,7 @@ public class NotionApiClient {
           String childIcon = childPage != null ? extractIcon(childPage) : null;
           String childLastEditedTime = childPage != null && childPage.has("last_edited_time")
               ? childPage.get("last_edited_time").asText() : lastEditedTime;
-          collectLeafPages(accessToken, childId, childTitle, childIcon, type, childLastEditedTime, leafPages, visitedPageIds, depth + 1);
+          collectLeafPages(accessToken, childId, childTitle, childIcon, type, childLastEditedTime, pageId, leafPages, visitedPageIds, depth + 1);
         }
       }
     } catch (JsonProcessingException e) {
@@ -323,7 +324,7 @@ public class NotionApiClient {
         String rowTitle = extractPageTitle(row);
         String rowIcon = extractIcon(row);
         String rowLastEditedTime = row.has("last_edited_time") ? row.get("last_edited_time").asText() : parentLastEditedTime;
-        collectLeafPages(accessToken, rowId, rowTitle, rowIcon, "page", rowLastEditedTime, leafPages, visitedPageIds, depth + 1);
+        collectLeafPages(accessToken, rowId, rowTitle, rowIcon, "page", rowLastEditedTime, databaseId, leafPages, visitedPageIds, depth + 1);
       }
     } catch (Exception e) {
       log.warn("Notion DB row 파싱 실패 (databaseId={}): {}", databaseId, e.getMessage());

--- a/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
+++ b/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
@@ -132,7 +132,8 @@ public class NotionApiClient {
           String icon = extractIcon(page);
           String type = page.has("object") ? page.get("object").asText() : "page";
           String lastEditedTime = page.has("last_edited_time") ? page.get("last_edited_time").asText() : null;
-          collectLeafPages(accessToken, pageId, title, icon, type, lastEditedTime, null, leafPages, visitedPageIds, 0);
+          String parentId = extractParentId(page);
+          collectLeafPages(accessToken, pageId, title, icon, type, lastEditedTime, parentId, leafPages, visitedPageIds, 0);
         }
       }
     } catch (JsonProcessingException e) {
@@ -401,6 +402,22 @@ public class NotionApiClient {
       log.warn("Notion 페이지 조회 예외 (pageId={}): {}", pageId, e.getMessage());
       return null;
     }
+  }
+
+  private String extractParentId(JsonNode page) {
+    try {
+      JsonNode parent = page.get("parent");
+      if (parent == null || parent.isNull()) return null;
+      String parentType = parent.has("type") ? parent.get("type").asText() : null;
+      if ("page_id".equals(parentType)) {
+        return parent.get("page_id").asText();
+      } else if ("database_id".equals(parentType)) {
+        return parent.get("database_id").asText();
+      }
+    } catch (Exception e) {
+      log.warn("parentId 추출 실패: {}", e.getMessage());
+    }
+    return null;
   }
 
   private String extractIcon(JsonNode page) {

--- a/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
+++ b/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
@@ -105,7 +105,7 @@ public class NotionApiClient {
             .header("Authorization", "Bearer " + accessToken)
             .header("Notion-Version", "2022-06-28")
             .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(Map.of("filter", Map.of("value", "page", "property", "object")))
+            .bodyValue(Map.of())
             .exchangeToMono(
                 res -> {
                   if (res.statusCode().is2xxSuccessful()) {
@@ -129,7 +129,10 @@ public class NotionApiClient {
         for (JsonNode page : response.get("results")) {
           String pageId = page.get("id").asText();
           String title = extractPageTitle(page);
-          collectLeafPages(accessToken, pageId, title, leafPages, visitedPageIds, 0);
+          String icon = extractIcon(page);
+          String type = page.has("object") ? page.get("object").asText() : "page";
+          String lastEditedTime = page.has("last_edited_time") ? page.get("last_edited_time").asText() : null;
+          collectLeafPages(accessToken, pageId, title, icon, type, lastEditedTime, leafPages, visitedPageIds, 0);
         }
       }
     } catch (JsonProcessingException e) {
@@ -144,6 +147,9 @@ public class NotionApiClient {
       String accessToken,
       String pageId,
       String title,
+      String icon,
+      String type,
+      String lastEditedTime,
       List<NotionPageListResponse.NotionPageInfo> leafPages,
       Set<String> visitedPageIds,
       int depth) {
@@ -151,6 +157,13 @@ public class NotionApiClient {
     if (depth > MAX_BLOCK_FETCH_DEPTH) return;
     if (visitedPageIds.contains(pageId)) return;
     visitedPageIds.add(pageId);
+
+    // database는 자체도 leaf로 추가하고, 하위 row 페이지들도 추가
+    if ("database".equals(type)) {
+      leafPages.add(new NotionPageListResponse.NotionPageInfo(pageId, title, icon, type, lastEditedTime));
+      fetchDatabaseRows(accessToken, pageId, icon, lastEditedTime, leafPages, visitedPageIds, depth);
+      return;
+    }
 
     String responseBody =
         webClient
@@ -176,7 +189,7 @@ public class NotionApiClient {
     try {
       JsonNode response = objectMapper.readTree(responseBody);
       if (response == null || !response.has("results")) {
-        leafPages.add(new NotionPageListResponse.NotionPageInfo(pageId, title));
+        leafPages.add(new NotionPageListResponse.NotionPageInfo(pageId, title, icon, type, lastEditedTime));
         return;
       }
 
@@ -189,13 +202,17 @@ public class NotionApiClient {
 
       if (childPages.isEmpty()) {
         // 하위 페이지 없음 → leaf
-        leafPages.add(new NotionPageListResponse.NotionPageInfo(pageId, title));
+        leafPages.add(new NotionPageListResponse.NotionPageInfo(pageId, title, icon, type, lastEditedTime));
       } else {
-        // 하위 페이지 있음 → 재귀
+        // 하위 페이지 있음 → 재귀 (child 페이지 아이콘/날짜는 /pages/{id}로 직접 조회)
         for (JsonNode child : childPages) {
           String childId = child.get("id").asText();
           String childTitle = child.get("child_page").get("title").asText("제목 없음");
-          collectLeafPages(accessToken, childId, childTitle, leafPages, visitedPageIds, depth + 1);
+          JsonNode childPage = fetchPage(accessToken, childId);
+          String childIcon = childPage != null ? extractIcon(childPage) : null;
+          String childLastEditedTime = childPage != null && childPage.has("last_edited_time")
+              ? childPage.get("last_edited_time").asText() : lastEditedTime;
+          collectLeafPages(accessToken, childId, childTitle, childIcon, type, childLastEditedTime, leafPages, visitedPageIds, depth + 1);
         }
       }
     } catch (JsonProcessingException e) {
@@ -268,11 +285,110 @@ public class NotionApiClient {
     return sb.toString();
   }
 
+  private void fetchDatabaseRows(
+      String accessToken,
+      String databaseId,
+      String parentIcon,
+      String parentLastEditedTime,
+      List<NotionPageListResponse.NotionPageInfo> leafPages,
+      Set<String> visitedPageIds,
+      int depth) {
+    try {
+      String responseBody = webClient
+          .post()
+          .uri("https://api.notion.com/v1/databases/" + databaseId + "/query")
+          .header("Authorization", "Bearer " + accessToken)
+          .header("Notion-Version", "2022-06-28")
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(Map.of())
+          .exchangeToMono(res -> {
+            if (res.statusCode().is2xxSuccessful()) {
+              return res.bodyToMono(String.class);
+            } else {
+              return res.bodyToMono(String.class)
+                  .flatMap(err -> {
+                    log.warn("Notion DB 쿼리 실패 (databaseId={}): {}", databaseId, err);
+                    return Mono.just("");
+                  });
+            }
+          })
+          .block();
+
+      if (responseBody == null || responseBody.isBlank()) return;
+      JsonNode response = objectMapper.readTree(responseBody);
+      if (response == null || !response.has("results")) return;
+
+      for (JsonNode row : response.get("results")) {
+        String rowId = row.get("id").asText();
+        String rowTitle = extractPageTitle(row);
+        String rowIcon = extractIcon(row);
+        String rowLastEditedTime = row.has("last_edited_time") ? row.get("last_edited_time").asText() : parentLastEditedTime;
+        collectLeafPages(accessToken, rowId, rowTitle, rowIcon, "page", rowLastEditedTime, leafPages, visitedPageIds, depth + 1);
+      }
+    } catch (Exception e) {
+      log.warn("Notion DB row 파싱 실패 (databaseId={}): {}", databaseId, e.getMessage());
+    }
+  }
+
+  private JsonNode fetchPage(String accessToken, String pageId) {
+    try {
+      String responseBody = webClient
+          .get()
+          .uri("https://api.notion.com/v1/pages/" + pageId)
+          .header("Authorization", "Bearer " + accessToken)
+          .header("Notion-Version", "2022-06-28")
+          .exchangeToMono(res -> {
+            if (res.statusCode().is2xxSuccessful()) {
+              return res.bodyToMono(String.class);
+            } else {
+              return res.bodyToMono(String.class)
+                  .flatMap(err -> {
+                    log.warn("Notion 페이지 조회 실패 (pageId={}): {}", pageId, err);
+                    return Mono.just("");
+                  });
+            }
+          })
+          .block();
+      if (responseBody == null || responseBody.isBlank()) return null;
+      return objectMapper.readTree(responseBody);
+    } catch (Exception e) {
+      log.warn("Notion 페이지 조회 예외 (pageId={}): {}", pageId, e.getMessage());
+      return null;
+    }
+  }
+
+  private String extractIcon(JsonNode page) {
+    try {
+      JsonNode icon = page.get("icon");
+      if (icon == null || icon.isNull()) return null;
+      String iconType = icon.has("type") ? icon.get("type").asText() : null;
+      if ("emoji".equals(iconType)) {
+        return icon.get("emoji").asText();
+      } else if ("external".equals(iconType)) {
+        return icon.get("external").get("url").asText();
+      } else if ("file".equals(iconType)) {
+        return icon.get("file").get("url").asText();
+      }
+    } catch (Exception e) {
+      log.warn("페이지 아이콘 추출 실패: {}", e.getMessage(), e);
+    }
+    return null;
+  }
+
   private String extractPageTitle(JsonNode page) {
     try {
+      // database는 title 필드가 최상위에 배열로 존재
+      String objectType = page.has("object") ? page.get("object").asText() : "";
+      if ("database".equals(objectType)) {
+        JsonNode titleArray = page.get("title");
+        if (titleArray != null && titleArray.isArray() && titleArray.size() > 0) {
+          return titleArray.get(0).get("plain_text").asText("제목 없음");
+        }
+        return "제목 없음";
+      }
+
       JsonNode properties = page.get("properties");
       if (properties == null) return "제목 없음";
-      // title 또는 Name 필드에서 추출
       for (JsonNode prop : properties) {
         if (prop.has("type") && prop.get("type").asText().equals("title")) {
           JsonNode titleArray = prop.get("title");


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #

## ✏️ 작업 내용

- NotionPageInfo 응답에 icon, type, lastEditedTime, parentId 필드 추가
- NotionPageListResponse에 workspaceName 필드 추가
- 데이터베이스 타입 페이지 조회 지원 (/databases/{id}/query 호출)
- 데이터베이스 하위 row 페이지 목록 조회 지원
- child 페이지 아이콘/날짜 정확도 개선 (/pages/{id} 직접 조회)

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [ ]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
