### PR TITLE
[REFACTOR] Notion OAuth 리다이렉트 URL 동적 처리

### DIFF
--- a/src/main/java/com/kusitms/kkium/notion/controller/NotionController.java
+++ b/src/main/java/com/kusitms/kkium/notion/controller/NotionController.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 import com.kusitms.kkium.experience.service.analyze.NotionAnalyzeService;
 import com.kusitms.kkium.global.response.ApiResponse;
@@ -27,8 +28,9 @@ public class NotionController {
   @Operation(summary = "Notion OAuth 인증 URL 반환", description = "Notion 연결을 위한 OAuth 인증 URL을 반환합니다.")
   @GetMapping("/api/v1/experiences/notion/auth")
   public ResponseEntity<ApiResponse<String>> getAuthorizationUrl(
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    String authUrl = notionService.getAuthorizationUrl(userDetails.getId());
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @RequestHeader(value = "Origin", defaultValue = "https://kkium.com") String origin) {
+    String authUrl = notionService.getAuthorizationUrl(userDetails.getId(), origin);
     return ResponseEntity.ok(ApiResponse.success(authUrl));
   }
 

--- a/src/main/java/com/kusitms/kkium/notion/service/NotionService.java
+++ b/src/main/java/com/kusitms/kkium/notion/service/NotionService.java
@@ -78,12 +78,16 @@ public class NotionService {
   }
 
   private void validateState(String state) {
-    String stateValue = state.split(":")[1];
-    String savedValue = redisTemplate.opsForValue().get(STATE_PREFIX + stateValue);
-    if (savedValue == null) {
+    try {
+      String stateValue = state.split(":")[1];
+      String savedValue = redisTemplate.opsForValue().get(STATE_PREFIX + stateValue);
+      if (savedValue == null) {
+        throw new BaseException(NOTION_INVALID_STATE);
+      }
+      redisTemplate.delete(STATE_PREFIX + stateValue);
+    } catch (Exception e) {
       throw new BaseException(NOTION_INVALID_STATE);
     }
-    redisTemplate.delete(STATE_PREFIX + stateValue);
   }
 
   private Long parseUserIdFromState(String state) {

--- a/src/main/java/com/kusitms/kkium/notion/service/NotionService.java
+++ b/src/main/java/com/kusitms/kkium/notion/service/NotionService.java
@@ -32,19 +32,12 @@ public class NotionService {
   private static final String STATE_PREFIX = "notion:state:";
   private static final long STATE_TTL_MINUTES = 10;
 
-  @Value("${notion.allowed-origins[0]}")
-  private String allowedOrigin0;
-
-  @Value("${notion.allowed-origins[1]}")
-  private String allowedOrigin1;
-
-  private List<String> getAllowedOrigins() {
-    return List.of(allowedOrigin0, allowedOrigin1);
-  }
+  @Value("${notion.allowed-origins}")
+  private List<String> allowedOrigins;
 
   // OAuth 인증 URL 반환 (state Redis 저장 후 CSRF 검증용)
   public String getAuthorizationUrl(Long userId, String origin) {
-    if (!getAllowedOrigins().contains(origin)) {
+    if (!allowedOrigins.contains(origin)) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "허용되지 않은 origin: " + origin);
     }
     String stateValue = UUID.randomUUID().toString();

--- a/src/main/java/com/kusitms/kkium/notion/service/NotionService.java
+++ b/src/main/java/com/kusitms/kkium/notion/service/NotionService.java
@@ -2,13 +2,16 @@ package com.kusitms.kkium.notion.service;
 
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.NOTION_INVALID_STATE;
 
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.kusitms.kkium.global.exception.BaseException;
 import com.kusitms.kkium.notion.domain.NotionConnection;
@@ -29,17 +32,26 @@ public class NotionService {
   private static final String STATE_PREFIX = "notion:state:";
   private static final long STATE_TTL_MINUTES = 10;
 
-  @Value("${notion.frontend-redirect-uri}")
-  private String frontendRedirectUri;
+  @Value("${notion.allowed-origins[0]}")
+  private String allowedOrigin0;
+
+  @Value("${notion.allowed-origins[1]}")
+  private String allowedOrigin1;
+
+  private List<String> getAllowedOrigins() {
+    return List.of(allowedOrigin0, allowedOrigin1);
+  }
 
   // OAuth 인증 URL 반환 (state Redis 저장 후 CSRF 검증용)
-  public String getAuthorizationUrl(Long userId) {
+  public String getAuthorizationUrl(Long userId, String origin) {
+    if (!getAllowedOrigins().contains(origin)) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "허용되지 않은 origin: " + origin);
+    }
     String stateValue = UUID.randomUUID().toString();
-    String state = userId + ":" + stateValue;
+    String state = userId + ":" + stateValue + ":" + origin;
     redisTemplate
         .opsForValue()
-        .set(
-            STATE_PREFIX + stateValue, String.valueOf(userId), STATE_TTL_MINUTES, TimeUnit.MINUTES);
+        .set(STATE_PREFIX + stateValue, userId + ":" + origin, STATE_TTL_MINUTES, TimeUnit.MINUTES);
     return notionApiClient.getAuthorizationUrl(state);
   }
 
@@ -48,6 +60,7 @@ public class NotionService {
   public String handleCallback(String code, String state) {
     validateState(state);
     Long userId = parseUserIdFromState(state);
+    String origin = parseOriginFromState(state);
 
     NotionTokenResponse tokenResponse = notionApiClient.getAccessToken(code);
 
@@ -68,13 +81,13 @@ public class NotionService {
                         .workspaceName(tokenResponse.workspaceName())
                         .build()));
 
-    return frontendRedirectUri + "?success=true";
+    return origin + "/experience/add?success=true";
   }
 
   private void validateState(String state) {
     String stateValue = state.split(":")[1];
-    String savedUserId = redisTemplate.opsForValue().get(STATE_PREFIX + stateValue);
-    if (savedUserId == null) {
+    String savedValue = redisTemplate.opsForValue().get(STATE_PREFIX + stateValue);
+    if (savedValue == null) {
       throw new BaseException(NOTION_INVALID_STATE);
     }
     redisTemplate.delete(STATE_PREFIX + stateValue);
@@ -83,6 +96,16 @@ public class NotionService {
   private Long parseUserIdFromState(String state) {
     try {
       return Long.parseLong(state.split(":")[0]);
+    } catch (Exception e) {
+      throw new BaseException(NOTION_INVALID_STATE);
+    }
+  }
+
+  private String parseOriginFromState(String state) {
+    try {
+      // state = "userId:stateValue:https://kkium.com" 또는 "userId:stateValue:http://localhost:3000"
+      String[] parts = state.split(":", 3);
+      return parts[2];
     } catch (Exception e) {
       throw new BaseException(NOTION_INVALID_STATE);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,8 +40,10 @@ notion:
   client-id: ${NOTION_CLIENT_ID}
   client-secret: ${NOTION_CLIENT_SECRET}
   redirect-uri: ${NOTION_REDIRECT_URI}
-  frontend-redirect-uri: ${NOTION_FRONTEND_REDIRECT_URI}
   aes-secret-key: ${AES_SECRET_KEY}
+  allowed-origins:
+    - https://kkium.com
+    - http://localhost:3000
 
 openai:
   api:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,9 +41,7 @@ notion:
   client-secret: ${NOTION_CLIENT_SECRET}
   redirect-uri: ${NOTION_REDIRECT_URI}
   aes-secret-key: ${AES_SECRET_KEY}
-  allowed-origins:
-    - https://kkium.com
-    - http://localhost:3000
+  allowed-origins: https://kkium.com,http://localhost:3000
 
 openai:
   api:


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #108 

## ✏️ 작업 내용

- `application.yml` notion.frontend-redirect-uri 제거 및 allowed-origins 리스트 추가
- `NotionService` 고정 리다이렉트 URI 대신 요청 Origin 기반 동적 리다이렉트 처리로 변경
- `NotionService` allowed-origins 화이트리스트 검증 로직 추가 (open redirect 방지)
- `NotionController` Origin 헤더 파라미터 추가
- `secret.yaml` NOTION_FRONTEND_REDIRECT_URI 제거

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
