### PR TITLE
[REFACTOR] resolvePeriodBulk 중복 제거 및 ExperiencePeriodResolver 추출

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/service/ExperiencePeriodResolver.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperiencePeriodResolver.java
@@ -1,0 +1,78 @@
+package com.kusitms.kkium.experience.service;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.kusitms.kkium.experience.domain.Experience;
+import com.kusitms.kkium.experience.domain.type.PieceType;
+import com.kusitms.kkium.experience.repository.ActivityRepository;
+import com.kusitms.kkium.experience.repository.CareerRepository;
+import com.kusitms.kkium.experience.repository.EducationRepository;
+import com.kusitms.kkium.experience.repository.EtcRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ExperiencePeriodResolver {
+
+  private final ActivityRepository activityRepository;
+  private final CareerRepository careerRepository;
+  private final EducationRepository educationRepository;
+  private final EtcRepository etcRepository;
+
+  public Map<Long, LocalDate[]> resolvePeriodBulk(List<Experience> experiences) {
+    Map<Long, LocalDate[]> periodMap = new HashMap<>();
+
+    Map<PieceType, List<Long>> byType =
+        experiences.stream()
+            .collect(
+                Collectors.groupingBy(
+                    e -> e.getPiece().getType(),
+                    Collectors.mapping(Experience::getId, Collectors.toList())));
+
+    if (byType.containsKey(PieceType.ACTIVITY)) {
+      activityRepository
+          .findByExperienceIdIn(byType.get(PieceType.ACTIVITY))
+          .forEach(
+              a ->
+                  periodMap.put(
+                      a.getExperience().getId(),
+                      new LocalDate[] {a.getStartDate(), a.getEndDate()}));
+    }
+    if (byType.containsKey(PieceType.CAREER)) {
+      careerRepository
+          .findByExperienceIdIn(byType.get(PieceType.CAREER))
+          .forEach(
+              c ->
+                  periodMap.put(
+                      c.getExperience().getId(),
+                      new LocalDate[] {c.getStartDate(), c.getEndDate()}));
+    }
+    if (byType.containsKey(PieceType.EDUCATION)) {
+      educationRepository
+          .findByExperienceIdIn(byType.get(PieceType.EDUCATION))
+          .forEach(
+              ed ->
+                  periodMap.put(
+                      ed.getExperience().getId(),
+                      new LocalDate[] {ed.getStartDate(), ed.getEndDate()}));
+    }
+    if (byType.containsKey(PieceType.ETC)) {
+      etcRepository
+          .findByExperienceIdIn(byType.get(PieceType.ETC))
+          .forEach(
+              etc ->
+                  periodMap.put(
+                      etc.getExperience().getId(),
+                      new LocalDate[] {etc.getStartDate(), etc.getEndDate()}));
+    }
+
+    return periodMap;
+  }
+}

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -65,6 +65,7 @@ public class ExperienceService {
   private final ExperienceEmbeddingService experienceEmbeddingService;
   private final JobTypeUpdateService jobTypeUpdateService;
   private final JdExperienceAnalysisService jdExperienceAnalysisService;
+  private final ExperiencePeriodResolver experiencePeriodResolver;
 
   @Transactional(readOnly = true)
   public ExperienceDetailResponse getDetail(Long userId, Long experienceId) {
@@ -173,7 +174,7 @@ public class ExperienceService {
                         t -> new TagResponse(t.getCategory(), t.getField()), Collectors.toList())));
 
     // 기간 벌크 조회
-    Map<Long, LocalDate[]> periodMap = resolvePeriodBulk(content, experienceIds);
+    Map<Long, LocalDate[]> periodMap = experiencePeriodResolver.resolvePeriodBulk(content);
 
     // sort_order 벌크 조회 (nextCursor 계산용)
     PieceType orderType = type != null ? type : PieceType.ALL;
@@ -204,57 +205,6 @@ public class ExperienceService {
 
     Integer nextCursor = hasNext ? sortOrderMap.get(content.get(content.size() - 1).getId()) : null;
     return new ExperienceListResponse(hasNext, nextCursor, cards);
-  }
-
-  private Map<Long, LocalDate[]> resolvePeriodBulk(
-      List<Experience> content, List<Long> experienceIds) {
-    Map<Long, LocalDate[]> periodMap = new HashMap<>();
-
-    Map<PieceType, List<Long>> byType =
-        content.stream()
-            .collect(
-                Collectors.groupingBy(
-                    e -> e.getPiece().getType(),
-                    Collectors.mapping(Experience::getId, Collectors.toList())));
-
-    if (byType.containsKey(PieceType.ACTIVITY)) {
-      activityRepository
-          .findByExperienceIdIn(byType.get(PieceType.ACTIVITY))
-          .forEach(
-              a ->
-                  periodMap.put(
-                      a.getExperience().getId(),
-                      new LocalDate[] {a.getStartDate(), a.getEndDate()}));
-    }
-    if (byType.containsKey(PieceType.CAREER)) {
-      careerRepository
-          .findByExperienceIdIn(byType.get(PieceType.CAREER))
-          .forEach(
-              c ->
-                  periodMap.put(
-                      c.getExperience().getId(),
-                      new LocalDate[] {c.getStartDate(), c.getEndDate()}));
-    }
-    if (byType.containsKey(PieceType.EDUCATION)) {
-      educationRepository
-          .findByExperienceIdIn(byType.get(PieceType.EDUCATION))
-          .forEach(
-              ed ->
-                  periodMap.put(
-                      ed.getExperience().getId(),
-                      new LocalDate[] {ed.getStartDate(), ed.getEndDate()}));
-    }
-    if (byType.containsKey(PieceType.ETC)) {
-      etcRepository
-          .findByExperienceIdIn(byType.get(PieceType.ETC))
-          .forEach(
-              etc ->
-                  periodMap.put(
-                      etc.getExperience().getId(),
-                      new LocalDate[] {etc.getStartDate(), etc.getEndDate()}));
-    }
-
-    return periodMap;
   }
 
   @Transactional

