### PR TITLE
[REFACTOR] 경험 분석 LLM 코드 역할별로 클래스 분리

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
@@ -1,99 +1,26 @@
 package com.kusitms.kkium.experience.service.llm;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kusitms.kkium.experience.dto.response.ExperienceAnalyzeResponse;
 import com.kusitms.kkium.experience.service.llm.pipeline.ExperiencePromptBuilder;
-import com.kusitms.kkium.global.exception.BaseException;
-import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
+import com.kusitms.kkium.experience.service.llm.pipeline.ExperienceResponseParser;
+import com.kusitms.kkium.experience.service.llm.pipeline.GeminiApiClient;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import reactor.util.retry.Retry;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GeminiLlmService implements LlmService {
 
-  private static final String GEMINI_API_URL =
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
-
-  private final WebClient webClient;
-  private final ObjectMapper objectMapper;
   private final ExperiencePromptBuilder promptBuilder;
-
-  @Value("${gemini.api-key}")
-  private String apiKey;
+  private final GeminiApiClient apiClient;
+  private final ExperienceResponseParser responseParser;
 
   @Override
   public ExperienceAnalyzeResponse analyze(Long userId, String extractedText) {
     String prompt = promptBuilder.build(extractedText);
-    String rawJson = callGeminiApi(prompt);
-    return parseResponse(rawJson);
-  }
-
-  private String callGeminiApi(String prompt) {
-    Map<String, Object> requestBody =
-        Map.of(
-            "contents", List.of(Map.of("parts", List.of(Map.of("text", prompt)))),
-            "generationConfig", Map.of("response_mime_type", "application/json"));
-
-    try {
-      return webClient
-          .post()
-          .uri(GEMINI_API_URL + "?key=" + apiKey)
-          .bodyValue(requestBody)
-          .retrieve()
-          .bodyToMono(String.class)
-          .timeout(Duration.ofSeconds(25))
-          .retryWhen(
-              Retry.backoff(3, Duration.ofSeconds(2))
-                  .filter(
-                      e ->
-                          e instanceof WebClientResponseException we
-                              && (we.getStatusCode().is5xxServerError()
-                                  || we.getStatusCode().value() == 429)))
-          .block(Duration.ofSeconds(60));
-    } catch (Exception e) {
-      log.error("Gemini API 호출 실패: {}", e.getMessage());
-      throw new BaseException(ErrorCode.LLM_CALL_FAILED);
-    }
-  }
-
-  private ExperienceAnalyzeResponse parseResponse(String rawResponse) {
-    try {
-      JsonNode root = objectMapper.readTree(rawResponse);
-      String jsonText =
-          root.path("candidates")
-              .path(0)
-              .path("content")
-              .path("parts")
-              .path(0)
-              .path("text")
-              .asText();
-
-      // JSON 객체 범위만 추출
-      int startIndex = jsonText.indexOf("{");
-      int endIndex = jsonText.lastIndexOf("}");
-      if (startIndex != -1 && endIndex != -1) {
-        jsonText = jsonText.substring(startIndex, endIndex + 1);
-      }
-
-      return objectMapper.readValue(jsonText, ExperienceAnalyzeResponse.class);
-    } catch (JsonProcessingException e) {
-      log.error("Gemini 응답 파싱 실패: {}", e.getMessage());
-      throw new BaseException(ErrorCode.LLM_CALL_FAILED);
-    }
+    String rawJson = apiClient.call(prompt);
+    return responseParser.parse(rawJson);
   }
 }

--- a/src/main/java/com/kusitms/kkium/experience/service/llm/pipeline/ExperienceResponseParser.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/pipeline/ExperienceResponseParser.java
@@ -1,0 +1,47 @@
+package com.kusitms.kkium.experience.service.llm.pipeline;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kusitms.kkium.experience.dto.response.ExperienceAnalyzeResponse;
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExperienceResponseParser {
+
+  private final ObjectMapper objectMapper;
+
+  public ExperienceAnalyzeResponse parse(String rawResponse) {
+    try {
+      JsonNode root = objectMapper.readTree(rawResponse);
+      String jsonText =
+          root.path("candidates")
+              .path(0)
+              .path("content")
+              .path("parts")
+              .path(0)
+              .path("text")
+              .asText();
+
+      // JSON 객체 범위만 추출
+      int startIndex = jsonText.indexOf("{");
+      int endIndex = jsonText.lastIndexOf("}");
+      if (startIndex != -1 && endIndex != -1) {
+        jsonText = jsonText.substring(startIndex, endIndex + 1);
+      }
+
+      return objectMapper.readValue(jsonText, ExperienceAnalyzeResponse.class);
+    } catch (JsonProcessingException e) {
+      log.error("Gemini 응답 파싱 실패: {}", e.getMessage());
+      throw new BaseException(ErrorCode.LLM_CALL_FAILED);
+    }
+  }
+}

