### PR TITLE
[FEAT] 홈 대시보드 API 구현

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -35,6 +35,7 @@ import com.kusitms.kkium.experience.dto.response.detail.EducationDetail;
 import com.kusitms.kkium.experience.dto.response.detail.EtcDetail;
 import com.kusitms.kkium.experience.repository.*;
 import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.home.service.JobTypeUpdateService;
 import com.kusitms.kkium.user.domain.User;
 import com.kusitms.kkium.user.repository.UserRepository;
 
@@ -56,7 +57,7 @@ public class ExperienceService {
   private final EtcRepository etcRepository;
   private final TagRepository tagRepository;
   private final ExperienceEmbeddingService experienceEmbeddingService;
-  private final com.kusitms.kkium.home.service.JobTypeUpdateService jobTypeUpdateService;
+  private final JobTypeUpdateService jobTypeUpdateService;
 
   @Transactional(readOnly = true)
   public ExperienceDetailResponse getDetail(Long userId, Long experienceId) {

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -56,6 +56,7 @@ public class ExperienceService {
   private final EtcRepository etcRepository;
   private final TagRepository tagRepository;
   private final ExperienceEmbeddingService experienceEmbeddingService;
+  private final com.kusitms.kkium.home.service.JobTypeUpdateService jobTypeUpdateService;
 
   @Transactional(readOnly = true)
   public ExperienceDetailResponse getDetail(Long userId, Long experienceId) {
@@ -299,6 +300,7 @@ public class ExperienceService {
                 request.employmentStatus(),
                 request.organizationName(),
                 request.tags());
+            jobTypeUpdateService.updateJobType(userId);
           }
         });
   }
@@ -386,6 +388,13 @@ public class ExperienceService {
 
     experience.getPiece().delete();
     experienceOrderRepository.deleteAllByExperienceId(experienceId);
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            jobTypeUpdateService.updateJobType(userId);
+          }
+        });
   }
 
   @Transactional
@@ -502,6 +511,7 @@ public class ExperienceService {
                 request.detail().employmentStatus(),
                 request.detail().organizationName(),
                 request.tags());
+            jobTypeUpdateService.updateJobType(userId);
           }
         });
   }

--- a/src/main/java/com/kusitms/kkium/global/config/AsyncConfig.java
+++ b/src/main/java/com/kusitms/kkium/global/config/AsyncConfig.java
@@ -21,4 +21,15 @@ public class AsyncConfig {
     executor.initialize();
     return executor;
   }
+
+  @Bean(name = "jobTypeExecutor")
+  public Executor jobTypeExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(1);
+    executor.setMaxPoolSize(3);
+    executor.setQueueCapacity(50);
+    executor.setThreadNamePrefix("job-type-");
+    executor.initialize();
+    return executor;
+  }
 }

--- a/src/main/java/com/kusitms/kkium/global/config/SecurityConfig.java
+++ b/src/main/java/com/kusitms/kkium/global/config/SecurityConfig.java
@@ -81,7 +81,7 @@ public class SecurityConfig {
             "http://localhost:8080",
             "https://www.kkium.com",
             "https://kkium.com"));
-    configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+    configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
     configuration.setAllowedHeaders(
         Arrays.asList("X-Requested-With", "Content-Type", "Authorization", "X-XSRF-token"));
     configuration.setAllowCredentials(true);

--- a/src/main/java/com/kusitms/kkium/home/controller/HomeController.java
+++ b/src/main/java/com/kusitms/kkium/home/controller/HomeController.java
@@ -1,0 +1,33 @@
+package com.kusitms.kkium.home.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kusitms.kkium.global.response.ApiResponse;
+import com.kusitms.kkium.home.dto.response.HomeResponse;
+import com.kusitms.kkium.home.service.HomeService;
+import com.kusitms.kkium.user.utils.CustomUserDetails;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Home", description = "홈 대시보드 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/home")
+public class HomeController {
+
+  private final HomeService homeService;
+
+  @Operation(summary = "홈 대시보드 조회")
+  @GetMapping
+  public ResponseEntity<ApiResponse<HomeResponse>> getHome(
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    return ResponseEntity.ok(
+        ApiResponse.success(homeService.getHome(userDetails.getId())));
+  }
+}

--- a/src/main/java/com/kusitms/kkium/home/dto/response/HomeResponse.java
+++ b/src/main/java/com/kusitms/kkium/home/dto/response/HomeResponse.java
@@ -21,7 +21,7 @@ public record HomeResponse(
       List<String> softSkills,
       Integer applicationFitScore) {}
 
