### PR TITLE
[FIX] 경험 수정 API 필드별 글자 수 제한 추가

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceCreateRequest.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceCreateRequest.java
@@ -14,7 +14,7 @@ import com.kusitms.kkium.experience.domain.type.PieceType;
 public record ExperienceCreateRequest(
     @NotNull PieceType type,
     @NotBlank @Size(max = 80, message = "제목은 80자 이하여야 합니다.") String title,
-    @NotBlank @Size(max = 200, message = "한 줄 설명은 200자 이하여야 합니다.") String oneLineIntro,
+    @NotBlank @Size(max = 100, message = "한 줄 설명은 100자 이하여야 합니다.") String oneLineIntro,
     @NotNull LocalDate startDate,
     @NotNull LocalDate endDate,
     @NotBlank String situation,

--- a/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceTitleUpdateRequest.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceTitleUpdateRequest.java
@@ -1,5 +1,8 @@
 package com.kusitms.kkium.experience.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
-public record ExperienceTitleUpdateRequest(@NotBlank(message = "제목을 입력해주세요.") String title) {}
+public record ExperienceTitleUpdateRequest(
+    @NotBlank(message = "제목을 입력해주세요.") @Size(max = 80, message = "제목은 80자 이하여야 합니다.")
+        String title) {}

--- a/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceUpdateRequest.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceUpdateRequest.java
@@ -5,16 +5,17 @@ import java.util.List;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record ExperienceUpdateRequest(
-    @NotBlank String title,
-    @NotBlank String oneLineIntro,
+    @NotBlank @Size(max = 80, message = "제목은 80자 이하여야 합니다.") String title,
+    @NotBlank @Size(max = 100, message = "한 줄 소개는 100자 이하여야 합니다.") String oneLineIntro,
     @NotNull List<TagCreateRequest> tags,
-    String situation,
-    String task,
-    String act,
-    String result,
-    String taken,
+    @Size(max = 1000, message = "Situation은 1000자 이하여야 합니다.") String situation,
+    @Size(max = 1000, message = "Task는 1000자 이하여야 합니다.") String task,
+    @Size(max = 1000, message = "Action은 1000자 이하여야 합니다.") String act,
+    @Size(max = 1000, message = "Result는 1000자 이하여야 합니다.") String result,
+    @Size(max = 1000, message = "Taken은 1000자 이하여야 합니다.") String taken,
     @NotNull Detail detail) {
 
   public record Detail(

--- a/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceUpdateRequest.java
+++ b/src/main/java/com/kusitms/kkium/experience/dto/request/ExperienceUpdateRequest.java
@@ -3,6 +3,7 @@ package com.kusitms.kkium.experience.dto.request;
 import java.time.LocalDate;
 import java.util.List;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -10,13 +11,13 @@ import jakarta.validation.constraints.Size;
 public record ExperienceUpdateRequest(
     @NotBlank @Size(max = 80, message = "제목은 80자 이하여야 합니다.") String title,
     @NotBlank @Size(max = 100, message = "한 줄 소개는 100자 이하여야 합니다.") String oneLineIntro,
-    @NotNull List<TagCreateRequest> tags,
+    @NotNull @Valid List<TagCreateRequest> tags,
     @Size(max = 1000, message = "Situation은 1000자 이하여야 합니다.") String situation,
     @Size(max = 1000, message = "Task는 1000자 이하여야 합니다.") String task,
     @Size(max = 1000, message = "Action은 1000자 이하여야 합니다.") String act,
     @Size(max = 1000, message = "Result는 1000자 이하여야 합니다.") String result,
     @Size(max = 1000, message = "Taken은 1000자 이하여야 합니다.") String taken,
-    @NotNull Detail detail) {
+    @NotNull @Valid Detail detail) {
 
   public record Detail(
       // ACTIVITY, EDUCATION 공통

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -1,7 +1,11 @@
 package com.kusitms.kkium.experience.service;
 
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_COMPANY_TOO_LONG;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_EDUCATION_NAME_TOO_LONG;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_NOT_FOUND;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_ORDER_NOT_FOUND;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_ORGANIZATION_NAME_TOO_LONG;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_ROLE_TOO_LONG;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.FORBIDDEN;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.INVALID_INPUT_VALUE;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.USER_NOT_FOUND;
@@ -481,6 +485,7 @@ public class ExperienceService {
             || detail.contributionRate() == null) {
           throw new BaseException(INVALID_INPUT_VALUE);
         }
+        if (detail.role().length() > 50) throw new BaseException(EXPERIENCE_ROLE_TOO_LONG);
         activityRepository
             .findByExperienceId(experienceId)
             .ifPresent(
@@ -497,6 +502,7 @@ public class ExperienceService {
         if (detail.company() == null || detail.employmentStatus() == null) {
           throw new BaseException(INVALID_INPUT_VALUE);
         }
+        if (detail.company().length() > 50) throw new BaseException(EXPERIENCE_COMPANY_TOO_LONG);
         careerRepository
             .findByExperienceId(experienceId)
             .ifPresent(
@@ -512,6 +518,10 @@ public class ExperienceService {
         if (detail.organizationName() == null || detail.name() == null) {
           throw new BaseException(INVALID_INPUT_VALUE);
         }
+        if (detail.organizationName().length() > 50)
+          throw new BaseException(EXPERIENCE_ORGANIZATION_NAME_TOO_LONG);
+        if (detail.name().length() > 80)
+          throw new BaseException(EXPERIENCE_EDUCATION_NAME_TOO_LONG);
         educationRepository
             .findByExperienceId(experienceId)
             .ifPresent(

--- a/src/main/java/com/kusitms/kkium/global/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/kusitms/kkium/global/exception/errorcode/ErrorCode.java
@@ -46,12 +46,10 @@ public enum ErrorCode {
 
   // experience
   EXPERIENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "E005", "존재하지 않는 경험입니다."),
-  EXPERIENCE_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "E007", "제목은 80자 이하여야 합니다."),
-  EXPERIENCE_ONE_LINE_INTRO_TOO_LONG(HttpStatus.BAD_REQUEST, "E008", "한 줄 소개는 100자 이하여야 합니다."),
-  EXPERIENCE_ROLE_TOO_LONG(HttpStatus.BAD_REQUEST, "E009", "역할은 50자 이하여야 합니다."),
-  EXPERIENCE_COMPANY_TOO_LONG(HttpStatus.BAD_REQUEST, "E010", "회사/기관/단체명은 50자 이하여야 합니다."),
-  EXPERIENCE_ORGANIZATION_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "E011", "교육기관명은 50자 이하여야 합니다."),
-  EXPERIENCE_EDUCATION_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "E012", "수강명은 80자 이하여야 합니다."),
+  EXPERIENCE_ROLE_TOO_LONG(HttpStatus.BAD_REQUEST, "E007", "역할은 50자 이하여야 합니다."),
+  EXPERIENCE_COMPANY_TOO_LONG(HttpStatus.BAD_REQUEST, "E008", "회사/기관/단체명은 50자 이하여야 합니다."),
+  EXPERIENCE_ORGANIZATION_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "E009", "교육기관명은 50자 이하여야 합니다."),
+  EXPERIENCE_EDUCATION_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "E010", "수강명은 80자 이하여야 합니다."),
   EXPERIENCE_ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "E006", "경험 순서 정보가 존재하지 않습니다."),
   INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "E001", "PDF 파일만 업로드 가능합니다."),
   FILE_ALREADY_UPLOADED(HttpStatus.CONFLICT, "E002", "이미 업로드된 자료가 있습니다. 다시 업로드하면 초기화됩니다."),

--- a/src/main/java/com/kusitms/kkium/global/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/kusitms/kkium/global/exception/errorcode/ErrorCode.java
@@ -46,6 +46,12 @@ public enum ErrorCode {
 
   // experience
   EXPERIENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "E005", "존재하지 않는 경험입니다."),
+  EXPERIENCE_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "E007", "제목은 80자 이하여야 합니다."),
+  EXPERIENCE_ONE_LINE_INTRO_TOO_LONG(HttpStatus.BAD_REQUEST, "E008", "한 줄 소개는 100자 이하여야 합니다."),
+  EXPERIENCE_ROLE_TOO_LONG(HttpStatus.BAD_REQUEST, "E009", "역할은 50자 이하여야 합니다."),
+  EXPERIENCE_COMPANY_TOO_LONG(HttpStatus.BAD_REQUEST, "E010", "회사/기관/단체명은 50자 이하여야 합니다."),
+  EXPERIENCE_ORGANIZATION_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "E011", "교육기관명은 50자 이하여야 합니다."),
+  EXPERIENCE_EDUCATION_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "E012", "수강명은 80자 이하여야 합니다."),
   EXPERIENCE_ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "E006", "경험 순서 정보가 존재하지 않습니다."),
   INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "E001", "PDF 파일만 업로드 가능합니다."),
   FILE_ALREADY_UPLOADED(HttpStatus.CONFLICT, "E002", "이미 업로드된 자료가 있습니다. 다시 업로드하면 초기화됩니다."),


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #113 

## ✏️ 작업 내용

- ExperienceUpdateRequest DTO에 @Size 검증 추가
  - title 80자, oneLineIntro 100자, STAR 각 필드 1000자
- ExperienceTitleUpdateRequest DTO에 @Size(max = 80) 추가
- 경험 수정 서비스 레이어에 유형별 detail 필드 길이 검증 추가
  - ACTIVITY: role 50자
  - CAREER: company 50자
  - EDUCATION: organizationName 50자, name 80자
- ErrorCode E007~E012 필드별 에러코드 추가
- ExperienceCreateRequest oneLineIntro 최대 글자 수 200자 → 100자 수정

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
