### PR TITLE
[REFACTOR] 응답방식 json_object 에서 Structured Outputs로 전환

### DIFF
--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/JdMatchPromptBuilder.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/JdMatchPromptBuilder.java
@@ -82,7 +82,6 @@ public class JdMatchPromptBuilder {
         - 반드시 제공된 내용만 근거로 사용하라.
         - 없는 내용을 추론하지 마라.
         - 점수는 0~100 사이 정수로 반환하라.
-        - 반드시 JSON 형식으로만 응답하라.
 
         %s
 
@@ -94,16 +93,43 @@ public class JdMatchPromptBuilder {
 
         [해야 할 일]
         각 경험이 위 공고와 자소서 문항에 얼마나 적합한지 개별적으로 평가하라.
-
-        반환 형식:
-        {
-          "usageScores": [
-            { "pieceId": 숫자, "score": 숫자 },
-            ...
-          ]
-        }
         """
         .formatted(buildJdContext(jd), question.getContent(), buildExperienceList(experiences));
+  }
+
+  /** buildQuestionCombinedPrompt 응답 스키마: usageScores 배열 */
+  public Map<String, Object> buildQuestionCombinedSchema() {
+    return Map.of(
+        "name",
+        "question_match_result",
+        "strict",
+        true,
+        "schema",
+        Map.of(
+            "type",
+            "object",
+            "properties",
+            Map.of(
+                "usageScores",
+                Map.of(
+                    "type",
+                    "array",
+                    "items",
+                    Map.of(
+                        "type",
+                        "object",
+                        "properties",
+                        Map.of(
+                            "pieceId", Map.of("type", "integer"),
+                            "score", Map.of("type", "integer")),
+                        "required",
+                        List.of("pieceId", "score"),
+                        "additionalProperties",
+                        false))),
+            "required",
+            List.of("usageScores"),
+            "additionalProperties",
+            false));
   }
 
   /** 하나의 경험이 공고와 연결되는 핵심키워드, 연결점, 작성가이드 반환하는 프롬프트 */
@@ -114,7 +140,6 @@ public class JdMatchPromptBuilder {
         [규칙]
         - 반드시 제공된 내용만 근거로 사용하라.
         - 없는 내용을 추론하거나 만들어내지 마라.
-        - 반드시 JSON 형식으로만 응답하라.
         - 한국어로 작성하라.
 
         %s
@@ -138,15 +163,30 @@ public class JdMatchPromptBuilder {
         [말투 규칙]
         - 모든 문장은 반드시 '~합니다', '~입니다', '~습니다' 체로 통일하라.
         - '~하십시오', '~이다', '~한다', '~세요', '~어요' 등 다른 말투는 절대 사용하지 마라.
-
-        반환 형식:
-        {
-          "coreKeywords": ["키워드1", "키워드2", ...],
-          "connectionToJd": "공고와의 연결점 서술",
-          "writingGuide": "구체적인 작성 팁"
-        }
         """
         .formatted(buildJdContext(jd), question.getContent(), buildExperienceList(experiences));
+  }
+
+  /** buildWritingGuidePrompt 응답 스키마: coreKeywords 배열 + connectionToJd + writingGuide */
+  public Map<String, Object> buildWritingGuideSchema() {
+    return Map.of(
+        "name",
+        "writing_guide_result",
+        "strict",
+        true,
+        "schema",
+        Map.of(
+            "type",
+            "object",
+            "properties",
+            Map.of(
+                "coreKeywords", Map.of("type", "array", "items", Map.of("type", "string")),
+                "connectionToJd", Map.of("type", "string"),
+                "writingGuide", Map.of("type", "string")),
+            "required",
+            List.of("coreKeywords", "connectionToJd", "writingGuide"),
+            "additionalProperties",
+            false));
   }
 
   /** 하나의 경험과 공고를 분석해서 경험의 강점, 보완할점, 작성가이드를 반환하는 프롬프트 */
@@ -157,7 +197,6 @@ public class JdMatchPromptBuilder {
         [규칙]
         - 반드시 제공된 내용만 근거로 사용하라.
         - 없는 내용을 추론하거나 만들어내지 마라.
-        - 반드시 JSON 형식으로만 응답하라.
         - 한국어로 작성하라.
 
         %s
@@ -186,17 +225,6 @@ public class JdMatchPromptBuilder {
         [말투 규칙]
         - 모든 문장은 반드시 '~합니다', '~입니다', '~습니다' 체로 통일하라.
         - '~하십시오', '~이다', '~한다', '~세요', '~어요' 등 다른 말투는 절대 사용하지 마라.
-
-        반환 형식:
-        {
-          "strengths": "좋은 점 서술",
-          "weaknesses": "보완하면 좋을 점 서술",
-          "usageGuide": "자기소개서 어필 방법 서술",
-          "highlightKeywords": [
-            { "keyword": "키워드1", "sources": ["mainResponsibilities", "hardSkill"] },
-            ...
-          ]
-        }
         """
         .formatted(
             buildJdContext(jd),
@@ -207,6 +235,45 @@ public class JdMatchPromptBuilder {
             defaultIfNull(experience.getAct()),
             defaultIfNull(experience.getResult()),
             defaultIfNull(experience.getTaken()));
+  }
+
+  /** buildExperienceDetailPrompt 응답 스키마: strengths + weaknesses + usageGuide + highlightKeywords */
+  public Map<String, Object> buildExperienceDetailSchema() {
+    return Map.of(
+        "name",
+        "experience_detail_result",
+        "strict",
+        true,
+        "schema",
+        Map.of(
+            "type",
+            "object",
+            "properties",
+            Map.of(
+                "strengths", Map.of("type", "string"),
+                "weaknesses", Map.of("type", "string"),
+                "usageGuide", Map.of("type", "string"),
+                "highlightKeywords",
+                    Map.of(
+                        "type",
+                        "array",
+                        "items",
+                        Map.of(
+                            "type",
+                            "object",
+                            "properties",
+                            Map.of(
+                                "keyword", Map.of("type", "string"),
+                                "sources",
+                                    Map.of("type", "array", "items", Map.of("type", "string"))),
+                            "required",
+                            List.of("keyword", "sources"),
+                            "additionalProperties",
+                            false))),
+            "required",
+            List.of("strengths", "weaknesses", "usageGuide", "highlightKeywords"),
+            "additionalProperties",
+            false));
   }
 
   private String buildJdContext(Jd jd) {

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/JdMatchPromptBuilder.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/JdMatchPromptBuilder.java
@@ -1,6 +1,7 @@
 package com.kusitms.kkium.jd.utils.llm;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -22,7 +23,6 @@ public class JdMatchPromptBuilder {
         - 반드시 제공된 내용만 근거로 사용하라.
         - 없는 내용을 추론하지 마라.
         - 점수는 0~100 사이 정수로 반환하라.
-        - 반드시 JSON 형식으로만 응답하라.
 
         %s
 
@@ -32,17 +32,44 @@ public class JdMatchPromptBuilder {
         [해야 할 일]
         1. 각 경험이 위 공고에 개별적으로 얼마나 활용 가능한지 평가하라. (usageScores)
         2. 위 경험들을 포트폴리오 전체 관점에서 공고 요구사항을 얼마나 커버하는지 평가하라. (applicationScore)
-
-        반환 형식:
-        {
-          "usageScores": [
-            { "pieceId": 숫자, "score": 숫자 },
-            ...
-          ],
-          "applicationScore": 숫자
-        }
         """
         .formatted(buildJdContext(jd), buildExperienceList(experiences));
+  }
+
+  /** buildCombinedPrompt 응답 스키마: usageScores 배열 + applicationScore */
+  public Map<String, Object> buildCombinedSchema() {
+    return Map.of(
+        "name",
+        "combined_match_result",
+        "strict",
+        true,
+        "schema",
+        Map.of(
+            "type",
+            "object",
+            "properties",
+            Map.of(
+                "usageScores",
+                    Map.of(
+                        "type",
+                        "array",
+                        "items",
+                        Map.of(
+                            "type",
+                            "object",
+                            "properties",
+                            Map.of(
+                                "pieceId", Map.of("type", "integer"),
+                                "score", Map.of("type", "integer")),
+                            "required",
+                            List.of("pieceId", "score"),
+                            "additionalProperties",
+                            false)),
+                "applicationScore", Map.of("type", "integer")),
+            "required",
+            List.of("usageScores", "applicationScore"),
+            "additionalProperties",
+            false));
   }
 
   /** 공고, 자소서문항, 지원자의 경험들 간의 적합도 산출 프롬프트 */

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
@@ -58,7 +58,7 @@ public class LlmMatchScoreService {
       Jd jd, JdQuestion question, List<Experience> experiences) {
     if (experiences.isEmpty()) return new LlmQuestionMatchResult(Map.of());
     String prompt = promptBuilder.buildQuestionCombinedPrompt(jd, question, experiences);
-    String response = callOpenAi(prompt);
+    String response = callOpenAi(prompt, promptBuilder.buildQuestionCombinedSchema());
     return parseQuestionMatchResult(response, experiences);
   }
 
@@ -67,33 +67,23 @@ public class LlmMatchScoreService {
       Jd jd, JdQuestion question, List<Experience> experiences) {
     if (experiences.isEmpty()) return LlmWritingGuideResult.empty();
     String prompt = promptBuilder.buildWritingGuidePrompt(jd, question, experiences);
-    String response = callOpenAi(prompt);
+    String response = callOpenAi(prompt, promptBuilder.buildWritingGuideSchema());
     return parseWritingGuideResult(response);
   }
 
   /** 경험 카드 클릭 시 상세 분석 */
   public LlmExperienceDetailResult analyzeExperienceDetail(Jd jd, Experience experience) {
     String prompt = promptBuilder.buildExperienceDetailPrompt(jd, experience);
-    String response = callOpenAi(prompt);
+    String response = callOpenAi(prompt, promptBuilder.buildExperienceDetailSchema());
     return parseExperienceDetailResult(response);
   }
 
-  // API 호출 (기존 json_object 방식 - scoreAll 외 메서드에서 사용)
-  private String callOpenAi(String prompt) {
-    return callOpenAi(prompt, null);
-  }
-
-  // API 호출 (jsonSchema가 null이면 json_object, 아니면 json_schema 방식 사용)
+  // API 호출
   private String callOpenAi(String prompt, Map<String, Object> jsonSchema) {
-    Map<String, Object> responseFormat =
-        jsonSchema != null
-            ? Map.of("type", "json_schema", "json_schema", jsonSchema)
-            : Map.of("type", "json_object");
-
     Map<String, Object> body = new HashMap<>();
     body.put("model", MODEL);
     body.put("messages", List.of(Map.of("role", "user", "content", prompt)));
-    body.put("response_format", responseFormat);
+    body.put("response_format", Map.of("type", "json_schema", "json_schema", jsonSchema));
     try {
       String response =
           webClient

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
@@ -49,7 +49,7 @@ public class LlmMatchScoreService {
   public LlmMatchResult scoreAll(Jd jd, List<Experience> experiences) {
     if (experiences.isEmpty()) return new LlmMatchResult(Map.of(), 0);
     String prompt = promptBuilder.buildCombinedPrompt(jd, experiences);
-    String response = callOpenAi(prompt);
+    String response = callOpenAi(prompt, promptBuilder.buildCombinedSchema());
     return parseCombinedResult(response, experiences);
   }
 
@@ -78,13 +78,22 @@ public class LlmMatchScoreService {
     return parseExperienceDetailResult(response);
   }
 
-  // API 호출
+  // API 호출 (기존 json_object 방식 - scoreAll 외 메서드에서 사용)
   private String callOpenAi(String prompt) {
-    Map<String, Object> body =
-        Map.of(
-            "model", MODEL,
-            "messages", List.of(Map.of("role", "user", "content", prompt)),
-            "response_format", Map.of("type", "json_object"));
+    return callOpenAi(prompt, null);
+  }
+
+  // API 호출 (jsonSchema가 null이면 json_object, 아니면 json_schema 방식 사용)
+  private String callOpenAi(String prompt, Map<String, Object> jsonSchema) {
+    Map<String, Object> responseFormat =
+        jsonSchema != null
+            ? Map.of("type", "json_schema", "json_schema", jsonSchema)
+            : Map.of("type", "json_object");
+
+    Map<String, Object> body = new HashMap<>();
+    body.put("model", MODEL);
+    body.put("messages", List.of(Map.of("role", "user", "content", prompt)));
+    body.put("response_format", responseFormat);
     try {
       String response =
           webClient


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #149 

## ✏️ 작업 내용

- LlmMatchScoreService 모든 LLM 호출을 json_schema 방식으로 전환
- JdMatchPromptBuilder에 각 프롬프트 메서드와 짝꿍 스키마 메서드 추가
  - buildCombinedSchema()
  - buildQuestionCombinedSchema()
  - buildWritingGuideSchema()
  - buildExperienceDetailSchema()
- 프롬프트 내 JSON 형식 지시문 및 반환 형식 예시 제거 (스키마가 대체)
- callOpenAi() json_object fallback 및 오버로딩 제거

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
