### PR TITLE
[INFRA] ArgoCD Discord 배포 알림 연동

### DIFF
--- a/argocd/argocd-app.yaml
+++ b/argocd/argocd-app.yaml
@@ -3,6 +3,10 @@ kind: Application
 metadata:
   name: kkium-app
   namespace: argocd
+  annotations:
+    notifications.argoproj.io/subscribe.on-deployed.discord: ""
+    notifications.argoproj.io/subscribe.on-sync-failed.discord: ""
+    notifications.argoproj.io/subscribe.on-health-degraded.discord: ""
 spec:
   project: default
   source:

--- a/argocd/argocd-monitoring-app.yaml
+++ b/argocd/argocd-monitoring-app.yaml
@@ -3,6 +3,9 @@ kind: Application
 metadata:
   name: kkium-monitoring
   namespace: argocd
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-failed.discord: ""
+    notifications.argoproj.io/subscribe.on-health-degraded.discord: ""
 spec:
   project: default
   source:

--- a/argocd/argocd-notifications-cm.yaml
+++ b/argocd/argocd-notifications-cm.yaml
@@ -50,11 +50,11 @@ data:
           }
 
   trigger.on-deployed: |
-    - when: app.status.operationState.phase in ['Succeeded']
+    - when: app.status.operationState != nil and app.status.operationState.phase in ['Succeeded']
       send: [app-deployed]
 
   trigger.on-sync-failed: |
-    - when: app.status.operationState.phase in ['Failed', 'Error']
+    - when: app.status.operationState != nil and app.status.operationState.phase in ['Failed', 'Error']
       send: [app-sync-failed]
 
   trigger.on-health-degraded: |

--- a/argocd/argocd-notifications-cm.yaml
+++ b/argocd/argocd-notifications-cm.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-notifications-cm
+  namespace: argocd
+data:
+  service.webhook.discord: |
+    url: $discord-webhook-url
+    headers:
+    - name: Content-Type
+      value: application/json
+
+  template.app-deployed: |
+    webhook:
+      discord:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "✅ 배포 성공: {{.app.metadata.name}}",
+              "description": "**브랜치:** {{.app.spec.source.targetRevision}}\n**네임스페이스:** {{.app.spec.destination.namespace}}",
+              "color": 3066993
+            }]
+          }
+
+  template.app-sync-failed: |
+    webhook:
+      discord:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "❌ 배포 실패: {{.app.metadata.name}}",
+              "description": "**브랜치:** {{.app.spec.source.targetRevision}}\n**네임스페이스:** {{.app.spec.destination.namespace}}\n\n[ArgoCD에서 확인하기](https://argocd.kkium.com/applications/{{.app.metadata.name}})",
+              "color": 15158332
+            }]
+          }
+
+  template.app-health-degraded: |
+    webhook:
+      discord:
+        method: POST
+        body: |
+          {
+            "embeds": [{
+              "title": "⚠️ 앱 상태 이상: {{.app.metadata.name}}",
+              "description": "**네임스페이스:** {{.app.spec.destination.namespace}}\n\n[ArgoCD에서 확인하기](https://argocd.kkium.com/applications/{{.app.metadata.name}})",
+              "color": 16776960
+            }]
+          }
+
+  trigger.on-deployed: |
+    - when: app.status.operationState.phase in ['Succeeded']
+      send: [app-deployed]
+
+  trigger.on-sync-failed: |
+    - when: app.status.operationState.phase in ['Failed', 'Error']
+      send: [app-sync-failed]
+
+  trigger.on-health-degraded: |
+    - when: app.status.health.status == 'Degraded'
+      send: [app-health-degraded]


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #142 

## ✏️ 작업 내용

- argocd-notifications-cm.yaml 추가 — Discord 웹훅 서비스, 메시지 템플릿, 트리거 설정
- argocd-app.yaml — Discord 알림 구독 annotations 추가 (배포 성공/실패/앱 이상)
- argocd-monitoring-app.yaml — Discord 알림 구독 annotations 추가 (배포 실패/앱 이상)

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
