### PR TITLE
[REFACTOR] 태그 개수 제한 방식 개선

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/dto/response/ExperienceAnalyzeResponse.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/response/ExperienceAnalyzeResponse.java
@@ -32,9 +32,11 @@ public record ExperienceAnalyzeResponse(
     if (tags != null) {
       tags =
           Stream.concat(
-                  tags.stream().filter(t -> t.category() == TagCategory.TECH).limit(MAX_TAG_COUNT),
                   tags.stream()
-                      .filter(t -> t.category() == TagCategory.COMPETENCY)
+                      .filter(t -> t != null && t.category() == TagCategory.TECH)
+                      .limit(MAX_TAG_COUNT),
+                  tags.stream()
+                      .filter(t -> t != null && t.category() == TagCategory.COMPETENCY)
                       .limit(MAX_TAG_COUNT))
               .toList();
     }

--- a/src/main/java/com/kusitms/kkium/experience/dto/response/ExperienceAnalyzeResponse.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/response/ExperienceAnalyzeResponse.java
@@ -2,6 +2,7 @@ package com.kusitms.kkium.experience.dto.response;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Stream;
 
 import com.kusitms.kkium.experience.domain.type.TagCategory;
 
@@ -24,6 +25,20 @@ public record ExperienceAnalyzeResponse(
 
     // 태그
     List<TagResponse> tags) {
+
+  private static final int MAX_TAG_COUNT = 4;
+
+  public ExperienceAnalyzeResponse {
+    if (tags != null) {
+      tags =
+          Stream.concat(
+                  tags.stream().filter(t -> t.category() == TagCategory.TECH).limit(MAX_TAG_COUNT),
+                  tags.stream()
+                      .filter(t -> t.category() == TagCategory.COMPETENCY)
+                      .limit(MAX_TAG_COUNT))
+              .toList();
+    }
+  }
 
   // Activity 테이블
   public record ActivityInfo(

--- a/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
@@ -91,7 +91,7 @@ public class GeminiLlmService implements LlmService {
         - COMPETENCY: 경험에서 발휘한 역량, 소프트스킬 (한국어로 작성)
           - 올바른 예시: 문제 해결, 협업, 리더십, 커뮤니케이션, 자기주도, 창의성, 유연성
           - 잘못된 예시 (포함 금지): 알고리즘 개발, 알고리즘 설계, 시스템 설계, API 개발, 데이터 분석, 코드 구현, 성능 최적화, 백엔드 개발, 프론트엔드 개발
-        - TECH, COMPETENCY 각각 최대 4개
+        - TECH, COMPETENCY 각각 최대 10개
         - 중복 태그 포함 금지
         - 기술명은 구체적으로 작성 (예: "백엔드" 대신 "SpringBoot", "Java")
         - 버전 정보 제외 (예: "Java 21" 대신 "Java")

--- a/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
@@ -91,7 +91,7 @@ public class GeminiLlmService implements LlmService {
         - COMPETENCY: 경험에서 발휘한 역량, 소프트스킬 (한국어로 작성)
           - 올바른 예시: 문제 해결, 협업, 리더십, 커뮤니케이션, 자기주도, 창의성, 유연성
           - 잘못된 예시 (포함 금지): 알고리즘 개발, 알고리즘 설계, 시스템 설계, API 개발, 데이터 분석, 코드 구현, 성능 최적화, 백엔드 개발, 프론트엔드 개발
-        - TECH, COMPETENCY 각각 최대 10개
+        - TECH, COMPETENCY 각각 최대 4개
         - 중복 태그 포함 금지
         - 기술명은 구체적으로 작성 (예: "백엔드" 대신 "SpringBoot", "Java")
         - 버전 정보 제외 (예: "Java 21" 대신 "Java")


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #97

## ✏️ 작업 내용

- ExperienceAnalyzeResponse compact constructor 추가
- TECH / COMPETENCY 각각 최대 4개로 제한
- LLM이 프롬프트를 무시하고 초과 태그를 반환해도 DTO에서 변경

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
