### PR TITLE
[REFACTOR] 노션 페이지 목록 조회 API 호출 구조 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,9 @@ dependencies {
     // jackson
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // rate limiter
+    implementation 'com.bucket4j:bucket4j_jdk17-core:8.19.0'
 }
 
 jar {

--- a/src/main/java/com/kusitms/kkium/experience/service/analyze/NotionAnalyzeService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/analyze/NotionAnalyzeService.java
@@ -2,6 +2,7 @@ package com.kusitms.kkium.experience.service.analyze;
 
 import java.util.List;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import com.kusitms.kkium.experience.dto.response.ExperienceAnalyzeResponse;
@@ -23,7 +24,8 @@ public class NotionAnalyzeService {
   private final NotionConnectionRepository notionConnectionRepository;
   private final LlmService llmService;
 
-  // 접근 가능한 Notion 페이지 목록 조회
+  // 접근 가능한 Notion 페이지 목록 조회 (5분 캐싱)
+  @Cacheable(value = "notion-pages", key = "#userId")
   public NotionPageListResponse getPages(Long userId) {
     NotionConnection connection = getConnection(userId);
     List<NotionPageListResponse.NotionPageInfo> pages =

--- a/src/main/java/com/kusitms/kkium/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/kusitms/kkium/global/config/RedisCacheConfig.java
@@ -1,0 +1,35 @@
+package com.kusitms.kkium.global.config;
+
+import java.time.Duration;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+  @Bean
+  @SuppressWarnings("removal")
+  public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+    RedisCacheConfiguration defaultConfig =
+        RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(5))
+            .disableCachingNullValues()
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new StringRedisSerializer()))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new GenericJackson2JsonRedisSerializer()));
+
+    return RedisCacheManager.builder(connectionFactory).cacheDefaults(defaultConfig).build();
+  }
+}

--- a/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
+++ b/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
@@ -66,7 +66,6 @@ public class NotionApiClient {
         Base64.getEncoder()
             .encodeToString((clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8));
 
-    acquireNotionRateLimit();
     return webClient
         .post()
         .uri(TOKEN_URI)
@@ -99,6 +98,7 @@ public class NotionApiClient {
                         });
               }
             })
+        .doFirst(this::acquireNotionRateLimit)
         .retryWhen(notionRetrySpec())
         .onErrorMap(NotionRetryableException.class, ex -> new BaseException(NOTION_TOKEN_FAILED))
         .block();
@@ -197,7 +197,6 @@ public class NotionApiClient {
       }
       final String currentCursor = nextCursor;
 
-      acquireNotionRateLimit();
       String responseBody =
           webClient
               .post()
@@ -231,6 +230,7 @@ public class NotionApiClient {
                               });
                     }
                   })
+              .doFirst(this::acquireNotionRateLimit)
               .retryWhen(notionRetrySpec())
               .onErrorMap(
                   NotionRetryableException.class,
@@ -238,6 +238,7 @@ public class NotionApiClient {
               .block();
 
       try {
+        if (responseBody == null || responseBody.isBlank()) break;
         JsonNode response = objectMapper.readTree(responseBody);
         if (response == null) break;
 
@@ -264,7 +265,6 @@ public class NotionApiClient {
   private void fetchDatabaseRows(
       String accessToken, String databaseId, List<NotionPageListResponse.NotionPageInfo> leafs) {
     try {
-      acquireNotionRateLimit();
       String responseBody =
           webClient
               .post()
@@ -298,6 +298,7 @@ public class NotionApiClient {
                               });
                     }
                   })
+              .doFirst(this::acquireNotionRateLimit)
               .retryWhen(notionRetrySpec())
               .onErrorResume(
                   NotionRetryableException.class,
@@ -341,7 +342,6 @@ public class NotionApiClient {
   private String fetchBlockChildren(String accessToken, String blockId, int depth) {
     if (depth > MAX_BLOCK_FETCH_DEPTH) return "";
 
-    acquireNotionRateLimit();
     String responseBody =
         webClient
             .get()
@@ -369,6 +369,7 @@ public class NotionApiClient {
                             });
                   }
                 })
+            .doFirst(this::acquireNotionRateLimit)
             .retryWhen(notionRetrySpec())
             .onErrorMap(
                 NotionRetryableException.class,

--- a/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
+++ b/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
@@ -2,6 +2,7 @@ package com.kusitms.kkium.notion.utils;
 
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.NOTION_TOKEN_FAILED;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -31,6 +32,7 @@ import io.github.bucket4j.Bucket;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -84,14 +86,21 @@ public class NotionApiClient {
                     .bodyToMono(String.class)
                     .flatMap(
                         errorBody -> {
-                          log.error(
-                              "Notion 토큰 발급 실패 - status: {}, body: {}",
-                              response.statusCode(),
-                              errorBody);
+                          int status = response.statusCode().value();
+                          boolean retryable =
+                              status == 429 || response.statusCode().is5xxServerError();
+                          log.error("Notion 토큰 발급 실패 - status: {}, body: {}", status, errorBody);
+                          if (retryable) {
+                            return Mono.error(
+                                new NotionRetryableException(
+                                    "Notion 토큰 발급 일시적 실패 (status=" + status + ")"));
+                          }
                           return Mono.error(new BaseException(NOTION_TOKEN_FAILED));
                         });
               }
             })
