### PR TITLE
[REFACTOR] LlmMatchScoreService 프롬프트 및 구조 분리

### DIFF
--- a/src/main/java/com/kusitms/kkium/jd/dto/response/JdExperienceAnalysisResponse.java
+++ b/src/main/java/com/kusitms/kkium/jd/dto/response/JdExperienceAnalysisResponse.java
@@ -2,7 +2,7 @@ package com.kusitms.kkium.jd.dto.response;
 
 import java.util.List;
 
-import com.kusitms.kkium.jd.utils.llm.LlmMatchScoreService.HighlightKeyword;
+import com.kusitms.kkium.jd.utils.llm.result.HighlightKeyword;
 
 public record JdExperienceAnalysisResponse(Long experienceId, ExperienceAnalysis analysis) {
 

--- a/src/main/java/com/kusitms/kkium/jd/service/JdExperienceAnalysisService.java
+++ b/src/main/java/com/kusitms/kkium/jd/service/JdExperienceAnalysisService.java
@@ -23,7 +23,7 @@ import com.kusitms.kkium.jd.dto.response.JdExperienceAnalysisResponse;
 import com.kusitms.kkium.jd.dto.response.JdExperienceAnalysisResponse.ExperienceAnalysis;
 import com.kusitms.kkium.jd.repository.JdRepository;
 import com.kusitms.kkium.jd.utils.llm.LlmMatchScoreService;
-import com.kusitms.kkium.jd.utils.llm.LlmMatchScoreService.LlmExperienceDetailResult;
+import com.kusitms.kkium.jd.utils.llm.result.LlmExperienceDetailResult;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/kusitms/kkium/jd/service/JdMatchService.java
+++ b/src/main/java/com/kusitms/kkium/jd/service/JdMatchService.java
@@ -29,6 +29,7 @@ import com.kusitms.kkium.jd.repository.JdMatchRepository;
 import com.kusitms.kkium.jd.repository.JdMatchRepository.PieceSimilarity;
 import com.kusitms.kkium.jd.repository.JdRepository;
 import com.kusitms.kkium.jd.utils.llm.LlmMatchScoreService;
+import com.kusitms.kkium.jd.utils.llm.result.LlmMatchResult;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -88,8 +89,7 @@ public class JdMatchService {
     // 5. LLM 1번 호출 - 전체 경험에 대해 활용 적합도 + 지원 적합도 한꺼번에
     // TODO: 경험이 많아질 경우 토큰 초과 위험 있음. 임베딩 상위 N개만 LLM에 넣고
     //       나머지는 임베딩 점수로만 계산하는 방식으로 최적화 필요
-    LlmMatchScoreService.LlmMatchResult llmResult =
-        llmMatchScoreService.scoreAll(jd, allExperiences);
+    LlmMatchResult llmResult = llmMatchScoreService.scoreAll(jd, allExperiences);
     Map<Long, Integer> llmScoreMap = llmResult.usageScores();
     log.info("[공고분석] 활용 적합도 LLM 점수: {}", llmScoreMap);
     log.info("[공고분석] 지원 적합도 LLM 점수: {}", llmResult.applicationScore());

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/JdMatchPromptBuilder.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/JdMatchPromptBuilder.java
@@ -1,0 +1,233 @@
+package com.kusitms.kkium.jd.utils.llm;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.springframework.stereotype.Component;
+
+import com.kusitms.kkium.experience.domain.Experience;
+import com.kusitms.kkium.jd.domain.Jd;
+import com.kusitms.kkium.jd.domain.JdQuestion;
+
+@Component
+public class JdMatchPromptBuilder {
+
+  /** 활용적합도, 지원적합도 산출 프롬프트 */
+  public String buildCombinedPrompt(Jd jd, List<Experience> experiences) {
+    return """
+        너는 채용 공고와 경험의 적합도를 평가하는 시스템이다.
+
+        [규칙]
+        - 반드시 제공된 내용만 근거로 사용하라.
+        - 없는 내용을 추론하지 마라.
+        - 점수는 0~100 사이 정수로 반환하라.
+        - 반드시 JSON 형식으로만 응답하라.
+
+        %s
+
+        [경험 목록]
+        %s
+
+        [해야 할 일]
+        1. 각 경험이 위 공고에 개별적으로 얼마나 활용 가능한지 평가하라. (usageScores)
+        2. 위 경험들을 포트폴리오 전체 관점에서 공고 요구사항을 얼마나 커버하는지 평가하라. (applicationScore)
+
+        반환 형식:
+        {
+          "usageScores": [
+            { "pieceId": 숫자, "score": 숫자 },
+            ...
+          ],
+          "applicationScore": 숫자
+        }
+        """
+        .formatted(buildJdContext(jd), buildExperienceList(experiences));
+  }
+
+  /** 공고, 자소서문항, 지원자의 경험들 간의 적합도 산출 프롬프트 */
+  public String buildQuestionCombinedPrompt(
+      Jd jd, JdQuestion question, List<Experience> experiences) {
+    return """
+        너는 채용 공고와 자소서 문항, 그리고 지원자의 경험 간의 적합도를 평가하는 시스템이다.
+
+        [규칙]
+        - 반드시 제공된 내용만 근거로 사용하라.
+        - 없는 내용을 추론하지 마라.
+        - 점수는 0~100 사이 정수로 반환하라.
+        - 반드시 JSON 형식으로만 응답하라.
+
+        %s
+
+        [자소서 문항]
+        %s
+
+        [경험 목록]
+        %s
+
+        [해야 할 일]
+        각 경험이 위 공고와 자소서 문항에 얼마나 적합한지 개별적으로 평가하라.
+
+        반환 형식:
+        {
+          "usageScores": [
+            { "pieceId": 숫자, "score": 숫자 },
+            ...
+          ]
+        }
+        """
+        .formatted(buildJdContext(jd), question.getContent(), buildExperienceList(experiences));
+  }
+
+  /** 하나의 경험이 공고와 연결되는 핵심키워드, 연결점, 작성가이드 반환하는 프롬프트 */
+  public String buildWritingGuidePrompt(Jd jd, JdQuestion question, List<Experience> experiences) {
+    return """
+        너는 자기소개서 작성을 도와주는 전문 커리어 코치이다.
+
+        [규칙]
+        - 반드시 제공된 내용만 근거로 사용하라.
+        - 없는 내용을 추론하거나 만들어내지 마라.
+        - 반드시 JSON 형식으로만 응답하라.
+        - 한국어로 작성하라.
+
+        %s
+
+        [자소서 문항]
+        %s
+
+        [선택된 경험 목록]
+        %s
+
+        [해야 할 일]
+        1. coreKeywords: 공고의 주요 업무, 필수 역량, 우대 역량, 소프트 스킬에 실제로 존재하는 단어나 구문만 최대 5개 추출하라.
+           위 공고 텍스트에 없는 단어는 절대 사용하지 마라. 10자 이내의 단어 또는 짧은 명사구로만 작성하라. 문장이나 설명 형태는 절대 사용하지 마라.
+           단독으로는 의미가 불분명한 범용적인 단어는 반드시 앞 단어와 결합한 명사구로 작성하라.
+        2. connectionToJd: 선택된 경험들을 종합적으로 보았을 때 공고의 어떤 요구사항들을 커버할 수 있는지 2문장 이내로 서술하라.
+        3. writingGuide: 자소서를 작성하는 사람의 입장에서, 각 경험의 어떤 내용을 자소서에 녹이면 공고에 어필이 될지 조언하라.
+           각 경험별로 경험 제목을 자연스럽게 문장에 녹여 "OOO 경험에서 ~을 언급하면 효과적입니다" 형태로 작성하라.
+           해당 경험의 Situation/Task/Action/Result/Taken에 실제로 존재하는 내용만 근거로 사용하고, 수치가 있다면 반드시 언급하라.
+           위 경험 데이터에 없는 수치, 사실, 성과를 절대 지어내거나 추론하지 마라.
+
+        [말투 규칙]
+        - 모든 문장은 반드시 '~합니다', '~입니다', '~습니다' 체로 통일하라.
+        - '~하십시오', '~이다', '~한다', '~세요', '~어요' 등 다른 말투는 절대 사용하지 마라.
+
+        반환 형식:
+        {
+          "coreKeywords": ["키워드1", "키워드2", ...],
+          "connectionToJd": "공고와의 연결점 서술",
+          "writingGuide": "구체적인 작성 팁"
+        }
+        """
+        .formatted(buildJdContext(jd), question.getContent(), buildExperienceList(experiences));
+  }
+
+  /** 하나의 경험과 공고를 분석해서 경험의 강점, 보완할점, 작성가이드를 반환하는 프롬프트 */
+  public String buildExperienceDetailPrompt(Jd jd, Experience experience) {
+    return """
+        너는 채용 공고와 지원자 경험을 비교 분석하는 전문가이다.
+
+        [규칙]
+        - 반드시 제공된 내용만 근거로 사용하라.
+        - 없는 내용을 추론하거나 만들어내지 마라.
+        - 반드시 JSON 형식으로만 응답하라.
+        - 한국어로 작성하라.
+
+        %s
+
+        [경험 정보]
+        - 제목: %s
+        - 한줄소개: %s
+        - Situation: %s
+        - Task: %s
+        - Action: %s
+        - Result: %s
+        - Taken: %s
+
+        [해야 할 일]
+        1. strengths: 이 경험이 공고 요구사항과 어떻게 직접적으로 연결되는지 2문장 이내로 서술하라.
+        2. weaknesses: 이 경험에서 보완하면 공고에 더 잘 어필할 수 있는 점을 2문장 이내로 서술하라. 경험 자체의 아쉬운 점이 아니라 공고 관점에서 추가하면 좋을 내용을 제안하라.
+        3. usageGuide: 이 경험을 자기소개서에서 어필할 때 어떤 포인트를 강조하면 좋을지 조언하는 방식으로 2문장 이내로 서술하라. "~을 강조하면 좋습니다", "~을 언급하면 효과적입니다" 처럼 조언하는 말투로 작성하라.
+        4. highlightKeywords: 공고 텍스트에서 이 경험과 직접 연관되는 핵심 키워드를 최대 5개 추출하라.
+           반드시 공고의 주요 업무, 필수 역량, 우대 역량, 기술 스택, 소프트 스킬에 실제로 존재하는 단어나 구문만 반환하라.
+           각 키워드가 공고의 어느 섹션에서 나왔는지 sources에 함께 반환하라.
+           sources는 다음 값 중에서만 선택하라: mainResponsibilities, requiredQualifications, preferredQualifications, hardSkill, softSkill
+           키워드는 반드시 10자 이내의 단어 또는 짧은 명사구로만 작성하라.
+           문장이나 설명 형태는 절대 사용하지 마라.
+           여러 단어를 쉼표로 합쳐서 하나의 키워드로 만들지 마라.
+
+        [말투 규칙]
+        - 모든 문장은 반드시 '~합니다', '~입니다', '~습니다' 체로 통일하라.
+        - '~하십시오', '~이다', '~한다', '~세요', '~어요' 등 다른 말투는 절대 사용하지 마라.
+
+        반환 형식:
+        {
+          "strengths": "좋은 점 서술",
+          "weaknesses": "보완하면 좋을 점 서술",
+          "usageGuide": "자기소개서 어필 방법 서술",
+          "highlightKeywords": [
+            { "keyword": "키워드1", "sources": ["mainResponsibilities", "hardSkill"] },
+            ...
+          ]
+        }
+        """
+        .formatted(
+            buildJdContext(jd),
+            experience.getTitle(),
+            experience.getOneLineIntro(),
+            experience.getSituation(),
+            experience.getTask(),
+            experience.getAct(),
+            experience.getResult(),
+            experience.getTaken());
+  }
+
+  private String buildJdContext(Jd jd) {
+    return """
+        [공고 정보]
+        - 기업: %s
+        - 직무: %s
+        - 주요 업무: %s
+        - 필수 역량: %s
+        - 우대 역량: %s
+        - 기술 스택: %s
+        - 소프트 스킬: %s"""
+        .formatted(
+            jd.getCompanyName(),
+            jd.getRecruitmentField(),
+            jd.getMainResponsibilities(),
+            jd.getRequiredQualifications(),
+            jd.getPreferredQualifications(),
+            jd.getHardSkill(),
+            jd.getSoftSkill());
+  }
+
+  private String buildExperienceList(List<Experience> experiences) {
+    return IntStream.range(0, experiences.size())
+        .mapToObj(
+            i -> {
+              Experience e = experiences.get(i);
+              return """
+              경험 %d (pieceId: %d):
+              - 제목: %s
+              - 한줄소개: %s
+              - Situation: %s
+              - Task: %s
+              - Action: %s
+              - Result: %s
+              - Taken: %s
+              """
+                  .formatted(
+                      i + 1,
+                      e.getPiece().getId(),
+                      e.getTitle(),
+                      e.getOneLineIntro(),
+                      e.getSituation(),
+                      e.getTask(),
+                      e.getAct(),
+                      e.getResult(),
+                      e.getTaken());
+            })
+        .collect(Collectors.joining("\n"));
+  }
+}

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/JdMatchPromptBuilder.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/JdMatchPromptBuilder.java
@@ -173,13 +173,13 @@ public class JdMatchPromptBuilder {
         """
         .formatted(
             buildJdContext(jd),
-            experience.getTitle(),
-            experience.getOneLineIntro(),
-            experience.getSituation(),
-            experience.getTask(),
-            experience.getAct(),
-            experience.getResult(),
-            experience.getTaken());
+            defaultIfNull(experience.getTitle()),
+            defaultIfNull(experience.getOneLineIntro()),
+            defaultIfNull(experience.getSituation()),
+            defaultIfNull(experience.getTask()),
+            defaultIfNull(experience.getAct()),
+            defaultIfNull(experience.getResult()),
+            defaultIfNull(experience.getTaken()));
   }
 
   private String buildJdContext(Jd jd) {
@@ -193,13 +193,17 @@ public class JdMatchPromptBuilder {
         - 기술 스택: %s
         - 소프트 스킬: %s"""
         .formatted(
-            jd.getCompanyName(),
-            jd.getRecruitmentField(),
-            jd.getMainResponsibilities(),
-            jd.getRequiredQualifications(),
-            jd.getPreferredQualifications(),
-            jd.getHardSkill(),
-            jd.getSoftSkill());
+            defaultIfNull(jd.getCompanyName()),
+            defaultIfNull(jd.getRecruitmentField()),
+            defaultIfNull(jd.getMainResponsibilities()),
+            defaultIfNull(jd.getRequiredQualifications()),
+            defaultIfNull(jd.getPreferredQualifications()),
+            defaultIfNull(jd.getHardSkill()),
+            defaultIfNull(jd.getSoftSkill()));
+  }
+
+  private String defaultIfNull(String value) {
+    return value == null ? "" : value;
   }
 
   private String buildExperienceList(List<Experience> experiences) {
@@ -220,13 +224,13 @@ public class JdMatchPromptBuilder {
                   .formatted(
                       i + 1,
                       e.getPiece().getId(),
-                      e.getTitle(),
-                      e.getOneLineIntro(),
-                      e.getSituation(),
-                      e.getTask(),
-                      e.getAct(),
-                      e.getResult(),
-                      e.getTaken());
+                      defaultIfNull(e.getTitle()),
+                      defaultIfNull(e.getOneLineIntro()),
+                      defaultIfNull(e.getSituation()),
+                      defaultIfNull(e.getTask()),
+                      defaultIfNull(e.getAct()),
+                      defaultIfNull(e.getResult()),
+                      defaultIfNull(e.getTaken()));
             })
         .collect(Collectors.joining("\n"));
   }

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -15,6 +14,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kusitms.kkium.experience.domain.Experience;
 import com.kusitms.kkium.jd.domain.Jd;
