### PR TITLE
[FIX] notion 리다이렉트 허용 origin에 www.kkium.com 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,7 +41,7 @@ notion:
   client-secret: ${NOTION_CLIENT_SECRET}
   redirect-uri: ${NOTION_REDIRECT_URI}
   aes-secret-key: ${AES_SECRET_KEY}
-  allowed-origins: https://kkium.com,http://localhost:3000
+  allowed-origins: https://kkium.com,https://www.kkium.com,http://localhost:3000
 
 openai:
   api:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,7 +41,7 @@ notion:
   client-secret: ${NOTION_CLIENT_SECRET}
   redirect-uri: ${NOTION_REDIRECT_URI}
   aes-secret-key: ${AES_SECRET_KEY}
-  allowed-origins: https://kkium.com,https://www.kkium.com,http://localhost:3000
+  allowed-origins: ${NOTION_ALLOWED_ORIGINS:https://kkium.com,https://www.kkium.com,http://localhost:3000}
 
 openai:
   api:


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #112 

## ✏️ 작업 내용

- application.yml의 notion.allowed-origins에 https://www.kkium.com 추가
- 기존에 https://kkium.com만 허용되어 있어 www 도메인으로 요청 시 400 Bad Request 발생하던 문제 수정

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