+        .retryWhen(notionRetrySpec())
+        .onErrorMap(NotionRetryableException.class, ex -> new BaseException(NOTION_TOKEN_FAILED))
         .block();
   }
 
@@ -157,6 +166,25 @@ public class NotionApiClient {
     }
   }
 
+  // 일시적 실패(5xx, 429, 네트워크 오류)에 대한 재시도 정책: 최대 3회, 지수 백오프 (1초 → 2초 → 4초)
+  private Retry notionRetrySpec() {
+    return Retry.backoff(3, Duration.ofSeconds(1)).filter(NotionApiClient::isRetryable);
+  }
+
+  // 재시도 대상 예외 판별 (5xx/429 + 네트워크 일시 오류)
+  private static boolean isRetryable(Throwable t) {
+    if (t instanceof NotionRetryableException) return true;
+    if (t instanceof IOException) return true;
+    return t.getCause() instanceof IOException;
+  }
+
+  // Notion API 일시적 실패(5xx, 429) 시 재시도 대상으로 표시
+  private static class NotionRetryableException extends RuntimeException {
+    NotionRetryableException(String message) {
+      super(message);
+    }
+  }
+
   // /v1/search 페이징 호출하여 모든 페이지 메타데이터 수집
   private List<JsonNode> fetchAllPagesViaSearch(String accessToken) {
     List<JsonNode> allPages = new ArrayList<>();
@@ -186,12 +214,27 @@ public class NotionApiClient {
                       return res.bodyToMono(String.class)
                           .flatMap(
                               err -> {
+                                int status = res.statusCode().value();
+                                boolean retryable =
+                                    status == 429 || res.statusCode().is5xxServerError();
                                 log.error(
-                                    "Notion 페이지 목록 조회 실패 (cursor={}): {}", currentCursor, err);
+                                    "Notion 페이지 목록 조회 실패 (cursor={}, status={}): {}",
+                                    currentCursor,
+                                    status,
+                                    err);
+                                if (retryable) {
+                                  return Mono.error(
+                                      new NotionRetryableException(
+                                          "Notion search 일시적 실패 (status=" + status + ")"));
+                                }
                                 return Mono.error(new BaseException(ErrorCode.NOTION_TOKEN_FAILED));
                               });
                     }
                   })
+              .retryWhen(notionRetrySpec())
+              .onErrorMap(
+                  NotionRetryableException.class,
+                  ex -> new BaseException(ErrorCode.NOTION_TOKEN_FAILED))
               .block();
 
       try {
@@ -238,10 +281,30 @@ public class NotionApiClient {
                       return res.bodyToMono(String.class)
                           .flatMap(
                               err -> {
-                                log.warn("Notion DB 쿼리 실패 (databaseId={}): {}", databaseId, err);
+                                int status = res.statusCode().value();
+                                boolean retryable =
+                                    status == 429 || res.statusCode().is5xxServerError();
+                                log.warn(
+                                    "Notion DB 쿼리 실패 (databaseId={}, status={}): {}",
+                                    databaseId,
+                                    status,
+                                    err);
+                                if (retryable) {
+                                  return Mono.error(
+                                      new NotionRetryableException(
+                                          "Notion DB 쿼리 일시적 실패 (status=" + status + ")"));
+                                }
                                 return Mono.just("");
                               });
                     }
+                  })
+              .retryWhen(notionRetrySpec())
+              .onErrorResume(
+                  NotionRetryableException.class,
+                  ex -> {
+                    log.warn(
+                        "Notion DB 쿼리 재시도 실패 (databaseId={}): {}", databaseId, ex.getMessage());
+                    return Mono.just("");
                   })
               .block();
 