+import com.kusitms.kkium.jd.domain.JdQuestion;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,28 +28,55 @@ public class LlmMatchScoreService {
 
   private final WebClient webClient;
   private final String apiKey;
+  private final JdMatchPromptBuilder promptBuilder;
 
-  public LlmMatchScoreService(WebClient webClient, @Value("${openai.api.key}") String apiKey) {
+  public LlmMatchScoreService(
+      WebClient webClient,
+      @Value("${openai.api.key}") String apiKey,
+      JdMatchPromptBuilder promptBuilder) {
     this.webClient = webClient;
     this.apiKey = apiKey;
+    this.promptBuilder = promptBuilder;
   }
 
   /** LLM 1번 호출로 활용 적합도(경험별) + 지원 적합도(포트폴리오 종합)를 한꺼번에 반환 */
   public LlmMatchResult scoreAll(Jd jd, List<Experience> experiences) {
     if (experiences.isEmpty()) return new LlmMatchResult(Map.of(), 0);
-    String prompt = buildCombinedPrompt(jd, experiences);
+    String prompt = promptBuilder.buildCombinedPrompt(jd, experiences);
     String response = callOpenAi(prompt);
     return parseCombinedResult(response, experiences);
   }
 
+  /** 문항 컨텍스트를 포함해 활용 적합도를 계산 (자소서 작성 화면 경험 선택 모달용) */
+  public LlmQuestionMatchResult scoreAllByQuestion(
+      Jd jd, JdQuestion question, List<Experience> experiences) {
+    if (experiences.isEmpty()) return new LlmQuestionMatchResult(Map.of());
+    String prompt = promptBuilder.buildQuestionCombinedPrompt(jd, question, experiences);
+    String response = callOpenAi(prompt);
+    return parseQuestionMatchResult(response, experiences);
+  }
+
   /** 선택된 경험들을 기반으로 자소서 작성 가이드 생성 */
   public LlmWritingGuideResult generateWritingGuide(
-      Jd jd, com.kusitms.kkium.jd.domain.JdQuestion question, List<Experience> experiences) {
+      Jd jd, JdQuestion question, List<Experience> experiences) {
     if (experiences.isEmpty()) return LlmWritingGuideResult.empty();
-    String prompt = buildWritingGuidePrompt(jd, question, experiences);
+    String prompt = promptBuilder.buildWritingGuidePrompt(jd, question, experiences);
     String response = callOpenAi(prompt);
     return parseWritingGuideResult(response);
   }
+
+  /** 경험 카드 클릭 시 상세 분석 */
+  public LlmExperienceDetailResult analyzeExperienceDetail(Jd jd, Experience experience) {
+    String prompt = promptBuilder.buildExperienceDetailPrompt(jd, experience);
+    String response = callOpenAi(prompt);
+    return parseExperienceDetailResult(response);
+  }
+
+  // Records
+
+  public record LlmMatchResult(Map<Long, Integer> usageScores, int applicationScore) {}
+
+  public record LlmQuestionMatchResult(Map<Long, Integer> usageScores) {}
 
   public record LlmWritingGuideResult(
       List<String> coreKeywords, String connectionToJd, String writingGuide) {
@@ -57,26 +84,6 @@ public class LlmMatchScoreService {
     public static LlmWritingGuideResult empty() {
       return new LlmWritingGuideResult(List.of(), "분석에 실패했습니다.", "분석에 실패했습니다.");
     }
-  }
-
-  /** 문항 컨텍스트를 포함해 활용 적합도를 계산 (자소서 작성 화면 경험 선택 모달용) */
-  public LlmQuestionMatchResult scoreAllByQuestion(
-      Jd jd, com.kusitms.kkium.jd.domain.JdQuestion question, List<Experience> experiences) {
-    if (experiences.isEmpty()) return new LlmQuestionMatchResult(Map.of());
-    String prompt = buildQuestionCombinedPrompt(jd, question, experiences);
-    String response = callOpenAi(prompt);
-    return parseQuestionMatchResult(response, experiences);
-  }
-
-  public record LlmQuestionMatchResult(Map<Long, Integer> usageScores) {}
-
-  public record LlmMatchResult(Map<Long, Integer> usageScores, int applicationScore) {}
-
-  /** 경험 카드 클릭 시 상세 분석 */
-  public LlmExperienceDetailResult analyzeExperienceDetail(Jd jd, Experience experience) {
-    String prompt = buildExperienceDetailPrompt(jd, experience);
-    String response = callOpenAi(prompt);
-    return parseExperienceDetailResult(response);
   }
 
   public record LlmExperienceDetailResult(
@@ -92,279 +99,7 @@ public class LlmMatchScoreService {
 
   public record HighlightKeyword(String keyword, List<String> sources) {}
 
-  private String buildWritingGuidePrompt(
-      Jd jd, com.kusitms.kkium.jd.domain.JdQuestion question, List<Experience> experiences) {
-    String expList = buildExperienceList(experiences);
-    return """
-        너는 자기소개서 작성을 도와주는 전문 커리어 코치이다.
-
-        [규칙]
-        - 반드시 제공된 내용만 근거로 사용하라.
-        - 없는 내용을 추론하거나 만들어내지 마라.
-        - 반드시 JSON 형식으로만 응답하라.
-        - 한국어로 작성하라.
-
-        [공고 정보]
-        - 기업: %s
-        - 직무: %s
-        - 주요 업무: %s
-        - 필수 역량: %s
-        - 우대 역량: %s
-        - 기술 스택: %s
-        - 소프트 스킬: %s
-
-        [자소서 문항]
-        %s
-
-        [선택된 경험 목록]
-        %s
-
-        [해야 할 일]
-        1. coreKeywords: 공고의 주요 업무, 필수 역량, 우대 역량, 소프트 스킬에 실제로 존재하는 단어나 구문만 최대 5개 추출하라.
-           위 공고 텍스트에 없는 단어는 절대 사용하지 마라. 10자 이내의 단어 또는 짧은 명사구로만 작성하라. 문장이나 설명 형태는 절대 사용하지 마라.
-           단독으로는 의미가 불분명한 범용적인 단어는 반드시 앞 단어와 결합한 명사구로 작성하라.
-        2. connectionToJd: 선택된 경험들을 종합적으로 보았을 때 공고의 어떤 요구사항들을 커버할 수 있는지 2문장 이내로 서술하라.
-        3. writingGuide: 자소서를 작성하는 사람의 입장에서, 각 경험의 어떤 내용을 자소서에 녹이면 공고에 어필이 될지 조언하라.
-           각 경험별로 경험 제목을 자연스럽게 문장에 녹여 "OOO 경험에서 ~을 언급하면 효과적입니다" 형태로 작성하라.
-           해당 경험의 Situation/Task/Action/Result/Taken에 실제로 존재하는 내용만 근거로 사용하고, 수치가 있다면 반드시 언급하라.
-           위 경험 데이터에 없는 수치, 사실, 성과를 절대 지어내거나 추론하지 마라.
-
-        [말투 규칙]
-        - 모든 문장은 반드시 '~합니다', '~입니다', '~습니다' 체로 통일하라.
-        - '~하십시오', '~이다', '~한다', '~세요', '~어요' 등 다른 말투는 절대 사용하지 마라.
-
-        반환 형식:
-        {
-          "coreKeywords": ["키워드1", "키워드2", ...],
-          "connectionToJd": "공고와의 연결점 서술",
-          "writingGuide": "구체적인 작성 팁"
-        }
-        """
-        .formatted(
-            jd.getCompanyName(),
-            jd.getRecruitmentField(),
-            jd.getMainResponsibilities(),
-            jd.getRequiredQualifications(),
-            jd.getPreferredQualifications(),
-            jd.getHardSkill(),
-            jd.getSoftSkill(),
-            question.getContent(),
-            expList);
-  }
-
-  private LlmWritingGuideResult parseWritingGuideResult(String response) {
-    if (response == null) return LlmWritingGuideResult.empty();
-    try {
-      JsonNode parsed = OBJECT_MAPPER.readTree(response);
-      List<String> keywords = new ArrayList<>();
-      for (JsonNode k : parsed.path("coreKeywords")) keywords.add(k.asText());
-      return new LlmWritingGuideResult(
-          keywords,
-          parsed.path("connectionToJd").asText("분석에 실패했습니다."),
-          parsed.path("writingGuide").asText("분석에 실패했습니다."));
-    } catch (Exception e) {
-      log.warn("작성 가이드 LLM 응답 파싱 실패: {}", e.getMessage());
-      return LlmWritingGuideResult.empty();
-    }
-  }
-
-  private String buildQuestionCombinedPrompt(
-      Jd jd, com.kusitms.kkium.jd.domain.JdQuestion question, List<Experience> experiences) {
-    String expList = buildExperienceList(experiences);
-    return """
-        너는 채용 공고와 자소서 문항, 그리고 지원자의 경험 간의 적합도를 평가하는 시스템이다.
-
-        [규칙]
-        - 반드시 제공된 내용만 근거로 사용하라.
-        - 없는 내용을 추론하지 마라.
-        - 점수는 0~100 사이 정수로 반환하라.
-        - 반드시 JSON 형식으로만 응답하라.
-
-        [공고 정보]
-        - 기업: %s
-        - 직무: %s
-        - 주요 업무: %s
-        - 필수 역량: %s
-        - 우대 역량: %s
-        - 기술 스택: %s
-        - 소프트 스킬: %s
-
-        [자소서 문항]
-        %s
-
-        [경험 목록]
-        %s
-
-        [해야 할 일]
-        각 경험이 위 공고와 자소서 문항에 얼마나 적합한지 개별적으로 평가하라.
-
-        반환 형식:
-        {
-          "usageScores": [
-            { "pieceId": 숫자, "score": 숫자 },
-            ...
-          ]
-        }
-        """
-        .formatted(
-            jd.getCompanyName(),
-            jd.getRecruitmentField(),
-            jd.getMainResponsibilities(),
-            jd.getRequiredQualifications(),
-            jd.getPreferredQualifications(),
-            jd.getHardSkill(),
-            jd.getSoftSkill(),
-            question.getContent(),
-            expList);
-  }
-
-  private String buildExperienceList(List<Experience> experiences) {
-    return IntStream.range(0, experiences.size())
-        .mapToObj(
-            i -> {
-              Experience e = experiences.get(i);
-              return """
-              경험 %d (pieceId: %d):
-              - 제목: %s
-              - 한줄소개: %s
-              - Situation: %s
-              - Task: %s
-              - Action: %s
-              - Result: %s
-              - Taken: %s
-              """
-                  .formatted(
-                      i + 1,
-                      e.getPiece().getId(),
-                      e.getTitle(),
-                      e.getOneLineIntro(),
-                      e.getSituation(),
-                      e.getTask(),
-                      e.getAct(),
-                      e.getResult(),
-                      e.getTaken());
-            })
-        .collect(Collectors.joining("\n"));
-  }
-
-  private String buildCombinedPrompt(Jd jd, List<Experience> experiences) {
-    String expList = buildExperienceList(experiences);
-    return """
-        너는 채용 공고와 경험의 적합도를 평가하는 시스템이다.
-
-        [규칙]
-        - 반드시 제공된 내용만 근거로 사용하라.
-        - 없는 내용을 추론하지 마라.
-        - 점수는 0~100 사이 정수로 반환하라.
-        - 반드시 JSON 형식으로만 응답하라.
-
-        [공고 정보]
-        - 기업: %s
-        - 직무: %s
-        - 주요 업무: %s
-        - 필수 역량: %s
-        - 우대 역량: %s
-        - 기술 스택: %s
-        - 소프트 스킬: %s
-
-        [경험 목록]
-        %s
-
-        [해야 할 일]
-        1. 각 경험이 위 공고에 개별적으로 얼마나 활용 가능한지 평가하라. (usageScores)
-        2. 위 경험들을 포트폴리오 전체 관점에서 공고 요구사항을 얼마나 커버하는지 평가하라. (applicationScore)
-
-        반환 형식:
-        {
-          "usageScores": [
-            { "pieceId": 숫자, "score": 숫자 },
-            ...
-          ],
-          "applicationScore": 숫자
-        }
-        """
-        .formatted(
-            jd.getCompanyName(),
-            jd.getRecruitmentField(),
-            jd.getMainResponsibilities(),
-            jd.getRequiredQualifications(),
-            jd.getPreferredQualifications(),
-            jd.getHardSkill(),
-            jd.getSoftSkill(),
-            expList);
-  }
-
-  private String buildExperienceDetailPrompt(Jd jd, Experience experience) {
-    return """
-        너는 채용 공고와 지원자 경험을 비교 분석하는 전문가이다.
-
-        [규칙]
-        - 반드시 제공된 내용만 근거로 사용하라.
-        - 없는 내용을 추론하거나 만들어내지 마라.
-        - 반드시 JSON 형식으로만 응답하라.
-        - 한국어로 작성하라.
-
-        [공고 정보]
-        - 기업: %s
-        - 직무: %s
-        - 주요 업무: %s
-        - 필수 역량: %s
-        - 우대 역량: %s
-        - 기술 스택: %s
-        - 소프트 스킬: %s
-
-        [경험 정보]
-        - 제목: %s
-        - 한줄소개: %s
-        - Situation: %s
-        - Task: %s
-        - Action: %s
-        - Result: %s
-        - Taken: %s
-
-        [해야 할 일]
-        1. strengths: 이 경험이 공고 요구사항과 어떻게 직접적으로 연결되는지 2문장 이내로 서술하라.
-        2. weaknesses: 이 경험에서 보완하면 공고에 더 잘 어필할 수 있는 점을 2문장 이내로 서술하라. 경험 자체의 아쉬운 점이 아니라 공고 관점에서 추가하면 좋을 내용을 제안하라.
-        3. usageGuide: 이 경험을 자기소개서에서 어필할 때 어떤 포인트를 강조하면 좋을지 조언하는 방식으로 2문장 이내로 서술하라. "~을 강조하면 좋습니다", "~을 언급하면 효과적입니다" 처럼 조언하는 말투로 작성하라.
-        4. highlightKeywords: 공고 텍스트에서 이 경험과 직접 연관되는 핵심 키워드를 최대 5개 추출하라.
-           반드시 공고의 주요 업무, 필수 역량, 우대 역량, 기술 스택, 소프트 스킬에 실제로 존재하는 단어나 구문만 반환하라.
-           각 키워드가 공고의 어느 섹션에서 나왔는지 sources에 함께 반환하라.
-           sources는 다음 값 중에서만 선택하라: mainResponsibilities, requiredQualifications, preferredQualifications, hardSkill, softSkill
-           키워드는 반드시 10자 이내의 단어 또는 짧은 명사구로만 작성하라.
-           문장이나 설명 형태는 절대 사용하지 마라.
-           여러 단어를 쉼표로 합쳐서 하나의 키워드로 만들지 마라.
-
-        [말투 규칙]
-        - 모든 문장은 반드시 '~합니다', '~입니다', '~습니다' 체로 통일하라.
-        - '~하십시오', '~이다', '~한다', '~세요', '~어요' 등 다른 말투는 절대 사용하지 마라.
-
-        반환 형식:
-        {
-          "strengths": "좋은 점 서술",
-          "weaknesses": "보완하면 좋을 점 서술",
-          "usageGuide": "자기소개서 어필 방법 서술",
-          "highlightKeywords": [
-            { "keyword": "키워드1", "sources": ["mainResponsibilities", "hardSkill"] },
-            ...
-          ]
-        }
-        """
-        .formatted(
-            jd.getCompanyName(),
-            jd.getRecruitmentField(),
-            jd.getMainResponsibilities(),
-            jd.getRequiredQualifications(),
-            jd.getPreferredQualifications(),
-            jd.getHardSkill(),
-            jd.getSoftSkill(),
-            experience.getTitle(),
-            experience.getOneLineIntro(),
-            experience.getSituation(),
-            experience.getTask(),
-            experience.getAct(),
-            experience.getResult(),
-            experience.getTaken());
-  }
+  // API 호출
 
   private String callOpenAi(String prompt) {
     Map<String, Object> body =
@@ -392,51 +127,48 @@ public class LlmMatchScoreService {
     }
   }
 
+  // 응답 파싱
+
+  private LlmMatchResult parseCombinedResult(String response, List<Experience> experiences) {
+    Map<Long, Integer> fallback = buildFallbackScores(experiences);
+    if (response == null) return new LlmMatchResult(fallback, 0);
+    try {
+      JsonNode parsed = OBJECT_MAPPER.readTree(response);
+      Map<Long, Integer> usageScores = parseUsageScores(parsed, fallback);
+      return new LlmMatchResult(
+          usageScores, Math.max(0, Math.min(100, parsed.path("applicationScore").asInt(0))));
+    } catch (Exception e) {
+      log.warn("LLM 응답 파싱 실패: {}", e.getMessage());
+      return new LlmMatchResult(fallback, 0);
+    }
+  }
+
   private LlmQuestionMatchResult parseQuestionMatchResult(
       String response, List<Experience> experiences) {
-    Map<Long, Integer> fallback =
-        experiences.stream()
-            .collect(
-                Collectors.toMap(
-                    e -> e.getPiece().getId(), e -> 50, (existing, replacement) -> existing));
+    Map<Long, Integer> fallback = buildFallbackScores(experiences);
     if (response == null) return new LlmQuestionMatchResult(fallback);
     try {
       JsonNode parsed = OBJECT_MAPPER.readTree(response);
-      Map<Long, Integer> usageScores = new HashMap<>();
-      for (JsonNode item : parsed.path("usageScores")) {
-        usageScores.put(
-            item.path("pieceId").asLong(),
-            Math.max(0, Math.min(100, item.path("score").asInt(50))));
-      }
-      fallback.forEach(usageScores::putIfAbsent);
-      return new LlmQuestionMatchResult(usageScores);
+      return new LlmQuestionMatchResult(parseUsageScores(parsed, fallback));
     } catch (Exception e) {
       log.warn("문항별 LLM 응답 파싱 실패: {}", e.getMessage());
       return new LlmQuestionMatchResult(fallback);
     }
   }
 
-  private LlmMatchResult parseCombinedResult(String response, List<Experience> experiences) {
-    Map<Long, Integer> fallback =
-        experiences.stream()
-            .collect(
-                Collectors.toMap(
-                    e -> e.getPiece().getId(), e -> 50, (existing, replacement) -> existing));
-    if (response == null) return new LlmMatchResult(fallback, 0);
+  private LlmWritingGuideResult parseWritingGuideResult(String response) {
+    if (response == null) return LlmWritingGuideResult.empty();
     try {
       JsonNode parsed = OBJECT_MAPPER.readTree(response);
-      Map<Long, Integer> usageScores = new HashMap<>();
-      for (JsonNode item : parsed.path("usageScores")) {
-        usageScores.put(
-            item.path("pieceId").asLong(),
-            Math.max(0, Math.min(100, item.path("score").asInt(50))));
-      }
-      fallback.forEach(usageScores::putIfAbsent);
-      return new LlmMatchResult(
-          usageScores, Math.max(0, Math.min(100, parsed.path("applicationScore").asInt(0))));
+      List<String> keywords = new ArrayList<>();
+      for (JsonNode k : parsed.path("coreKeywords")) keywords.add(k.asText());
+      return new LlmWritingGuideResult(
+          keywords,
+          parsed.path("connectionToJd").asText("분석에 실패했습니다."),
+          parsed.path("writingGuide").asText("분석에 실패했습니다."));
     } catch (Exception e) {
-      log.warn("LLM 응답 파싱 실패: {}", e.getMessage());
-      return new LlmMatchResult(fallback, 0);
+      log.warn("작성 가이드 LLM 응답 파싱 실패: {}", e.getMessage());
+      return LlmWritingGuideResult.empty();
     }
   }
 
@@ -471,5 +203,24 @@ public class LlmMatchScoreService {
       log.warn("경험 상세 분석 LLM 응답 파싱 실패: {}", e.getMessage());
       return LlmExperienceDetailResult.empty();
     }
+  }
+
+  // 공통 유틸
+
+  private Map<Long, Integer> buildFallbackScores(List<Experience> experiences) {
+    return experiences.stream()
+        .collect(
+            Collectors.toMap(
+                e -> e.getPiece().getId(), e -> 50, (existing, replacement) -> existing));
+  }
+
+  private Map<Long, Integer> parseUsageScores(JsonNode parsed, Map<Long, Integer> fallback) {
+    Map<Long, Integer> usageScores = new HashMap<>();
+    for (JsonNode item : parsed.path("usageScores")) {
+      usageScores.put(
+          item.path("pieceId").asLong(), Math.max(0, Math.min(100, item.path("score").asInt(50))));
+    }
+    fallback.forEach(usageScores::putIfAbsent);
+    return usageScores;
   }
 }

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
@@ -15,6 +15,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kusitms.kkium.experience.domain.Experience;
 import com.kusitms.kkium.jd.domain.Jd;
 import com.kusitms.kkium.jd.domain.JdQuestion;
+import com.kusitms.kkium.jd.utils.llm.result.*;
+import com.kusitms.kkium.jd.utils.llm.result.HighlightKeyword;
+import com.kusitms.kkium.jd.utils.llm.result.LlmExperienceDetailResult;
+import com.kusitms.kkium.jd.utils.llm.result.LlmMatchResult;
+import com.kusitms.kkium.jd.utils.llm.result.LlmQuestionMatchResult;
+import com.kusitms.kkium.jd.utils.llm.result.LlmWritingGuideResult;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -72,35 +78,7 @@ public class LlmMatchScoreService {
     return parseExperienceDetailResult(response);
   }
 
-  // Records
-
-  public record LlmMatchResult(Map<Long, Integer> usageScores, int applicationScore) {}
-
-  public record LlmQuestionMatchResult(Map<Long, Integer> usageScores) {}
-
-  public record LlmWritingGuideResult(
-      List<String> coreKeywords, String connectionToJd, String writingGuide) {
-
-    public static LlmWritingGuideResult empty() {
-      return new LlmWritingGuideResult(List.of(), "분석에 실패했습니다.", "분석에 실패했습니다.");
-    }
-  }
-
-  public record LlmExperienceDetailResult(
-      String strengths,
-      String weaknesses,
-      String usageGuide,
-      List<HighlightKeyword> highlightKeywords) {
-
-    public static LlmExperienceDetailResult empty() {
-      return new LlmExperienceDetailResult("분석에 실패했습니다.", "분석에 실패했습니다.", "분석에 실패했습니다.", List.of());
-    }
-  }
-
-  public record HighlightKeyword(String keyword, List<String> sources) {}
-
   // API 호출
-
   private String callOpenAi(String prompt) {
     Map<String, Object> body =
         Map.of(

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/result/HighlightKeyword.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/result/HighlightKeyword.java
@@ -1,0 +1,5 @@
+package com.kusitms.kkium.jd.utils.llm.result;
+
+import java.util.List;
+
+public record HighlightKeyword(String keyword, List<String> sources) {}

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/result/LlmExperienceDetailResult.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/result/LlmExperienceDetailResult.java
@@ -1,0 +1,14 @@
+package com.kusitms.kkium.jd.utils.llm.result;
+
+import java.util.List;
+
+public record LlmExperienceDetailResult(
+    String strengths,
+    String weaknesses,
+    String usageGuide,
+    List<HighlightKeyword> highlightKeywords) {
+
+  public static LlmExperienceDetailResult empty() {
+    return new LlmExperienceDetailResult("분석에 실패했습니다.", "분석에 실패했습니다.", "분석에 실패했습니다.", List.of());
+  }
+}

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/result/LlmMatchResult.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/result/LlmMatchResult.java
@@ -1,0 +1,5 @@
+package com.kusitms.kkium.jd.utils.llm.result;
+
+import java.util.Map;
+
+public record LlmMatchResult(Map<Long, Integer> usageScores, int applicationScore) {}

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/result/LlmQuestionMatchResult.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/result/LlmQuestionMatchResult.java
@@ -1,0 +1,5 @@
+package com.kusitms.kkium.jd.utils.llm.result;
+
+import java.util.Map;
+
+public record LlmQuestionMatchResult(Map<Long, Integer> usageScores) {}

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/result/LlmWritingGuideResult.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/result/LlmWritingGuideResult.java
@@ -1,0 +1,11 @@
+package com.kusitms.kkium.jd.utils.llm.result;
+
+import java.util.List;
+
+public record LlmWritingGuideResult(
+    List<String> coreKeywords, String connectionToJd, String writingGuide) {
+
+  public static LlmWritingGuideResult empty() {
+    return new LlmWritingGuideResult(List.of(), "분석에 실패했습니다.", "분석에 실패했습니다.");
+  }
+}

--- a/src/main/java/com/kusitms/kkium/resume/service/ResumeQuestionExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/resume/service/ResumeQuestionExperienceService.java
@@ -28,6 +28,7 @@ import com.kusitms.kkium.jd.repository.JdMatchRepository.PieceSimilarity;
 import com.kusitms.kkium.jd.repository.JdQuestionRepository;
 import com.kusitms.kkium.jd.repository.JdRepository;
 import com.kusitms.kkium.jd.utils.llm.LlmMatchScoreService;
+import com.kusitms.kkium.jd.utils.llm.result.LlmQuestionMatchResult;
 import com.kusitms.kkium.resume.dto.response.ResumeQuestionExperienceResponse;
 import com.kusitms.kkium.resume.dto.response.ResumeQuestionExperienceResponse.ExperienceMatchItem;
 
@@ -81,7 +82,7 @@ public class ResumeQuestionExperienceService {
                     (existing, replacement) -> existing));
 
     // 5. LLM 호출 — 문항 content를 추가 컨텍스트로 포함
-    LlmMatchScoreService.LlmQuestionMatchResult llmResult =
+    LlmQuestionMatchResult llmResult =
         llmMatchScoreService.scoreAllByQuestion(jd, question, allExperiences);
     Map<Long, Integer> llmScoreMap = llmResult.usageScores();
 

--- a/src/main/java/com/kusitms/kkium/resume/service/ResumeWritingGuideService.java
+++ b/src/main/java/com/kusitms/kkium/resume/service/ResumeWritingGuideService.java
@@ -19,7 +19,7 @@ import com.kusitms.kkium.jd.domain.JdQuestion;
 import com.kusitms.kkium.jd.repository.JdQuestionRepository;
 import com.kusitms.kkium.jd.repository.JdRepository;
 import com.kusitms.kkium.jd.utils.llm.LlmMatchScoreService;
-import com.kusitms.kkium.jd.utils.llm.LlmMatchScoreService.LlmWritingGuideResult;
+import com.kusitms.kkium.jd.utils.llm.result.LlmWritingGuideResult;
 import com.kusitms.kkium.resume.dto.response.ResumeWritingGuideResponse;
 
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #144 

## ✏️ 작업 내용

- buildJdContext(Jd jd) 메서드 추출로 JD 공고 정보 블록 중복 제거
- buildPrompt() 메서드들을 JdMatchPromptBuilder 클래스로 분리

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