--- a/src/main/java/com/kusitms/kkium/resume/service/ResumeQuestionExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/resume/service/ResumeQuestionExperienceService.java
@@ -96,7 +96,6 @@ public class ResumeQuestionExperienceService {
     }
 
     // 7. 기간 벌크 조회
-    List<Long> experienceIds = allExperiences.stream().map(Experience::getId).toList();
     Map<Long, LocalDate[]> periodMap = experiencePeriodResolver.resolvePeriodBulk(allExperiences);
 
     // 8. 응답 구성 (usageFitScore 내림차순 정렬)

--- a/src/main/java/com/kusitms/kkium/resume/service/ResumeQuestionExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/resume/service/ResumeQuestionExperienceService.java
@@ -14,12 +14,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kusitms.kkium.experience.domain.Experience;
-import com.kusitms.kkium.experience.domain.type.PieceType;
-import com.kusitms.kkium.experience.repository.ActivityRepository;
-import com.kusitms.kkium.experience.repository.CareerRepository;
-import com.kusitms.kkium.experience.repository.EducationRepository;
-import com.kusitms.kkium.experience.repository.EtcRepository;
 import com.kusitms.kkium.experience.repository.ExperienceRepository;
+import com.kusitms.kkium.experience.service.ExperiencePeriodResolver;
 import com.kusitms.kkium.global.exception.BaseException;
 import com.kusitms.kkium.jd.domain.Jd;
 import com.kusitms.kkium.jd.domain.JdQuestion;
@@ -44,12 +40,9 @@ public class ResumeQuestionExperienceService {
   private final JdRepository jdRepository;
   private final JdQuestionRepository jdQuestionRepository;
   private final ExperienceRepository experienceRepository;
-  private final ActivityRepository activityRepository;
-  private final CareerRepository careerRepository;
-  private final EducationRepository educationRepository;
-  private final EtcRepository etcRepository;
   private final JdMatchRepository jdMatchRepository;
   private final LlmMatchScoreService llmMatchScoreService;
+  private final ExperiencePeriodResolver experiencePeriodResolver;
 
   public ResumeQuestionExperienceResponse getExperiencesWithFitScore(
       Long jdId, Long questionId, Long userId) {
@@ -104,7 +97,7 @@ public class ResumeQuestionExperienceService {
 
     // 7. 기간 벌크 조회
     List<Long> experienceIds = allExperiences.stream().map(Experience::getId).toList();
-    Map<Long, LocalDate[]> periodMap = resolvePeriodBulk(allExperiences, experienceIds);
+    Map<Long, LocalDate[]> periodMap = experiencePeriodResolver.resolvePeriodBulk(allExperiences);
 
     // 8. 응답 구성 (usageFitScore 내림차순 정렬)
     List<ExperienceMatchItem> items =
@@ -125,56 +118,5 @@ public class ResumeQuestionExperienceService {
             .toList();
 
     return new ResumeQuestionExperienceResponse(items);
-  }
-
-  private Map<Long, LocalDate[]> resolvePeriodBulk(
-      List<Experience> experiences, List<Long> experienceIds) {
-    Map<Long, LocalDate[]> periodMap = new HashMap<>();
-
-    Map<PieceType, List<Long>> byType =
-        experiences.stream()
-            .collect(
-                Collectors.groupingBy(
-                    e -> e.getPiece().getType(),
-                    Collectors.mapping(Experience::getId, Collectors.toList())));
-
-    if (byType.containsKey(PieceType.ACTIVITY)) {
-      activityRepository
-          .findByExperienceIdIn(byType.get(PieceType.ACTIVITY))
-          .forEach(
-              a ->
-                  periodMap.put(
-                      a.getExperience().getId(),
-                      new LocalDate[] {a.getStartDate(), a.getEndDate()}));
-    }
-    if (byType.containsKey(PieceType.CAREER)) {
-      careerRepository
-          .findByExperienceIdIn(byType.get(PieceType.CAREER))
-          .forEach(
-              c ->
-                  periodMap.put(
-                      c.getExperience().getId(),
-                      new LocalDate[] {c.getStartDate(), c.getEndDate()}));
-    }
-    if (byType.containsKey(PieceType.EDUCATION)) {
-      educationRepository
-          .findByExperienceIdIn(byType.get(PieceType.EDUCATION))
-          .forEach(
-              ed ->
-                  periodMap.put(
-                      ed.getExperience().getId(),
-                      new LocalDate[] {ed.getStartDate(), ed.getEndDate()}));
-    }
-    if (byType.containsKey(PieceType.ETC)) {
-      etcRepository
-          .findByExperienceIdIn(byType.get(PieceType.ETC))
-          .forEach(
-              etc ->
-                  periodMap.put(
-                      etc.getExperience().getId(),
-                      new LocalDate[] {etc.getStartDate(), etc.getEndDate()}));
-    }
-
-    return periodMap;
   }
 }


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #146 

## ✏️ 작업 내용

- ExperienceService와 ResumeQuestionExperienceService에 중복으로 존재하던 resolvePeriodBulk() 메서드를 ExperiencePeriodResolver 클래스로 추출
- 레포지토리 4개(Activity, Career, Education, Etc) 의존성을 ResumeQuestionExperienceService에서 제거
- 리팩토링 후 불필요해진 미사용 변수 experienceIds 제거

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