--- a/src/main/java/com/kusitms/kkium/experience/service/llm/pipeline/ExperienceResponseParser.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/pipeline/ExperienceResponseParser.java
@@ -20,6 +20,11 @@ public class ExperienceResponseParser {
   private final ObjectMapper objectMapper;
 
   public ExperienceAnalyzeResponse parse(String rawResponse) {
+    if (rawResponse == null || rawResponse.isBlank()) {
+      log.error("Gemini 응답이 비어있음");
+      throw new BaseException(ErrorCode.LLM_CALL_FAILED);
+    }
+
     try {
       JsonNode root = objectMapper.readTree(rawResponse);
       String jsonText =
@@ -34,7 +39,7 @@ public class ExperienceResponseParser {
       // JSON 객체 범위만 추출
       int startIndex = jsonText.indexOf("{");
       int endIndex = jsonText.lastIndexOf("}");
-      if (startIndex != -1 && endIndex != -1) {
+      if (startIndex != -1 && endIndex != -1 && startIndex < endIndex) {
         jsonText = jsonText.substring(startIndex, endIndex + 1);
       }
 

--- a/src/main/java/com/kusitms/kkium/experience/service/llm/pipeline/GeminiApiClient.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/pipeline/GeminiApiClient.java
@@ -36,21 +36,28 @@ public class GeminiApiClient {
             "generationConfig", Map.of("response_mime_type", "application/json"));
 
     try {
-      return webClient
-          .post()
-          .uri(GEMINI_API_URL + "?key=" + apiKey)
-          .bodyValue(requestBody)
-          .retrieve()
-          .bodyToMono(String.class)
-          .timeout(Duration.ofSeconds(25))
-          .retryWhen(
-              Retry.backoff(3, Duration.ofSeconds(2))
-                  .filter(
-                      e ->
-                          e instanceof WebClientResponseException we
-                              && (we.getStatusCode().is5xxServerError()
-                                  || we.getStatusCode().value() == 429)))
-          .block(Duration.ofSeconds(60));
+      String response =
+          webClient
+              .post()
+              .uri(GEMINI_API_URL + "?key=" + apiKey)
+              .bodyValue(requestBody)
+              .retrieve()
+              .bodyToMono(String.class)
+              .timeout(Duration.ofSeconds(25))
+              .retryWhen(
+                  Retry.backoff(3, Duration.ofSeconds(2))
+                      .filter(
+                          e ->
+                              e instanceof WebClientResponseException we
+                                  && (we.getStatusCode().is5xxServerError()
+                                      || we.getStatusCode().value() == 429)))
+              .block(Duration.ofSeconds(60));
+
+      if (response == null) {
+        log.error("Gemini API 응답이 null");
+        throw new BaseException(ErrorCode.LLM_CALL_FAILED);
+      }
+      return response;
     } catch (Exception e) {
       log.error("Gemini API 호출 실패: {}", e.getMessage());
       throw new BaseException(ErrorCode.LLM_CALL_FAILED);

--- a/src/main/java/com/kusitms/kkium/experience/service/llm/pipeline/GeminiApiClient.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/pipeline/GeminiApiClient.java
@@ -1,0 +1,59 @@
+package com.kusitms.kkium.experience.service.llm.pipeline;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.util.retry.Retry;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GeminiApiClient {
+
+  private static final String GEMINI_API_URL =
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
+
+  private final WebClient webClient;
+
+  @Value("${gemini.api-key}")
+  private String apiKey;
+
+  public String call(String prompt) {
+    Map<String, Object> requestBody =
+        Map.of(
+            "contents", List.of(Map.of("parts", List.of(Map.of("text", prompt)))),
+            "generationConfig", Map.of("response_mime_type", "application/json"));
+
+    try {
+      return webClient
+          .post()
+          .uri(GEMINI_API_URL + "?key=" + apiKey)
+          .bodyValue(requestBody)
+          .retrieve()
+          .bodyToMono(String.class)
+          .timeout(Duration.ofSeconds(25))
+          .retryWhen(
+              Retry.backoff(3, Duration.ofSeconds(2))
+                  .filter(
+                      e ->
+                          e instanceof WebClientResponseException we
+                              && (we.getStatusCode().is5xxServerError()
+                                  || we.getStatusCode().value() == 429)))
+          .block(Duration.ofSeconds(60));
+    } catch (Exception e) {
+      log.error("Gemini API 호출 실패: {}", e.getMessage());
+      throw new BaseException(ErrorCode.LLM_CALL_FAILED);
+    }
+  }
+}


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #151 

## ✏️ 작업 내용

`GeminiLlmService` 하나에 모여 있던 코드를 역할별로 클래스 3개로 분리
- `GeminiApiClient`: Gemini API 호출 부분 담당
- `ExperienceResponseParser` : Gemini 응답을 JSON으로 읽는 부분 담당
- `GeminiLlmService`: `GeminiApiClient`, `ExperienceResponseParser`, 그리고 `ExperiencePromptBuilder`를 순서대로 호출하는 역할만 남김
- `pipeline/` 패키지에 분리된 컴포넌트들 이동

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
