### PR TITLE
[REFACTOR] 공고-경험에서 경험 카드 단 건 상세 분석 결과 Redis 캐싱 적용

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/kusitms/kkium/experience/repository/ExperienceRepository.java
@@ -26,6 +26,14 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long> {
           + "ORDER BY eo.sortOrder ASC")
   List<Experience> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
 
+  // 공고분석용 전체 조회 (페이지네이션 없음, experience_order 조인 없음)
+  @Query(
+      "SELECT e FROM Experience e JOIN FETCH e.piece p "
+          + "WHERE p.user.id = :userId "
+          + "AND p.deleteAt IS NULL "
+          + "ORDER BY e.id ASC")
+  List<Experience> findAllByUserIdForAnalysis(@Param("userId") Long userId);
+
   // 공고분석용 전체 조회 (페이지네이션 없음)
   @Query(
       "SELECT e FROM Experience e JOIN FETCH e.piece p "

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -37,6 +37,7 @@ import com.kusitms.kkium.experience.dto.response.detail.EtcDetail;
 import com.kusitms.kkium.experience.repository.*;
 import com.kusitms.kkium.global.exception.BaseException;
 import com.kusitms.kkium.home.service.JobTypeUpdateService;
+import com.kusitms.kkium.jd.service.JdExperienceAnalysisService;
 import com.kusitms.kkium.user.domain.User;
 import com.kusitms.kkium.user.repository.UserRepository;
 
@@ -59,6 +60,7 @@ public class ExperienceService {
   private final TagRepository tagRepository;
   private final ExperienceEmbeddingService experienceEmbeddingService;
   private final JobTypeUpdateService jobTypeUpdateService;
+  private final JdExperienceAnalysisService jdExperienceAnalysisService;
 
   @Transactional(readOnly = true)
   public ExperienceDetailResponse getDetail(Long userId, Long experienceId) {
@@ -419,6 +421,10 @@ public class ExperienceService {
 
     experience.getPiece().delete();
     experienceOrderRepository.deleteAllByExperienceId(experienceId);
+
+    // 캐시 무효화
+    jdExperienceAnalysisService.evictCache(experienceId);
+
     TransactionSynchronizationManager.registerSynchronization(
         new TransactionSynchronization() {
           @Override
@@ -521,6 +527,9 @@ public class ExperienceService {
               .findByExperienceId(experienceId)
               .ifPresent(e -> e.update(detail.startDate(), detail.endDate()));
     }
+
+    // 캐시 무효화
+    jdExperienceAnalysisService.evictCache(experienceId);
 
     Long pieceId = experience.getPiece().getId();
     TransactionSynchronizationManager.registerSynchronization(

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -569,6 +569,9 @@ public class ExperienceService {
 
     experience.updateTitle(title);
 
+    // 캐시 무효화
+    jdExperienceAnalysisService.evictCache(experienceId);
+
     Long pieceId = experience.getPiece().getId();
     PieceType type = experience.getPiece().getType();
     List<TagCreateRequest> tags =

--- a/src/main/java/com/kusitms/kkium/jd/repository/JdMatchRepository.java
+++ b/src/main/java/com/kusitms/kkium/jd/repository/JdMatchRepository.java
@@ -16,14 +16,14 @@ public class JdMatchRepository {
   private final JdbcTemplate jdbcTemplate;
 
   /**
-   * JD 임베딩 vs 유저의 전체 Piece 임베딩 코사인 유사도 계산 pgvector의 <=> 연산자는 코사인 거리(0~2)를 반환하므로 1 - distance =
-   * 유사도(-1~1) 이를 0~100으로 정규화: (유사도 + 1) / 2 * 100
+   * JD 임베딩 vs 유저의 전체 Piece 임베딩 코사인 유사도 계산 pgvector의 <=> 연산자는 코사인 거리(0~1)를 반환하므로 유사도 = 1 - distance
+   * (0~1 범위) 이를 0~100으로 정규화: (1 - distance) * 100
    */
   public List<PieceSimilarity> findSimilaritiesByJdAndUser(Long jdId, Long userId) {
     String sql =
         """
         SELECT p.id AS piece_id,
-               CAST(((1 - (p.embedding <=> j.embedding) + 1) / 2.0 * 100) AS INTEGER) AS similarity_score
+               CAST(((1 - (p.embedding <=> j.embedding)) * 100) AS INTEGER) AS similarity_score
         FROM pieces p, jds j
         WHERE j.id = ?
           AND p.user_id = ?

--- a/src/main/java/com/kusitms/kkium/jd/service/JdExperienceAnalysisService.java
+++ b/src/main/java/com/kusitms/kkium/jd/service/JdExperienceAnalysisService.java
@@ -4,9 +4,13 @@ import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.FORBIDDEN;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.JD_NOT_FOUND;
 
+import java.util.Set;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kusitms.kkium.experience.domain.Experience;
 import com.kusitms.kkium.experience.repository.ExperienceRepository;
 import com.kusitms.kkium.global.exception.BaseException;
@@ -26,9 +30,12 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 public class JdExperienceAnalysisService {
 
+  private static final String CACHE_KEY_PREFIX = "jd-analysis:";
   private final JdRepository jdRepository;
   private final ExperienceRepository experienceRepository;
   private final LlmMatchScoreService llmMatchScoreService;
+  private final StringRedisTemplate redisTemplate;
+  private final ObjectMapper objectMapper;
 
   public JdExperienceAnalysisResponse analyze(Long jdId, Long experienceId, Long userId) {
     // 1. JD 조회
@@ -50,17 +57,67 @@ public class JdExperienceAnalysisService {
       throw new BaseException(FORBIDDEN);
     }
 
-    // 4. LLM 호출 - 좋은 점 / 부족한 점 / 활용 가이드 / 하이라이팅 키워드
+    // 5. Redis 캐시 조회
+    String cacheKey = CACHE_KEY_PREFIX + experienceId + ":" + jdId;
+    try {
+      String cached = redisTemplate.opsForValue().get(cacheKey);
+      if (cached != null) {
+        log.info("[경험 상세 분석] 캐시 히트 - experienceId={}, jdId={}", experienceId, jdId);
+        return objectMapper.readValue(cached, JdExperienceAnalysisResponse.class);
+      }
+    } catch (Exception e) {
+      log.warn("[경험 상세 분석] 캐시 조회 실패, LLM 호출로 fallback: {}", e.getMessage());
+    }
+
+    // 6. LLM 호출 - 좋은 점 / 부족한 점 / 활용 가이드 / 하이라이팅 키워드
     LlmExperienceDetailResult result = llmMatchScoreService.analyzeExperienceDetail(jd, experience);
-
-    log.info("[경험 상세 분석] experienceId={} | keywords={}", experienceId, result.highlightKeywords());
-
-    return new JdExperienceAnalysisResponse(
+    log.info(
+        "[경험 상세 분석] LLM 호출 - experienceId={} | keywords={}",
         experienceId,
-        new ExperienceAnalysis(
-            result.strengths(),
-            result.weaknesses(),
-            result.usageGuide(),
-            result.highlightKeywords()));
+        result.highlightKeywords());
+
+    JdExperienceAnalysisResponse response =
+        new JdExperienceAnalysisResponse(
+            experienceId,
+            new ExperienceAnalysis(
+                result.strengths(),
+                result.weaknesses(),
+                result.usageGuide(),
+                result.highlightKeywords()));
+
+    // 7. Redis 캐시 저장 (TTL 없음 - 경험/JD 수정, 삭제 시 명시적으로 무효화)
+    try {
+      redisTemplate.opsForValue().set(cacheKey, objectMapper.writeValueAsString(response));
+    } catch (Exception e) {
+      log.warn("[경험 상세 분석] 캐시 저장 실패: {}", e.getMessage());
+    }
+
+    return response;
+  }
+
+  // 경험 수정/삭제 시 캐시 무효화 - jd-analysis:{experienceId}:*
+  public void evictCache(Long experienceId) {
+    try {
+      Set<String> keys = redisTemplate.keys(CACHE_KEY_PREFIX + experienceId + ":*");
+      if (keys != null && !keys.isEmpty()) {
+        redisTemplate.delete(keys);
+        log.info("[경험 상세 분석] 캐시 무효화 - experienceId={}, 삭제된 키 수={}", experienceId, keys.size());
+      }
+    } catch (Exception e) {
+      log.warn("[경험 상세 분석] 캐시 무효화 실패: {}", e.getMessage());
+    }
+  }
+
+  // JD 삭제 시 캐시 무효화 - jd-analysis:*:{jdId}
+  public void evictCacheByJdId(Long jdId) {
+    try {
+      Set<String> keys = redisTemplate.keys(CACHE_KEY_PREFIX + "*:" + jdId);
+      if (keys != null && !keys.isEmpty()) {
+        redisTemplate.delete(keys);
+        log.info("[경험 상세 분석] JD 캐시 무효화 - jdId={}, 삭제된 키 수={}", jdId, keys.size());
+      }
+    } catch (Exception e) {
+      log.warn("[경험 상세 분석] JD 캐시 무효화 실패: {}", e.getMessage());
+    }
   }
 }

--- a/src/main/java/com/kusitms/kkium/jd/service/JdExperienceAnalysisService.java
+++ b/src/main/java/com/kusitms/kkium/jd/service/JdExperienceAnalysisService.java
@@ -4,8 +4,12 @@ import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.FORBIDDEN;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.JD_NOT_FOUND;
 
-import java.util.Set;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 public class JdExperienceAnalysisService {
 
   private static final String CACHE_KEY_PREFIX = "jd-analysis:";
+  private static final Duration CACHE_TTL = Duration.ofDays(7);
   private final JdRepository jdRepository;
   private final ExperienceRepository experienceRepository;
   private final LlmMatchScoreService llmMatchScoreService;
@@ -85,9 +90,11 @@ public class JdExperienceAnalysisService {
                 result.usageGuide(),
                 result.highlightKeywords()));
 
-    // 7. Redis 캐시 저장 (TTL 없음 - 경험/JD 수정, 삭제 시 명시적으로 무효화)
+    // 7. Redis 캐시 저장 (TTL 7일 - 경험/JD 수정, 삭제 시 명시적으로 무효화)
     try {
-      redisTemplate.opsForValue().set(cacheKey, objectMapper.writeValueAsString(response));
+      redisTemplate
+          .opsForValue()
+          .set(cacheKey, objectMapper.writeValueAsString(response), CACHE_TTL);
     } catch (Exception e) {
       log.warn("[경험 상세 분석] 캐시 저장 실패: {}", e.getMessage());
     }
@@ -97,27 +104,28 @@ public class JdExperienceAnalysisService {
 
   // 경험 수정/삭제 시 캐시 무효화 - jd-analysis:{experienceId}:*
   public void evictCache(Long experienceId) {
-    try {
-      Set<String> keys = redisTemplate.keys(CACHE_KEY_PREFIX + experienceId + ":*");
-      if (keys != null && !keys.isEmpty()) {
-        redisTemplate.delete(keys);
-        log.info("[경험 상세 분석] 캐시 무효화 - experienceId={}, 삭제된 키 수={}", experienceId, keys.size());
-      }
-    } catch (Exception e) {
-      log.warn("[경험 상세 분석] 캐시 무효화 실패: {}", e.getMessage());
-    }
+    scanAndDelete(
+        CACHE_KEY_PREFIX + experienceId + ":*", "[경험 상세 분석] 캐시 무효화 - experienceId=" + experienceId);
   }
 
   // JD 삭제 시 캐시 무효화 - jd-analysis:*:{jdId}
   public void evictCacheByJdId(Long jdId) {
+    scanAndDelete(CACHE_KEY_PREFIX + "*:" + jdId, "[경험 상세 분석] JD 캐시 무효화 - jdId=" + jdId);
+  }
+
+  private void scanAndDelete(String pattern, String logPrefix) {
     try {
-      Set<String> keys = redisTemplate.keys(CACHE_KEY_PREFIX + "*:" + jdId);
-      if (keys != null && !keys.isEmpty()) {
+      ScanOptions options = ScanOptions.scanOptions().match(pattern).count(100).build();
+      List<String> keys = new ArrayList<>();
+      try (Cursor<String> cursor = redisTemplate.scan(options)) {
+        cursor.forEachRemaining(keys::add);
+      }
+      if (!keys.isEmpty()) {
         redisTemplate.delete(keys);
-        log.info("[경험 상세 분석] JD 캐시 무효화 - jdId={}, 삭제된 키 수={}", jdId, keys.size());
+        log.info("{}, 삭제된 키 수={}", logPrefix, keys.size());
       }
     } catch (Exception e) {
-      log.warn("[경험 상세 분석] JD 캐시 무효화 실패: {}", e.getMessage());
+      log.warn("{} 캐시 무효화 실패: {}", logPrefix, e.getMessage());
     }
   }
 }

--- a/src/main/java/com/kusitms/kkium/jd/service/JdMatchService.java
+++ b/src/main/java/com/kusitms/kkium/jd/service/JdMatchService.java
@@ -60,8 +60,8 @@ public class JdMatchService {
     // 1. JD Info 구성
     JdInfo jdInfo = buildJdInfo(jd);
 
-    // 2. 유저의 전체 경험 조회
-    List<Experience> allExperiences = experienceRepository.findAllByUserIdNoPage(userId);
+    // 2. 유저의 전체 경험 조회 (experience_order 조인 없이 모든 경험 가져옴)
+    List<Experience> allExperiences = experienceRepository.findAllByUserIdForAnalysis(userId);
 
     if (allExperiences.isEmpty()) {
       return new JdMatchAnalysisResponse(

--- a/src/main/java/com/kusitms/kkium/jd/service/JdService.java
+++ b/src/main/java/com/kusitms/kkium/jd/service/JdService.java
@@ -46,6 +46,7 @@ public class JdService {
   private final JdQuestionRepository jdQuestionRepository;
   private final JdAnswerRepository jdAnswerRepository;
   private final UserRepository userRepository;
+  private final JdExperienceAnalysisService jdExperienceAnalysisService;
 
   public JdListPageResponse getJdList(
       CustomUserDetails userDetails, int page, int size, String keyword) {
@@ -229,6 +230,9 @@ public class JdService {
     }
 
     jd.delete();
+
+    // 해당 JD와 연관된 캐시 무효화
+    jdExperienceAnalysisService.evictCacheByJdId(jdId);
   }
 
   @Transactional


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #103 

## ✏️ 작업 내용

- JdExperienceAnalysisService에 Redis 캐싱 로직 추가
  - (캐시 키: jd-analysis:{experienceId}:{jdId})
  - 첫 요청 시 LLM 호출 후 Redis에 저장, 이후 동일 요청은 캐시에서 즉시 반환
- 경험 수정/삭제 시 evictCache(experienceId) 캐시 무효
- JD 삭제 시 evictCacheByJdId(jdId)로 연관 캐시 무효화
- -> key 방식에서 scan 방식으로 개선
- 코사인 유사도 정규화 공식 수정

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
