### PR TITLE
[REFACTOR] GeminiLlmService 오류 발생 시 재시도 로직 추가

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
@@ -1,11 +1,13 @@
 package com.kusitms.kkium.experience.service.llm;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -16,6 +18,7 @@ import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import reactor.util.retry.Retry;
 
 @Slf4j
 @Service
@@ -23,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 public class GeminiLlmService implements LlmService {
 
   private static final String GEMINI_API_URL =
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent";
 
   private final WebClient webClient;
   private final ObjectMapper objectMapper;
@@ -116,7 +119,10 @@ public class GeminiLlmService implements LlmService {
           .bodyValue(requestBody)
           .retrieve()
           .bodyToMono(String.class)
-          .block();
+          .retryWhen(
+              Retry.backoff(3, Duration.ofSeconds(2))
+                  .filter(e -> e instanceof WebClientResponseException.ServiceUnavailable))
+          .block(Duration.ofSeconds(60));
     } catch (Exception e) {
       log.error("Gemini API 호출 실패: {}", e.getMessage());
       throw new BaseException(ErrorCode.LLM_CALL_FAILED);

--- a/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
@@ -26,7 +26,7 @@ import reactor.util.retry.Retry;
 public class GeminiLlmService implements LlmService {
 
   private static final String GEMINI_API_URL =
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent";
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
 
   private final WebClient webClient;
   private final ObjectMapper objectMapper;

--- a/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
@@ -119,6 +119,7 @@ public class GeminiLlmService implements LlmService {
           .bodyValue(requestBody)
           .retrieve()
           .bodyToMono(String.class)
+          .timeout(Duration.ofSeconds(25))
           .retryWhen(
               Retry.backoff(3, Duration.ofSeconds(2))
                   .filter(

--- a/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
@@ -121,7 +121,11 @@ public class GeminiLlmService implements LlmService {
           .bodyToMono(String.class)
           .retryWhen(
               Retry.backoff(3, Duration.ofSeconds(2))
-                  .filter(e -> e instanceof WebClientResponseException.ServiceUnavailable))
+                  .filter(
+                      e ->
+                          e instanceof WebClientResponseException we
+                              && (we.getStatusCode().is5xxServerError()
+                                  || we.getStatusCode().value() == 429)))
           .block(Duration.ofSeconds(60));
     } catch (Exception e) {
       log.error("Gemini API 호출 실패: {}", e.getMessage());


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #131 

## ✏️ 작업 내용

- GeminiLlmService 503 에러 한정 Retry with Exponential Backoff 추가 (최대 3회, 2s→4s→8s 간격)
- callGeminiApi() timeout 누락 → 60초로 추가

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