@@ -293,11 +356,23 @@ public class NotionApiClient {
                     return res.bodyToMono(String.class)
                         .flatMap(
                             err -> {
-                              log.error("Notion 블록 조회 실패: {}", err);
+                              int status = res.statusCode().value();
+                              boolean retryable =
+                                  status == 429 || res.statusCode().is5xxServerError();
+                              log.error("Notion 블록 조회 실패 (status={}): {}", status, err);
+                              if (retryable) {
+                                return Mono.error(
+                                    new NotionRetryableException(
+                                        "Notion 블록 조회 일시적 실패 (status=" + status + ")"));
+                              }
                               return Mono.error(new BaseException(ErrorCode.NOTION_TOKEN_FAILED));
                             });
                   }
                 })
+            .retryWhen(notionRetrySpec())
+            .onErrorMap(
+                NotionRetryableException.class,
+                ex -> new BaseException(ErrorCode.NOTION_TOKEN_FAILED))
             .block();
 
     StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
+++ b/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
@@ -5,10 +5,12 @@ import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.NOTION_TOKE
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
@@ -98,176 +100,153 @@ public class NotionApiClient {
 
   // 접근 가능한 최하단(leaf) 페이지 목록 조회
   public List<NotionPageListResponse.NotionPageInfo> getPages(String accessToken) {
-    String responseBody =
-        webClient
-            .post()
-            .uri("https://api.notion.com/v1/search")
-            .header("Authorization", "Bearer " + accessToken)
-            .header("Notion-Version", "2022-06-28")
-            .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue(Map.of())
-            .exchangeToMono(
-                res -> {
-                  if (res.statusCode().is2xxSuccessful()) {
-                    return res.bodyToMono(String.class);
-                  } else {
-                    return res.bodyToMono(String.class)
-                        .flatMap(
-                            err -> {
-                              log.error("Notion 페이지 목록 조회 실패: {}", err);
-                              return Mono.error(new BaseException(ErrorCode.NOTION_TOKEN_FAILED));
-                            });
-                  }
-                })
-            .block();
+    // 1. /v1/search 페이징으로 모든 페이지 메타데이터 수집
+    List<JsonNode> allPages = fetchAllPagesViaSearch(accessToken);
 
-    List<NotionPageListResponse.NotionPageInfo> leafPages = new ArrayList<>();
-    Set<String> visitedPageIds = new HashSet<>();
-    try {
-      JsonNode response = objectMapper.readTree(responseBody);
-      if (response != null && response.has("results")) {
-        for (JsonNode page : response.get("results")) {
-          String pageId = page.get("id").asText();
-          String title = extractPageTitle(page);
-          String icon = extractIcon(page);
-          String type = page.has("object") ? page.get("object").asText() : "page";
-          String lastEditedTime =
-              page.hasNonNull("last_edited_time") ? page.get("last_edited_time").asText() : null;
-          String parentId = extractParentId(page);
-          collectLeafPages(
-              accessToken,
-              pageId,
-              title,
-              icon,
-              type,
-              lastEditedTime,
-              parentId,
-              leafPages,
-              visitedPageIds,
-              0);
-        }
+    // 2. 누군가의 부모로 등장하는 페이지 id 집합 구성
+    Set<String> parentIds =
+        allPages.stream()
+            .map(this::extractParentId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+    // 3. leaf 판별
+    //    - database 타입: 자기 자신 + 안의 row 모두 추가 (기존 동작 유지)
+    //    - DB row(parent.type == database_id)는 fetchDatabaseRows에서 처리되므로 일반 페이지 루프에서 스킵
+    //    - 일반 페이지: parentIds에 없는 경우에만 leaf로 추가
+    List<NotionPageListResponse.NotionPageInfo> leafs = new ArrayList<>();
+    for (JsonNode page : allPages) {
+      String type = page.has("object") ? page.get("object").asText() : "page";
+      String pageId = page.get("id").asText();
+
+      if ("database".equals(type)) {
+        leafs.add(toPageInfo(page));
+        fetchDatabaseRows(accessToken, pageId, leafs);
+      } else if (!isDatabaseRow(page) && !parentIds.contains(pageId)) {
+        leafs.add(toPageInfo(page));
       }
-    } catch (JsonProcessingException e) {
-      log.error("Notion 페이지 목록 파싱 실패: {}", e.getMessage(), e);
-      throw new BaseException(ErrorCode.NOTION_RESPONSE_PARSE_ERROR);
     }
-    return leafPages;
+
+    return leafs;
   }
 
-  // 하위 페이지 재귀 탐색 — child_page 없는 leaf만 수집
-  private void collectLeafPages(
-      String accessToken,
-      String pageId,
-      String title,
-      String icon,
-      String type,
-      String lastEditedTime,
-      String parentId,
-      List<NotionPageListResponse.NotionPageInfo> leafPages,
-      Set<String> visitedPageIds,
-      int depth) {
+  // parent.type이 database_id인지 확인 (DB row 여부)
+  private boolean isDatabaseRow(JsonNode page) {
+    JsonNode parent = page.get("parent");
+    if (parent == null || parent.isNull()) return false;
+    String parentType = parent.has("type") ? parent.get("type").asText() : null;
+    return "database_id".equals(parentType);
+  }
 
-    if (depth > MAX_BLOCK_FETCH_DEPTH) return;
-    if (visitedPageIds.contains(pageId)) return;
-    visitedPageIds.add(pageId);
+  // /v1/search 페이징 호출하여 모든 페이지 메타데이터 수집
+  private List<JsonNode> fetchAllPagesViaSearch(String accessToken) {
+    List<JsonNode> allPages = new ArrayList<>();
+    String nextCursor = null;
 
-    // database는 자체도 leaf로 추가하고, 하위 row 페이지들도 추가
-    if ("database".equals(type)) {
-      leafPages.add(
-          new NotionPageListResponse.NotionPageInfo(
-              pageId, title, icon, type, lastEditedTime, parentId));
-      fetchDatabaseRows(
-          accessToken, pageId, icon, lastEditedTime, leafPages, visitedPageIds, depth);
-      return;
-    }
+    do {
+      Map<String, Object> body = new HashMap<>();
+      if (nextCursor != null) {
+        body.put("start_cursor", nextCursor);
+      }
+      final String currentCursor = nextCursor;
 
-    String responseBody =
-        webClient
-            .get()
-            .uri("https://api.notion.com/v1/blocks/" + pageId + "/children")
-            .header("Authorization", "Bearer " + accessToken)
-            .header("Notion-Version", "2022-06-28")
-            .exchangeToMono(
-                res -> {
-                  if (res.statusCode().is2xxSuccessful()) {
-                    return res.bodyToMono(String.class);
-                  } else {
-                    return res.bodyToMono(String.class)
-                        .flatMap(
-                            err -> {
-                              log.error("Notion 하위 블록 조회 실패: {}", err);
-                              return Mono.error(new BaseException(ErrorCode.NOTION_TOKEN_FAILED));
-                            });
-                  }
-                })
-            .block();
+      String responseBody =
+          webClient
+              .post()
+              .uri("https://api.notion.com/v1/search")
+              .header("Authorization", "Bearer " + accessToken)
+              .header("Notion-Version", "2022-06-28")
+              .contentType(MediaType.APPLICATION_JSON)
+              .bodyValue(body)
+              .exchangeToMono(
+                  res -> {
+                    if (res.statusCode().is2xxSuccessful()) {
+                      return res.bodyToMono(String.class);
+                    } else {
+                      return res.bodyToMono(String.class)
+                          .flatMap(
+                              err -> {
+                                log.error(
+                                    "Notion 페이지 목록 조회 실패 (cursor={}): {}", currentCursor, err);
+                                return Mono.error(new BaseException(ErrorCode.NOTION_TOKEN_FAILED));
+                              });
+                    }
+                  })
+              .block();
 
+      try {
+        JsonNode response = objectMapper.readTree(responseBody);
+        if (response == null) break;
+
+        if (response.has("results")) {
+          for (JsonNode page : response.get("results")) {
+            allPages.add(page);
+          }
+        }
+
+        nextCursor =
+            response.hasNonNull("has_more") && response.get("has_more").asBoolean()
+                ? response.path("next_cursor").asText(null)
+                : null;
+      } catch (JsonProcessingException e) {
+        log.error("Notion 페이지 목록 파싱 실패: {}", e.getMessage(), e);
+        throw new BaseException(ErrorCode.NOTION_RESPONSE_PARSE_ERROR);
+      }
+    } while (nextCursor != null);
+
+    return allPages;
+  }
+
+  // database row 조회하여 leaf 목록에 추가
+  private void fetchDatabaseRows(
+      String accessToken, String databaseId, List<NotionPageListResponse.NotionPageInfo> leafs) {
     try {
+      String responseBody =
+          webClient
+              .post()
+              .uri("https://api.notion.com/v1/databases/" + databaseId + "/query")
+              .header("Authorization", "Bearer " + accessToken)
+              .header("Notion-Version", "2022-06-28")
+              .contentType(MediaType.APPLICATION_JSON)
+              .bodyValue(Map.of())
+              .exchangeToMono(
+                  res -> {
+                    if (res.statusCode().is2xxSuccessful()) {
+                      return res.bodyToMono(String.class);
+                    } else {
+                      return res.bodyToMono(String.class)
+                          .flatMap(
+                              err -> {
+                                log.warn("Notion DB 쿼리 실패 (databaseId={}): {}", databaseId, err);
+                                return Mono.just("");
+                              });
+                    }
+                  })
+              .block();
+
+      if (responseBody == null || responseBody.isBlank()) return;
       JsonNode response = objectMapper.readTree(responseBody);
-      if (response == null || !response.has("results")) {
-        leafPages.add(
-            new NotionPageListResponse.NotionPageInfo(
-                pageId, title, icon, type, lastEditedTime, parentId));
-        return;
+      if (response == null || !response.has("results")) return;
+
+      for (JsonNode row : response.get("results")) {
+        leafs.add(toPageInfo(row));
       }
-
-      List<JsonNode> childPages = new ArrayList<>();
-      for (JsonNode block : response.get("results")) {
-        if ("child_page".equals(block.get("type").asText())) {
-          childPages.add(block);
-        }
-      }
-
-      if (childPages.isEmpty()) {
-        // 하위 페이지 없음 → leaf
-        leafPages.add(
-            new NotionPageListResponse.NotionPageInfo(
-                pageId, title, icon, type, lastEditedTime, parentId));
-      } else {
-        // 하위 페이지 있음 → fetchPage 병렬 호출 후 재귀
-        List<String> childIds =
-            childPages.stream().map(child -> child.path("id").asText()).toList();
-        List<String> childTitles =
-            childPages.stream()
-                .map(child -> child.path("child_page").path("title").asText("제목 없음"))
-                .toList();
-
-        List<Mono<JsonNode>> fetchMonos =
-            childIds.stream().map(childId -> fetchPageAsync(accessToken, childId)).toList();
-
-        List<JsonNode> childPageNodes =
-            Mono.zip(
-                    fetchMonos,
-                    results -> java.util.Arrays.stream(results).map(r -> (JsonNode) r).toList())
-                .blockOptional()
-                .orElse(List.of());
-
-        for (int i = 0; i < childIds.size(); i++) {
-          String childId = childIds.get(i);
-          String childTitle = childTitles.get(i);
-          JsonNode childPage = i < childPageNodes.size() ? childPageNodes.get(i) : null;
-          String childIcon = childPage != null ? extractIcon(childPage) : null;
-          String childLastEditedTime =
-              childPage != null && childPage.has("last_edited_time")
-                  ? childPage.get("last_edited_time").asText()
-                  : lastEditedTime;
-          collectLeafPages(
-              accessToken,
-              childId,
-              childTitle,
-              childIcon,
-              type,
-              childLastEditedTime,
-              pageId,
-              leafPages,
-              visitedPageIds,
-              depth + 1);
-        }
-      }
-    } catch (JsonProcessingException e) {
-      log.error("Notion 하위 페이지 파싱 실패: {}", e.getMessage(), e);
-      throw new BaseException(ErrorCode.NOTION_BLOCK_PARSE_ERROR);
+    } catch (Exception e) {
+      log.warn("Notion DB row 파싱 실패 (databaseId={}): {}", databaseId, e.getMessage());
     }
+  }
+
+  // JsonNode → NotionPageInfo 변환
+  private NotionPageListResponse.NotionPageInfo toPageInfo(JsonNode page) {
+    String pageId = page.get("id").asText();
+    String title = extractPageTitle(page);
+    String icon = extractIcon(page);
+    String type = page.has("object") ? page.get("object").asText() : "page";
+    String lastEditedTime =
+        page.hasNonNull("last_edited_time") ? page.get("last_edited_time").asText() : null;
+    String parentId = extractParentId(page);
+    return new NotionPageListResponse.NotionPageInfo(
+        pageId, title, icon, type, lastEditedTime, parentId);
   }
 
   // 페이지 블록 콘텐츠 텍스트 추출
@@ -332,129 +311,6 @@ public class NotionApiClient {
       }
     }
     return sb.toString();
-  }
-
-  private void fetchDatabaseRows(
-      String accessToken,
-      String databaseId,
-      String parentIcon,
-      String parentLastEditedTime,
-      List<NotionPageListResponse.NotionPageInfo> leafPages,
-      Set<String> visitedPageIds,
-      int depth) {
-    try {
-      String responseBody =
-          webClient
-              .post()
-              .uri("https://api.notion.com/v1/databases/" + databaseId + "/query")
-              .header("Authorization", "Bearer " + accessToken)
-              .header("Notion-Version", "2022-06-28")
-              .contentType(MediaType.APPLICATION_JSON)
-              .bodyValue(Map.of())
-              .exchangeToMono(
-                  res -> {
-                    if (res.statusCode().is2xxSuccessful()) {
-                      return res.bodyToMono(String.class);
-                    } else {
-                      return res.bodyToMono(String.class)
-                          .flatMap(
-                              err -> {
-                                log.warn("Notion DB 쿼리 실패 (databaseId={}): {}", databaseId, err);
-                                return Mono.just("");
-                              });
-                    }
-                  })
-              .block();
-
-      if (responseBody == null || responseBody.isBlank()) return;
-      JsonNode response = objectMapper.readTree(responseBody);
-      if (response == null || !response.has("results")) return;
-
-      for (JsonNode row : response.get("results")) {
-        String rowId = row.get("id").asText();
-        String rowTitle = extractPageTitle(row);
-        String rowIcon = extractIcon(row);
-        String rowLastEditedTime =
-            row.hasNonNull("last_edited_time")
-                ? row.get("last_edited_time").asText()
-                : parentLastEditedTime;
-        collectLeafPages(
-            accessToken,
-            rowId,
-            rowTitle,
-            rowIcon,
-            "page",
-            rowLastEditedTime,
-            databaseId,
-            leafPages,
-            visitedPageIds,
-            depth + 1);
-      }
-    } catch (Exception e) {
-      log.warn("Notion DB row 파싱 실패 (databaseId={}): {}", databaseId, e.getMessage());
-    }
-  }
-
-  private Mono<JsonNode> fetchPageAsync(String accessToken, String pageId) {
-    return webClient
-        .get()
-        .uri("https://api.notion.com/v1/pages/" + pageId)
-        .header("Authorization", "Bearer " + accessToken)
-        .header("Notion-Version", "2022-06-28")
-        .exchangeToMono(
-            res -> {
-              if (res.statusCode().is2xxSuccessful()) {
-                return res.bodyToMono(String.class);
-              } else {
-                return res.bodyToMono(String.class)
-                    .flatMap(
-                        err -> {
-                          log.warn("Notion 페이지 조회 실패 (pageId={}): {}", pageId, err);
-                          return Mono.just("");
-                        });
-              }
-            })
-        .mapNotNull(
-            body -> {
-              if (body == null || body.isBlank()) return null;
-              try {
-                return objectMapper.readTree(body);
-              } catch (Exception e) {
-                log.warn("Notion 페이지 파싱 실패 (pageId={}): {}", pageId, e.getMessage());
-                return null;
-              }
-            })
-        .onErrorReturn(objectMapper.createObjectNode());
-  }
-
-  private JsonNode fetchPage(String accessToken, String pageId) {
-    try {
-      String responseBody =
-          webClient
-              .get()
-              .uri("https://api.notion.com/v1/pages/" + pageId)
-              .header("Authorization", "Bearer " + accessToken)
-              .header("Notion-Version", "2022-06-28")
-              .exchangeToMono(
-                  res -> {
-                    if (res.statusCode().is2xxSuccessful()) {
-                      return res.bodyToMono(String.class);
-                    } else {
-                      return res.bodyToMono(String.class)
-                          .flatMap(
-                              err -> {
-                                log.warn("Notion 페이지 조회 실패 (pageId={}): {}", pageId, err);
-                                return Mono.just("");
-                              });
-                    }
-                  })
-              .block();
-      if (responseBody == null || responseBody.isBlank()) return null;
-      return objectMapper.readTree(responseBody);
-    } catch (Exception e) {
-      log.warn("Notion 페이지 조회 예외 (pageId={}): {}", pageId, e.getMessage());
-      return null;
-    }
   }
 
   private String extractParentId(JsonNode page) {

--- a/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
+++ b/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
@@ -3,6 +3,7 @@ package com.kusitms.kkium.notion.utils;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.NOTION_TOKEN_FAILED;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
@@ -26,6 +27,7 @@ import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
 import com.kusitms.kkium.notion.dto.response.NotionPageListResponse;
 import com.kusitms.kkium.notion.dto.response.NotionTokenResponse;
 
+import io.github.bucket4j.Bucket;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
@@ -37,6 +39,12 @@ public class NotionApiClient {
 
   private final WebClient webClient;
   private final ObjectMapper objectMapper = new ObjectMapper();
+
+  // Notion API rate limiter (공식 평균 초당 3 req 제한 준수)
+  private final Bucket notionRateLimiter =
+      Bucket.builder()
+          .addLimit(limit -> limit.capacity(3).refillGreedy(3, Duration.ofSeconds(1)))
+          .build();
 
   private static final String TOKEN_URI = "https://api.notion.com/v1/oauth/token";
   private static final int MAX_BLOCK_FETCH_DEPTH = 5;
@@ -56,6 +64,7 @@ public class NotionApiClient {
         Base64.getEncoder()
             .encodeToString((clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8));
 
+    acquireNotionRateLimit();
     return webClient
         .post()
         .uri(TOKEN_URI)
@@ -138,6 +147,16 @@ public class NotionApiClient {
     return "database_id".equals(parentType);
   }
 
+  // Notion API 호출 직전 rate limit 토큰 소비 (초당 3 req 초과 시 대기)
+  private void acquireNotionRateLimit() {
+    try {
+      notionRateLimiter.asBlocking().consume(1);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Notion rate limit wait interrupted", e);
+    }
+  }
+
   // /v1/search 페이징 호출하여 모든 페이지 메타데이터 수집
   private List<JsonNode> fetchAllPagesViaSearch(String accessToken) {
     List<JsonNode> allPages = new ArrayList<>();
@@ -150,6 +169,7 @@ public class NotionApiClient {
       }
       final String currentCursor = nextCursor;
 
+      acquireNotionRateLimit();
       String responseBody =
           webClient
               .post()
@@ -201,6 +221,7 @@ public class NotionApiClient {
   private void fetchDatabaseRows(
       String accessToken, String databaseId, List<NotionPageListResponse.NotionPageInfo> leafs) {
     try {
+      acquireNotionRateLimit();
       String responseBody =
           webClient
               .post()
@@ -257,6 +278,7 @@ public class NotionApiClient {
   private String fetchBlockChildren(String accessToken, String blockId, int depth) {
     if (depth > MAX_BLOCK_FETCH_DEPTH) return "";
 
+    acquireNotionRateLimit();
     String responseBody =
         webClient
             .get()


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #140 

## ✏️ 작업 내용

1. 노션 API 호출 구조 개선 (refactor)
- 기존: 워크스페이스 안의 페이지마다 노션 API를 따로 호출하면서 자식 페이지를 재귀적으로 탐색 → 한 번의 요청이 노션 API를 300번 이상 호출하는 구조
- 개선: 노션 `/v1/search` 한 번이면 모든 페이지 정보가 한꺼번에 내려옴 → 메모리에서 부모-자식 관계를 계산해 분석 대상 페이지만 추려냄
- 결과: 노션 API 호출 수가 **300+회 → 3~5회**로 줄어들어 QA에서 발생한 `Connection reset by peer` 에러 해소

2. 호출 속도 제한 (feat)
- Bucket4j로 노션 API 호출을 초당 3회로 제한 (노션 공식 정책 준수)
- 동시 요청이 몰려서 다시 제한에 걸리는 상황 자체를 차단

3. 재시도 로직 (feat)
- 노션 서버 일시 오류(5xx, 429)나 네트워크 일시 장애 발생 시 최대 3회 자동 재시도
- 재시도 간격은 1초 → 2초 → 4초로 점점 늘어남
- 사용자 입장에서는 일시 장애가 나도 그대로 응답이 떨어지는 것처럼 보임

4. Redis 캐싱 (feat)
- 사용자별 페이지 목록을 5분간 Redis에 캐싱
- 5분 안에 같은 사용자가 다시 호출하면 노션 API 호출 없이 즉시 응답

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
