### PR TITLE
[FIX] 홈 대시보드 목표 공고 지정순 정렬 적용

### DIFF
--- a/src/main/java/com/kusitms/kkium/home/repository/HomeRepository.java
+++ b/src/main/java/com/kusitms/kkium/home/repository/HomeRepository.java
@@ -38,6 +38,6 @@ public interface HomeRepository extends JpaRepository<Piece, Long> {
 
   // 목표 공고 조회 (최신 지정순)
   @Query(
-      "SELECT j FROM Jd j WHERE j.user.id = :userId AND j.isTarget = true AND j.deleteAt IS NULL ORDER BY j.targetedAt DESC")
+      "SELECT j FROM Jd j WHERE j.user.id = :userId AND j.isTarget = true AND j.deleteAt IS NULL ORDER BY j.targetedAt DESC NULLS LAST")
   List<Jd> findTargetJds(@Param("userId") Long userId);
 }

--- a/src/main/java/com/kusitms/kkium/home/repository/HomeRepository.java
+++ b/src/main/java/com/kusitms/kkium/home/repository/HomeRepository.java
@@ -36,8 +36,8 @@ public interface HomeRepository extends JpaRepository<Piece, Long> {
   List<Object[]> countByPieceType(
       @Param("userId") Long userId, @Param("allType") PieceType allType);
 
-  // 목표 공고 조회
+  // 목표 공고 조회 (최신 지정순)
   @Query(
-      "SELECT j FROM Jd j WHERE j.user.id = :userId AND j.isTarget = true AND j.deleteAt IS NULL")
+      "SELECT j FROM Jd j WHERE j.user.id = :userId AND j.isTarget = true AND j.deleteAt IS NULL ORDER BY j.targetedAt DESC")
   List<Jd> findTargetJds(@Param("userId") Long userId);
 }

--- a/src/main/java/com/kusitms/kkium/jd/domain/Jd.java
+++ b/src/main/java/com/kusitms/kkium/jd/domain/Jd.java
@@ -88,6 +88,9 @@ public class Jd extends BaseEntity {
   @Column(name = "sort_order")
   private Integer sortOrder;
 
+  @Column(name = "targeted_at")
+  private LocalDateTime targetedAt;
+
   @Column(name = "delete_at")
   private LocalDateTime deleteAt;
 
@@ -134,7 +137,13 @@ public class Jd extends BaseEntity {
   }
 
   public void toggleTarget() {
-    this.isTarget = !Boolean.TRUE.equals(this.isTarget);
+    if (Boolean.TRUE.equals(this.isTarget)) {
+      this.isTarget = false;
+      this.targetedAt = null;
+    } else {
+      this.isTarget = true;
+      this.targetedAt = LocalDateTime.now();
+    }
   }
 
   public void delete() {


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #128 

## ✏️ 작업 내용

- Jd 엔티티에 targetedAt 필드 추가
- toggleTarget() 수정 — 목표 지정 시 targetedAt = now(), 해제 시 null 초기화
- HomeRepository.findTargetJds() 쿼리에 ORDER BY j.targetedAt DESC 추가

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
