### PR TITLE
[INFRA] kkium-app 리소스 requests 축소

### DIFF
--- a/k8s/app/deployment.yaml
+++ b/k8s/app/deployment.yaml
@@ -128,8 +128,8 @@ spec:
               key: GOOGLE_CLOUD_VISION_API_KEY
         resources:
           requests:
-            memory: "512Mi"
-            cpu: "250m"
+            memory: "256Mi"
+            cpu: "100m"
           limits:
             memory: "1Gi"
             cpu: "500m"


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #130 

## ✏️ 작업 내용

- GKE Standard 클러스터 전환 후 노드 CPU 부족(96% 사용)으로 kkium-app Pod Pending 발생
- kkium-app CPU requests 250m → 100m, Memory requests 512Mi → 256Mi 축소
- limits는 기존과 동일하게 유지 (cpu: 500m, memory: 1Gi)

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
