### PR TITLE
[FEAT] 자기소개서 문항 삭제 기능 구현

### DIFF
--- a/src/main/java/com/kusitms/kkium/jd/repository/JdAnswerRepository.java
+++ b/src/main/java/com/kusitms/kkium/jd/repository/JdAnswerRepository.java
@@ -4,6 +4,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.kusitms.kkium.jd.domain.JdAnswer;
 import com.kusitms.kkium.jd.domain.JdQuestion;
@@ -14,7 +17,7 @@ public interface JdAnswerRepository extends JpaRepository<JdAnswer, Long> {
 
   List<JdAnswer> findAllByJdQuestionInAndUser(List<JdQuestion> questions, User user);
 
-  List<JdAnswer> findAllByJdQuestion(JdQuestion jdQuestion);
-
-  void deleteAllByJdQuestion(JdQuestion jdQuestion);
+  @Modifying
+  @Query("DELETE FROM JdAnswer a WHERE a.jdQuestion = :jdQuestion")
+  void deleteAllByJdQuestion(@Param("jdQuestion") JdQuestion jdQuestion);
 }

--- a/src/main/java/com/kusitms/kkium/jd/repository/JdAnswerRepository.java
+++ b/src/main/java/com/kusitms/kkium/jd/repository/JdAnswerRepository.java
@@ -13,4 +13,8 @@ public interface JdAnswerRepository extends JpaRepository<JdAnswer, Long> {
   Optional<JdAnswer> findByJdQuestionAndUser(JdQuestion jdQuestion, User user);
 
   List<JdAnswer> findAllByJdQuestionInAndUser(List<JdQuestion> questions, User user);
+
+  List<JdAnswer> findAllByJdQuestion(JdQuestion jdQuestion);
+
+  void deleteAllByJdQuestion(JdQuestion jdQuestion);
 }

