### PR TITLE
[FEAT] GCP Secret Manager, External Secrets, Reloader 적용

### DIFF
--- a/k8s/app/deployment.yaml
+++ b/k8s/app/deployment.yaml
@@ -17,6 +17,8 @@ spec:
     metadata:
       labels:
         app: kkium-app
+      annotations:
+        secret.reloader.stakater.com/reload: "kkium-secret"
     spec:
       containers:
       - name: kkium-app

--- a/k8s/app/deployment.yaml
+++ b/k8s/app/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: kkium-app
   namespace: kkium
+  annotations:
+    secret.reloader.stakater.com/reload: "kkium-secret"
 spec:
   replicas: 2
   selector:
@@ -17,8 +19,6 @@ spec:
     metadata:
       labels:
         app: kkium-app
-      annotations:
-        secret.reloader.stakater.com/reload: "kkium-secret"
     spec:
       containers:
       - name: kkium-app

--- a/k8s/app/external-secret.yaml
+++ b/k8s/app/external-secret.yaml
@@ -1,0 +1,74 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kkium-secret
+  namespace: kkium
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-store
+    kind: SecretStore
+  target:
+    name: kkium-secret
+    creationPolicy: Owner
+  data:
+  - secretKey: DB_URL
+    remoteRef:
+      key: DB_URL
+  - secretKey: DB_USER
+    remoteRef:
+      key: DB_USER
+  - secretKey: DB_PASSWORD
+    remoteRef:
+      key: DB_PASSWORD
+  - secretKey: JWT_SECRET
+    remoteRef:
+      key: JWT_SECRET
+  - secretKey: JWT_ACCESS_TOKEN_EXPIRATION
+    remoteRef:
+      key: JWT_ACCESS_TOKEN_EXPIRATION
+  - secretKey: KAKAO_REST_API_KEY
+    remoteRef:
+      key: KAKAO_REST_API_KEY
+  - secretKey: KAKAO_REDIRECT_URI
+    remoteRef:
+      key: KAKAO_REDIRECT_URI
+  - secretKey: KAKAO_CLIENT_SECRET
+    remoteRef:
+      key: KAKAO_CLIENT_SECRET
+  - secretKey: GOOGLE_CLIENT_ID
+    remoteRef:
+      key: GOOGLE_CLIENT_ID
+  - secretKey: GOOGLE_REDIRECT_URI
+    remoteRef:
+      key: GOOGLE_REDIRECT_URI
+  - secretKey: GOOGLE_CLIENT_SECRET
+    remoteRef:
+      key: GOOGLE_CLIENT_SECRET
+  - secretKey: GEMINI_API_KEY
+    remoteRef:
+      key: GEMINI_API_KEY
+  - secretKey: OPENAI_API_KEY
+    remoteRef:
+      key: OPENAI_API_KEY
+  - secretKey: NOTION_CLIENT_ID
+    remoteRef:
+      key: NOTION_CLIENT_ID
+  - secretKey: NOTION_CLIENT_SECRET
+    remoteRef:
+      key: NOTION_CLIENT_SECRET
+  - secretKey: NOTION_REDIRECT_URI
+    remoteRef:
+      key: NOTION_REDIRECT_URI
+  - secretKey: NOTION_FRONTEND_REDIRECT_URI
+    remoteRef:
+      key: NOTION_FRONTEND_REDIRECT_URI
+  - secretKey: AES_SECRET_KEY
+    remoteRef:
+      key: AES_SECRET_KEY
+  - secretKey: REDIS_HOST
+    remoteRef:
+      key: REDIS_HOST
+  - secretKey: GOOGLE_CLOUD_VISION_API_KEY
+    remoteRef:
+      key: GOOGLE_CLOUD_VISION_API_KEY

--- a/k8s/app/secret-store.yaml
+++ b/k8s/app/secret-store.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: gcp-secret-store
+  namespace: kkium
+spec:
+  provider:
+    gcpsm:
+      projectID: kkium-prod
+      auth:
+        workloadIdentity:
+          clusterLocation: asia-northeast3-a
+          clusterName: kkium-cluster
+          clusterProjectID: kkium-prod
+          serviceAccountRef:
+            name: kkium-external-secrets-ksa
+            namespace: kkium


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #136 

## ✏️ 작업 내용

- GCP Secret Manager에 키 20개 등록
- Workload Identity 활성화 및 GSA/KSA 생성 + 바인딩
- External Secrets Operator 설치 (secret-store.yaml, external-secret.yaml 추가)
- Reloader 설치 및 deployment.yaml annotation 추가
- 기존 secret.yaml 방식에서 GCP Secret Manager 자동 동기화 방식으로 전환

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