-  public record JobTypeInfo(String typeName, String description) {}
+  public record JobTypeInfo(String typeName) {}
 
   public record ExperienceDistribution(PieceType type, int count, int percentage) {}
 }

--- a/src/main/java/com/kusitms/kkium/home/dto/response/HomeResponse.java
+++ b/src/main/java/com/kusitms/kkium/home/dto/response/HomeResponse.java
@@ -1,0 +1,27 @@
+package com.kusitms.kkium.home.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.kusitms.kkium.experience.domain.type.PieceType;
+
+public record HomeResponse(
+    TargetJdInfo targetJd,
+    int totalExperienceCount,
+    int thisMonthExperienceCount,
+    JobTypeInfo jobType,
+    List<ExperienceDistribution> experienceDistribution) {
+
+  public record TargetJdInfo(
+      String companyName,
+      String recruitmentField,
+      LocalDateTime startDate,
+      LocalDateTime endDate,
+      List<String> hardSkills,
+      List<String> softSkills,
+      Integer applicationFitScore) {}
+
+  public record JobTypeInfo(String typeName, String description) {}
+
+  public record ExperienceDistribution(PieceType type, int count, int percentage) {}
+}

--- a/src/main/java/com/kusitms/kkium/home/repository/HomeRepository.java
+++ b/src/main/java/com/kusitms/kkium/home/repository/HomeRepository.java
@@ -1,0 +1,43 @@
+package com.kusitms.kkium.home.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.kusitms.kkium.experience.domain.Piece;
+import com.kusitms.kkium.experience.domain.type.PieceType;
+
+public interface HomeRepository extends JpaRepository<Piece, Long> {
+
+  // 전체 경험 수
+  @Query("SELECT COUNT(p) FROM Piece p WHERE p.user.id = :userId AND p.deleteAt IS NULL")
+  int countTotalExperience(@Param("userId") Long userId);
+
+  // 이번 달 경험 수 (Experience.createdDate 기준)
+  @Query(
+      "SELECT COUNT(e) FROM Experience e JOIN e.piece p "
+          + "WHERE p.user.id = :userId AND p.deleteAt IS NULL "
+          + "AND e.createdDate >= :start AND e.createdDate < :end")
+  int countThisMonthExperience(
+      @Param("userId") Long userId,
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end);
+
+  // 경험 분포 (type별 COUNT)
+  @Query(
+      "SELECT p.type, COUNT(p) FROM Piece p "
+          + "WHERE p.user.id = :userId AND p.deleteAt IS NULL "
+          + "AND p.type != :allType "
+          + "GROUP BY p.type")
+  List<Object[]> countByPieceType(
+      @Param("userId") Long userId, @Param("allType") PieceType allType);
+
+  // 목표 공고 조회
+  @Query(
+      "SELECT j FROM Jd j WHERE j.user.id = :userId AND j.isTarget = true AND j.deleteAt IS NULL")
+  Optional<com.kusitms.kkium.jd.domain.Jd> findTargetJd(@Param("userId") Long userId);
+}

--- a/src/main/java/com/kusitms/kkium/home/repository/HomeRepository.java
+++ b/src/main/java/com/kusitms/kkium/home/repository/HomeRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import com.kusitms.kkium.experience.domain.Piece;
 import com.kusitms.kkium.experience.domain.type.PieceType;