--- a/src/main/java/com/kusitms/kkium/jd/repository/JdQuestionRepository.java
+++ b/src/main/java/com/kusitms/kkium/jd/repository/JdQuestionRepository.java
@@ -21,7 +21,7 @@ public interface JdQuestionRepository extends JpaRepository<JdQuestion, Long> {
   @Query("SELECT COALESCE(MAX(q.orderNum), 0) FROM JdQuestion q WHERE q.jd.id = :jdId")
   int findMaxOrderNumByJdId(@Param("jdId") Long jdId);
 
-  @Modifying
+  @Modifying(clearAutomatically = true)
   @Query(
       "UPDATE JdQuestion q SET q.orderNum = q.orderNum - 1 "
           + "WHERE q.jd.id = :jdId AND q.orderNum > :deletedOrder")

--- a/src/main/java/com/kusitms/kkium/jd/repository/JdQuestionRepository.java
+++ b/src/main/java/com/kusitms/kkium/jd/repository/JdQuestionRepository.java
@@ -1,8 +1,10 @@
 package com.kusitms.kkium.jd.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,6 +16,14 @@ public interface JdQuestionRepository extends JpaRepository<JdQuestion, Long> {
 
   List<JdQuestion> findAllByIdInAndJdId(List<Long> ids, Long jdId);
 
+  Optional<JdQuestion> findByIdAndJdId(Long id, Long jdId);
+
   @Query("SELECT COALESCE(MAX(q.orderNum), 0) FROM JdQuestion q WHERE q.jd.id = :jdId")
   int findMaxOrderNumByJdId(@Param("jdId") Long jdId);
+
+  @Modifying
+  @Query(
+      "UPDATE JdQuestion q SET q.orderNum = q.orderNum - 1 "
+          + "WHERE q.jd.id = :jdId AND q.orderNum > :deletedOrder")
+  void decrementOrderNumAfter(@Param("jdId") Long jdId, @Param("deletedOrder") int deletedOrder);
 }

--- a/src/main/java/com/kusitms/kkium/jd/service/JdService.java
+++ b/src/main/java/com/kusitms/kkium/jd/service/JdService.java
@@ -177,12 +177,8 @@ public class JdService {
 
     int deletedOrder = question.getOrderNum();
 
-    // 1. 해당 문항에 연결된 모든 답변 조회 → AnswerExperience 먼저 삭제 (FK 제약 회피)
-    List<JdAnswer> answers = jdAnswerRepository.findAllByJdQuestion(question);
-    if (!answers.isEmpty()) {
-      List<Long> answerIds = answers.stream().map(JdAnswer::getId).toList();
-      answerExperienceRepository.deleteAllByJdAnswerIdIn(answerIds);
-    }
+    // 1. 답변-경험 매핑 먼저 삭제 (FK 제약 회피)
+    answerExperienceRepository.deleteAllByJdQuestion(question);
 
     // 2. 답변 삭제 (aiDraft 포함)
     jdAnswerRepository.deleteAllByJdQuestion(question);

--- a/src/main/java/com/kusitms/kkium/jd/service/JdService.java
+++ b/src/main/java/com/kusitms/kkium/jd/service/JdService.java
@@ -30,6 +30,7 @@ import com.kusitms.kkium.jd.dto.response.JdSaveResponse;
 import com.kusitms.kkium.jd.repository.JdAnswerRepository;
 import com.kusitms.kkium.jd.repository.JdQuestionRepository;
 import com.kusitms.kkium.jd.repository.JdRepository;
+import com.kusitms.kkium.resume.repository.AnswerExperienceRepository;
 import com.kusitms.kkium.user.domain.User;
 import com.kusitms.kkium.user.repository.UserRepository;
 import com.kusitms.kkium.user.utils.CustomUserDetails;
@@ -46,6 +47,7 @@ public class JdService {
   private final JdRepository jdRepository;
   private final JdQuestionRepository jdQuestionRepository;
   private final JdAnswerRepository jdAnswerRepository;
+  private final AnswerExperienceRepository answerExperienceRepository;
   private final UserRepository userRepository;
   private final JdExperienceAnalysisService jdExperienceAnalysisService;
 
@@ -155,6 +157,41 @@ public class JdService {
     int orderNum = jdQuestionRepository.findMaxOrderNumByJdId(jdId) + 1;
     jdQuestionRepository.save(
         JdQuestion.builder().jd(jd).orderNum(orderNum).content(request.content()).build());
+  }
+
+  @Transactional
+  public void deleteQuestion(Long jdId, Long questionId, Long userId) {
+    Jd jd =
+        jdRepository
+            .findByIdAndDeleteAtIsNull(jdId)
+            .orElseThrow(() -> new BaseException(ErrorCode.JD_NOT_FOUND));
+
+    if (!jd.getUser().getId().equals(userId)) {
+      throw new BaseException(ErrorCode.FORBIDDEN);
+    }
+
+    JdQuestion question =
+        jdQuestionRepository
+            .findByIdAndJdId(questionId, jdId)
+            .orElseThrow(() -> new BaseException(ErrorCode.INVALID_QUESTION_FOR_JD));
+
+    int deletedOrder = question.getOrderNum();
+
+    // 1. 해당 문항에 연결된 모든 답변 조회 → AnswerExperience 먼저 삭제 (FK 제약 회피)
+    List<JdAnswer> answers = jdAnswerRepository.findAllByJdQuestion(question);
+    if (!answers.isEmpty()) {
+      List<Long> answerIds = answers.stream().map(JdAnswer::getId).toList();
+      answerExperienceRepository.deleteAllByJdAnswerIdIn(answerIds);
+    }
+
+    // 2. 답변 삭제 (aiDraft 포함)
+    jdAnswerRepository.deleteAllByJdQuestion(question);
+
+    // 3. 문항 삭제
+    jdQuestionRepository.delete(question);
+
+    // 4. 이후 문항들 orderNum -1 재정렬
+    jdQuestionRepository.decrementOrderNumAfter(jdId, deletedOrder);
   }
 
   @Transactional

--- a/src/main/java/com/kusitms/kkium/resume/controller/ResumeController.java
+++ b/src/main/java/com/kusitms/kkium/resume/controller/ResumeController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kusitms.kkium.global.response.ApiResponse;
+import com.kusitms.kkium.jd.service.JdService;
 import com.kusitms.kkium.resume.dto.request.AiDraftRequest;
 import com.kusitms.kkium.resume.dto.request.ResumeAnswerSaveRequest;
 import com.kusitms.kkium.resume.dto.response.AiDraftResponse;
@@ -40,6 +42,7 @@ public class ResumeController {
   private final ResumeWritingGuideService resumeWritingGuideService;
   private final ResumeAiDraftService resumeAiDraftService;
   private final ResumeAnswerService resumeAnswerService;
+  private final JdService jdService;
 
   @Operation(
       summary = "[자소서 작성] 문항별 경험 목록 & 활용 적합도 조회",
@@ -95,5 +98,17 @@ public class ResumeController {
         ApiResponse.success(
             resumeAiDraftService.generateAiDraft(
                 jdId, questionId, request.experienceIds(), userDetails.getId())));
+  }
+
+  @Operation(
+      summary = "[자소서 작성] 문항 삭제",
+      description = "자기소개서 문항과 연결된 모든 답변(AI 초안 포함), 답변-경험 매핑을 삭제하고 이후 문항의 번호를 재정렬합니다.")
+  @DeleteMapping("/jd/{jdId}/questions/{questionId}")
+  public ResponseEntity<ApiResponse<Void>> deleteQuestion(
+      @PathVariable Long jdId,
+      @PathVariable Long questionId,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    jdService.deleteQuestion(jdId, questionId, userDetails.getId());
+    return ResponseEntity.ok(ApiResponse.successWithNoContent());
   }
 }

--- a/src/main/java/com/kusitms/kkium/resume/repository/AnswerExperienceRepository.java
+++ b/src/main/java/com/kusitms/kkium/resume/repository/AnswerExperienceRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.kusitms.kkium.jd.domain.JdQuestion;
 import com.kusitms.kkium.resume.domain.AnswerExperience;
 
 public interface AnswerExperienceRepository extends JpaRepository<AnswerExperience, Long> {
@@ -16,4 +17,10 @@ public interface AnswerExperienceRepository extends JpaRepository<AnswerExperien
   @Modifying
   @Query("DELETE FROM AnswerExperience ae WHERE ae.jdAnswer.id IN :answerIds")
   void deleteAllByJdAnswerIdIn(@Param("answerIds") List<Long> answerIds);
+
+  @Modifying
+  @Query(
+      "DELETE FROM AnswerExperience ae WHERE ae.jdAnswer.id IN "
+          + "(SELECT a.id FROM JdAnswer a WHERE a.jdQuestion = :jdQuestion)")
+  void deleteAllByJdQuestion(@Param("jdQuestion") JdQuestion jdQuestion);
 }


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #135

## ✏️ 작업 내용

- `JdQuestionRepository` - findByIdAndJdId, decrementOrderNumAfter 추가
- `JdAnswerRepository `- findAllByJdQuestion, deleteAllByJdQuestion 추가
- `JdService `- deleteQuestion() 메서드 구현 및 AnswerExperienceRepository 의존성 추가
- `ResumeController `- DELETE /api/v1/resume/jd/{jdId}/questions/{questionId} 엔드포인트 추가
- 삭제 순서: `AnswerExperience `→ `JdAnswer `→ `JdQuestion `
- 삭제 후 동일 JD 내 이후 문항들 `orderNum -1` 재정렬

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