+import com.kusitms.kkium.jd.domain.Jd;
 
 public interface HomeRepository extends JpaRepository<Piece, Long> {
 
@@ -39,5 +40,5 @@ public interface HomeRepository extends JpaRepository<Piece, Long> {
   // 목표 공고 조회
   @Query(
       "SELECT j FROM Jd j WHERE j.user.id = :userId AND j.isTarget = true AND j.deleteAt IS NULL")
-  Optional<com.kusitms.kkium.jd.domain.Jd> findTargetJd(@Param("userId") Long userId);
+  Optional<Jd> findTargetJd(@Param("userId") Long userId);
 }

--- a/src/main/java/com/kusitms/kkium/home/service/HomeService.java
+++ b/src/main/java/com/kusitms/kkium/home/service/HomeService.java
@@ -55,8 +55,8 @@ public class HomeService {
     // 직무 유형
     JobTypeInfo jobTypeInfo =
         user.getJobType() != null
-            ? new JobTypeInfo(user.getJobType().getLabel(), user.getJobType().getDescription())
-            : new JobTypeInfo(null, null);
+            ? new JobTypeInfo(user.getJobType().getLabel())
+            : new JobTypeInfo(null);
 
     // 경험 분포
     List<Object[]> rawCounts = homeRepository.countByPieceType(userId, PieceType.ALL);

--- a/src/main/java/com/kusitms/kkium/home/service/HomeService.java
+++ b/src/main/java/com/kusitms/kkium/home/service/HomeService.java
@@ -1,0 +1,96 @@
+package com.kusitms.kkium.home.service;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kusitms.kkium.experience.domain.type.PieceType;
+import com.kusitms.kkium.home.dto.response.HomeResponse;
+import com.kusitms.kkium.home.dto.response.HomeResponse.ExperienceDistribution;
+import com.kusitms.kkium.home.dto.response.HomeResponse.JobTypeInfo;
+import com.kusitms.kkium.home.dto.response.HomeResponse.TargetJdInfo;
+import com.kusitms.kkium.home.repository.HomeRepository;
+import com.kusitms.kkium.jd.domain.Jd;
+import com.kusitms.kkium.user.domain.User;
+import com.kusitms.kkium.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HomeService {
+
+  private final HomeRepository homeRepository;
+  private final UserRepository userRepository;
+
+  public HomeResponse getHome(Long userId) {
+    User user = userRepository.findById(userId).orElseThrow();
+
+    // 목표 공고
+    TargetJdInfo targetJdInfo =
+        homeRepository
+            .findTargetJd(userId)
+            .map(this::buildTargetJdInfo)
+            .orElse(null);
+
+    // 전체 경험 수
+    int totalCount = homeRepository.countTotalExperience(userId);
+
+    // 이번 달 경험 수
+    LocalDateTime now = LocalDateTime.now();
+    LocalDateTime startOfMonth = now.withDayOfMonth(1).toLocalDate().atStartOfDay();
+    LocalDateTime startOfNextMonth = startOfMonth.plusMonths(1);
+    int thisMonthCount =
+        homeRepository.countThisMonthExperience(userId, startOfMonth, startOfNextMonth);
+
+    // 직무 유형
+    JobTypeInfo jobTypeInfo =
+        user.getJobType() != null
+            ? new JobTypeInfo(user.getJobType().getLabel(), user.getJobType().getDescription())
+            : new JobTypeInfo(null, null);
+
+    // 경험 분포
+    List<Object[]> rawCounts = homeRepository.countByPieceType(userId, PieceType.ALL);
+    Map<PieceType, Integer> countMap =
+        rawCounts.stream()
+            .collect(Collectors.toMap(r -> (PieceType) r[0], r -> ((Long) r[1]).intValue()));
+
+    List<ExperienceDistribution> distribution =
+        countMap.entrySet().stream()
+            .map(
+                entry -> {
+                  int percentage =
+                      totalCount > 0 ? Math.round(entry.getValue() * 100f / totalCount) : 0;
+                  return new ExperienceDistribution(entry.getKey(), entry.getValue(), percentage);
+                })
+            .collect(Collectors.toList());
+
+    return new HomeResponse(targetJdInfo, totalCount, thisMonthCount, jobTypeInfo, distribution);
+  }
+
+  private TargetJdInfo buildTargetJdInfo(Jd jd) {
+    return new TargetJdInfo(
+        jd.getCompanyName(),
+        jd.getRecruitmentField(),
+        jd.getStartDate(),
+        jd.getEndDate(),
+        parseSkillTags(jd.getHardSkill()),
+        parseSkillTags(jd.getSoftSkill()),
+        jd.getApplicationFitScore());
+  }
+
+  private List<String> parseSkillTags(String skillString) {
+    if (skillString == null || skillString.isBlank()) return Collections.emptyList();
+    return Arrays.stream(skillString.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isBlank())
+        .toList();
+  }
+}

--- a/src/main/java/com/kusitms/kkium/home/service/HomeService.java
+++ b/src/main/java/com/kusitms/kkium/home/service/HomeService.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kusitms.kkium.experience.domain.type.PieceType;
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
 import com.kusitms.kkium.home.dto.response.HomeResponse;
 import com.kusitms.kkium.home.dto.response.HomeResponse.ExperienceDistribution;
 import com.kusitms.kkium.home.dto.response.HomeResponse.JobTypeInfo;
@@ -31,7 +33,7 @@ public class HomeService {
   private final UserRepository userRepository;
 
   public HomeResponse getHome(Long userId) {
-    User user = userRepository.findById(userId).orElseThrow();
+    User user = userRepository.findById(userId).orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
 
     // 목표 공고
     TargetJdInfo targetJdInfo =

--- a/src/main/java/com/kusitms/kkium/home/service/JobTypeUpdateService.java
+++ b/src/main/java/com/kusitms/kkium/home/service/JobTypeUpdateService.java
@@ -1,0 +1,37 @@
+package com.kusitms.kkium.home.service;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kusitms.kkium.home.service.llm.JobTypeLlmService;
+import com.kusitms.kkium.user.domain.User;
+import com.kusitms.kkium.user.domain.type.JobType;
+import com.kusitms.kkium.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JobTypeUpdateService {
+
+  private final UserRepository userRepository;
+  private final JobTypeLlmService jobTypeLlmService;
+
+  @Async("jobTypeExecutor")
+  @Transactional
+  public void updateJobType(Long userId) {
+    try {
+      User user = userRepository.findById(userId).orElseThrow();
+      JobType jobType = jobTypeLlmService.analyzeJobType(userId);
+      user.updateJobType(jobType);
+      log.info("[직무유형] userId={} → {}", userId, jobType);
+    } catch (Exception e) {
+      log.error("[직무유형] 업데이트 실패 userId={}: {}", userId, e.getMessage());
+    }
+  }
+}

--- a/src/main/java/com/kusitms/kkium/home/service/JobTypeUpdateService.java
+++ b/src/main/java/com/kusitms/kkium/home/service/JobTypeUpdateService.java
@@ -6,6 +6,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
 import com.kusitms.kkium.home.service.llm.JobTypeLlmService;
 import com.kusitms.kkium.user.domain.User;
 import com.kusitms.kkium.user.domain.type.JobType;
@@ -26,7 +28,7 @@ public class JobTypeUpdateService {
   @Transactional
   public void updateJobType(Long userId) {
     try {
-      User user = userRepository.findById(userId).orElseThrow();
+      User user = userRepository.findById(userId).orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND));
       JobType jobType = jobTypeLlmService.analyzeJobType(userId);
       user.updateJobType(jobType);
       log.info("[직무유형] userId={} → {}", userId, jobType);

--- a/src/main/java/com/kusitms/kkium/home/service/llm/GeminiJobTypeLlmService.java
+++ b/src/main/java/com/kusitms/kkium/home/service/llm/GeminiJobTypeLlmService.java
@@ -138,7 +138,12 @@ public class GeminiJobTypeLlmService implements JobTypeLlmService {
 
       JsonNode parsed = objectMapper.readTree(jsonText);
       String jobTypeName = parsed.path("jobType").asText();
-      return JobType.valueOf(jobTypeName);
+      try {
+        return JobType.valueOf(jobTypeName);
+      } catch (IllegalArgumentException e) {
+        log.error("[직무유형] 알 수 없는 JobType 값: {}", jobTypeName);
+        throw new BaseException(ErrorCode.LLM_CALL_FAILED);
+      }
     } catch (Exception e) {
       log.error("[직무유형] 응답 파싱 실패: {}", e.getMessage());
       throw new BaseException(ErrorCode.LLM_CALL_FAILED);

--- a/src/main/java/com/kusitms/kkium/home/service/llm/GeminiJobTypeLlmService.java
+++ b/src/main/java/com/kusitms/kkium/home/service/llm/GeminiJobTypeLlmService.java
@@ -1,0 +1,151 @@
+package com.kusitms.kkium.home.service.llm;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kusitms.kkium.experience.domain.Experience;
+import com.kusitms.kkium.experience.repository.ExperienceRepository;
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
+import com.kusitms.kkium.user.domain.type.JobType;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GeminiJobTypeLlmService implements JobTypeLlmService {
+
+  private static final String GEMINI_API_URL =
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
+
+  private final WebClient webClient;
+  private final ObjectMapper objectMapper;
+  private final ExperienceRepository experienceRepository;
+
+  @Value("${gemini.api-key}")
+  private String apiKey;
+
+  @Override
+  public JobType analyzeJobType(Long userId) {
+    List<Experience> experiences = experienceRepository.findAllByUserIdNoPage(userId);
+
+    if (experiences.isEmpty()) {
+      return null;
+    }
+
+    String experienceText = buildExperienceText(experiences);
+    String prompt = buildPrompt(experienceText);
+    String rawJson = callGeminiApi(prompt);
+    return parseJobType(rawJson);
+  }
+
+  private String buildExperienceText(List<Experience> experiences) {
+    return experiences.stream()
+        .map(
+            e ->
+                """
+                [경험: %s]
+                상황: %s
+                과제: %s
+                행동: %s
+                결과: %s
+                배운점: %s
+                """
+                    .formatted(
+                        e.getTitle(),
+                        nullSafe(e.getSituation()),
+                        nullSafe(e.getTask()),
+                        nullSafe(e.getAct()),
+                        nullSafe(e.getResult()),
+                        nullSafe(e.getTaken())))
+        .collect(Collectors.joining("\n"));
+  }
+
+  private String buildPrompt(String experienceText) {
+    return """
+        아래는 사용자의 전체 경험 목록입니다.
+        경험들에서 반복적으로 나타나는 역량과 패턴을 분석하여, 아래 9가지 직무 유형 중 가장 잘 부합하는 하나를 선택해 주세요.
+        JSON 외 다른 텍스트는 절대 포함하지 마세요.
+
+        직무 유형:
+        - GOAL_DESIGNER: 목표 설계자 (전략적 실행·계획력)
+        - DRIVEN_EXECUTOR: 추진형 실행가 (추진력·빠른 결단)
+        - PRECISION_ANALYST: 정밀 분석가 (데이터 기반 사고·정확성)
+        - RELATIONSHIP_CONNECTOR: 관계 연결자 (공감·소통·팀 화합)
+        - STABLE_SUPPORTER: 안정적 지지자 (일관성·신뢰감·서포터)
+        - IDEA_EXPLORER: 아이디어 탐험가 (창의성·새로운 시각)
+        - PRINCIPLE_GUARDIAN: 원칙 수호자 (윤리·완벽주의·기준 준수)
+        - GROWTH_SEEKER: 성장 지향자 (학습·자기계발·피드백 수용)
+        - BALANCE_COORDINATOR: 균형 조율자 (중재·유연성·맥락 파악)
+
+        경험 목록:
+        %s
+
+        응답 형식:
+        {
+          "jobType": "GOAL_DESIGNER"
+        }
+        """
+        .formatted(experienceText);
+  }
+
+  private String callGeminiApi(String prompt) {
+    Map<String, Object> requestBody =
+        Map.of(
+            "contents", List.of(Map.of("parts", List.of(Map.of("text", prompt)))),
+            "generationConfig", Map.of("response_mime_type", "application/json"));
+
+    try {
+      return webClient
+          .post()
+          .uri(GEMINI_API_URL + "?key=" + apiKey)
+          .bodyValue(requestBody)
+          .retrieve()
+          .bodyToMono(String.class)
+          .block();
+    } catch (Exception e) {
+      log.error("[직무유형] Gemini API 호출 실패: {}", e.getMessage());
+      throw new BaseException(ErrorCode.LLM_CALL_FAILED);
+    }
+  }
+
+  private JobType parseJobType(String rawResponse) {
+    try {
+      JsonNode root = objectMapper.readTree(rawResponse);
+      String jsonText =
+          root.path("candidates")
+              .path(0)
+              .path("content")
+              .path("parts")
+              .path(0)
+              .path("text")
+              .asText();
+
+      int startIndex = jsonText.indexOf("{");
+      int endIndex = jsonText.lastIndexOf("}");
+      if (startIndex != -1 && endIndex != -1) {
+        jsonText = jsonText.substring(startIndex, endIndex + 1);
+      }
+
+      JsonNode parsed = objectMapper.readTree(jsonText);
+      String jobTypeName = parsed.path("jobType").asText();
+      return JobType.valueOf(jobTypeName);
+    } catch (Exception e) {
+      log.error("[직무유형] 응답 파싱 실패: {}", e.getMessage());
+      throw new BaseException(ErrorCode.LLM_CALL_FAILED);
+    }
+  }
+
+  private String nullSafe(String value) {
+    return value != null ? value : "";
+  }
+}

--- a/src/main/java/com/kusitms/kkium/home/service/llm/JobTypeLlmService.java
+++ b/src/main/java/com/kusitms/kkium/home/service/llm/JobTypeLlmService.java
@@ -1,0 +1,7 @@
+package com.kusitms.kkium.home.service.llm;
+
+import com.kusitms.kkium.user.domain.type.JobType;
+
+public interface JobTypeLlmService {
+  JobType analyzeJobType(Long userId);
+}

--- a/src/main/java/com/kusitms/kkium/jd/domain/Jd.java
+++ b/src/main/java/com/kusitms/kkium/jd/domain/Jd.java
@@ -57,19 +57,19 @@ public class Jd extends BaseEntity {
   @Column(name = "raw_text", columnDefinition = "TEXT")
   private String rawText;
 
-  @Column(name = "main_responsibilities")
+  @Column(name = "main_responsibilities", columnDefinition = "TEXT")
   private String mainResponsibilities;
 
-  @Column(name = "required_qualifications")
+  @Column(name = "required_qualifications", columnDefinition = "TEXT")
   private String requiredQualifications;
 
-  @Column(name = "preferred_qualifications")
+  @Column(name = "preferred_qualifications", columnDefinition = "TEXT")
   private String preferredQualifications;
 
-  @Column(name = "hard_skill")
+  @Column(name = "hard_skill", columnDefinition = "TEXT")
   private String hardSkill;
 
-  @Column(name = "soft_skill")
+  @Column(name = "soft_skill", columnDefinition = "TEXT")
   private String softSkill;
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/kusitms/kkium/user/domain/User.java
+++ b/src/main/java/com/kusitms/kkium/user/domain/User.java
@@ -3,6 +3,7 @@ package com.kusitms.kkium.user.domain;
 import jakarta.persistence.*;
 
 import com.kusitms.kkium.global.entity.BaseEntity;
+import com.kusitms.kkium.user.domain.type.JobType;
 import com.kusitms.kkium.user.domain.type.Role;
 
 import lombok.Builder;
@@ -38,8 +39,16 @@ public class User extends BaseEntity {
   @Column(name = "illustrate_id", nullable = true)
   private Integer illustrateId;
 
+  @Enumerated(EnumType.STRING)
+  @Column(name = "job_type", nullable = true)
+  private JobType jobType;
+
   public void updateIllustrateId(Integer illustrateId) {
     this.illustrateId = illustrateId;
+  }
+
+  public void updateJobType(JobType jobType) {
+    this.jobType = jobType;
   }
 
   @Builder(builderMethodName = "basicLoginBuilder", builderClassName = "buildBasicLogin")

--- a/src/main/java/com/kusitms/kkium/user/domain/type/JobType.java
+++ b/src/main/java/com/kusitms/kkium/user/domain/type/JobType.java
@@ -1,0 +1,29 @@
+package com.kusitms.kkium.user.domain.type;
+
+public enum JobType {
+  GOAL_DESIGNER("목표 설계자", "전략적 실행·계획력"),
+  DRIVEN_EXECUTOR("추진형 실행가", "추진력·빠른 결단"),
+  PRECISION_ANALYST("정밀 분석가", "데이터 기반 사고·정확성"),
+  RELATIONSHIP_CONNECTOR("관계 연결자", "공감·소통·팀 화합"),
+  STABLE_SUPPORTER("안정적 지지자", "일관성·신뢰감·서포터"),
+  IDEA_EXPLORER("아이디어 탐험가", "창의성·새로운 시각"),
+  PRINCIPLE_GUARDIAN("원칙 수호자", "윤리·완벽주의·기준 준수"),
+  GROWTH_SEEKER("성장 지향자", "학습·자기계발·피드백 수용"),
+  BALANCE_COORDINATOR("균형 조율자", "중재·유연성·맥락 파악");
+
+  private final String label;
+  private final String description;
+
+  JobType(String label, String description) {
+    this.label = label;
+    this.description = description;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+}


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #83 

## ✏️ 작업 내용

- `GET /api/v1/home` 홈 대시보드 조회 API 구현
- 목표 공고 정보 조회 (is_target = true인 JD 기업명, 모집분야, 기간, 기술/역량 태그, 적합도)
- 나의 전체 경험 수 / 이번 달 새로운 경험 수 조회
- 나의 경험 분포 조회 (PieceType별 COUNT 및 비율 계산)
- JobType Enum 추가 및 User 엔티티에 job_type 컬럼 추가
- 경험 저장/수정/삭제 후 afterCommit()에서 직무 유형 비동기 분석 트리거
- GeminiJobTypeLlmService 구현 (전체 경험 기반 직무 유형 분석)

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
