### PR TITLE
[FEAT] refresh token 도입 및 소셜 로그인 운영/로컬 분기

### DIFF
--- a/k8s/app/deployment.yaml
+++ b/k8s/app/deployment.yaml
@@ -53,6 +53,21 @@ spec:
             secretKeyRef:
               name: kkium-secret
               key: JWT_ACCESS_TOKEN_EXPIRATION
+        - name: JWT_REFRESH_TOKEN_EXPIRATION
+          valueFrom:
+            secretKeyRef:
+              name: kkium-secret
+              key: JWT_REFRESH_TOKEN_EXPIRATION
+        - name: REFRESH_TOKEN_COOKIE_SECURE
+          valueFrom:
+            secretKeyRef:
+              name: kkium-secret
+              key: REFRESH_TOKEN_COOKIE_SECURE
+        - name: REFRESH_TOKEN_COOKIE_SAME_SITE
+          valueFrom:
+            secretKeyRef:
+              name: kkium-secret
+              key: REFRESH_TOKEN_COOKIE_SAME_SITE
         - name: KAKAO_REST_API_KEY
           valueFrom:
             secretKeyRef:
@@ -63,6 +78,16 @@ spec:
             secretKeyRef:
               name: kkium-secret
               key: KAKAO_REDIRECT_URI
+        - name: KAKAO_REDIRECT_URI_PROD
+          valueFrom:
+            secretKeyRef:
+              name: kkium-secret
+              key: KAKAO_REDIRECT_URI_PROD
+        - name: KAKAO_REDIRECT_URI_LOCAL
+          valueFrom:
+            secretKeyRef:
+              name: kkium-secret
+              key: KAKAO_REDIRECT_URI_LOCAL
         - name: KAKAO_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
@@ -118,6 +143,16 @@ spec:
             secretKeyRef:
               name: kkium-secret
               key: GOOGLE_REDIRECT_URI
+        - name: GOOGLE_REDIRECT_URI_PROD
+          valueFrom:
+            secretKeyRef:
+              name: kkium-secret
+              key: GOOGLE_REDIRECT_URI_PROD
+        - name: GOOGLE_REDIRECT_URI_LOCAL
+          valueFrom:
+            secretKeyRef:
+              name: kkium-secret
+              key: GOOGLE_REDIRECT_URI_LOCAL
         - name: GOOGLE_CLIENT_SECRET
           valueFrom:
             secretKeyRef:

--- a/k8s/app/external-secret.yaml
+++ b/k8s/app/external-secret.yaml
@@ -27,12 +27,27 @@ spec:
   - secretKey: JWT_ACCESS_TOKEN_EXPIRATION
     remoteRef:
       key: JWT_ACCESS_TOKEN_EXPIRATION
+  - secretKey: JWT_REFRESH_TOKEN_EXPIRATION
+    remoteRef:
+      key: JWT_REFRESH_TOKEN_EXPIRATION
+  - secretKey: REFRESH_TOKEN_COOKIE_SECURE
+    remoteRef:
+      key: REFRESH_TOKEN_COOKIE_SECURE
+  - secretKey: REFRESH_TOKEN_COOKIE_SAME_SITE
+    remoteRef:
+      key: REFRESH_TOKEN_COOKIE_SAME_SITE
   - secretKey: KAKAO_REST_API_KEY
     remoteRef:
       key: KAKAO_REST_API_KEY
   - secretKey: KAKAO_REDIRECT_URI
     remoteRef:
       key: KAKAO_REDIRECT_URI
+  - secretKey: KAKAO_REDIRECT_URI_PROD
+    remoteRef:
+      key: KAKAO_REDIRECT_URI_PROD
+  - secretKey: KAKAO_REDIRECT_URI_LOCAL
+    remoteRef:
+      key: KAKAO_REDIRECT_URI_LOCAL
   - secretKey: KAKAO_CLIENT_SECRET
     remoteRef:
       key: KAKAO_CLIENT_SECRET
@@ -42,6 +57,12 @@ spec:
   - secretKey: GOOGLE_REDIRECT_URI
     remoteRef:
       key: GOOGLE_REDIRECT_URI
+  - secretKey: GOOGLE_REDIRECT_URI_PROD
+    remoteRef:
+      key: GOOGLE_REDIRECT_URI_PROD
+  - secretKey: GOOGLE_REDIRECT_URI_LOCAL
+    remoteRef:
+      key: GOOGLE_REDIRECT_URI_LOCAL
   - secretKey: GOOGLE_CLIENT_SECRET
     remoteRef:
       key: GOOGLE_CLIENT_SECRET

--- a/src/main/java/com/kusitms/kkium/auth/controller/AuthController.java
+++ b/src/main/java/com/kusitms/kkium/auth/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.kusitms.kkium.auth.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
@@ -15,8 +17,10 @@ import com.kusitms.kkium.auth.controller.docs.AuthControllerDocs;
 import com.kusitms.kkium.auth.domain.type.RedirectType;
 import com.kusitms.kkium.auth.dto.request.BasicLoginRequest;
 import com.kusitms.kkium.auth.dto.request.BasicSignupRequest;
+import com.kusitms.kkium.auth.dto.response.AccessTokenResponse;
 import com.kusitms.kkium.auth.dto.response.LoginResponse;
 import com.kusitms.kkium.auth.service.AuthService;
+import com.kusitms.kkium.auth.service.RefreshTokenService;
 import com.kusitms.kkium.global.response.ApiResponse;
 import com.kusitms.kkium.user.domain.type.LoginType;
 import com.kusitms.kkium.user.dto.request.TermsAgreementRequest;
@@ -32,6 +36,7 @@ public class AuthController implements AuthControllerDocs {
 
   private final AuthService authService;
   private final UserService userService;
+  private final RefreshTokenService refreshTokenService;
 
   @PostMapping("/signup")
   public ResponseEntity<ApiResponse<Void>> signUp(@Valid @RequestBody BasicSignupRequest request) {
@@ -41,17 +46,33 @@ public class AuthController implements AuthControllerDocs {
 
   @PostMapping("/login")
   public ResponseEntity<ApiResponse<LoginResponse>> login(
-      @Valid @RequestBody BasicLoginRequest request) {
-    return ResponseEntity.ok(ApiResponse.success(authService.login(request)));
+      @Valid @RequestBody BasicLoginRequest request, HttpServletResponse response) {
+    LoginResponse loginResponse = authService.login(request);
+    refreshTokenService.issueRefreshToken(loginResponse.accessToken(), response);
+    return ResponseEntity.ok(ApiResponse.success(loginResponse));
   }
 
   @PostMapping("/login/{loginType}")
   public ResponseEntity<ApiResponse<LoginResponse>> socialLogin(
       @PathVariable LoginType loginType,
       @RequestParam String code,
-      @RequestParam(defaultValue = "PROD") RedirectType redirectType) {
-    return ResponseEntity.ok(
-        ApiResponse.success(authService.socialLogin(loginType, code, redirectType)));
+      @RequestParam(defaultValue = "PROD") RedirectType redirectType,
+      HttpServletResponse response) {
+    LoginResponse loginResponse = authService.socialLogin(loginType, code, redirectType);
+    refreshTokenService.issueRefreshToken(loginResponse.accessToken(), response);
+    return ResponseEntity.ok(ApiResponse.success(loginResponse));
+  }
+
+  @PostMapping("/reissue")
+  public ResponseEntity<ApiResponse<AccessTokenResponse>> reissue(HttpServletRequest request) {
+    return ResponseEntity.ok(ApiResponse.success(refreshTokenService.reissue(request)));
+  }
+
+  @PostMapping("/logout")
+  public ResponseEntity<ApiResponse<Void>> logout(
+      HttpServletRequest request, HttpServletResponse response) {
+    refreshTokenService.logout(request, response);
+    return ResponseEntity.ok(ApiResponse.successWithNoContent());
   }
 
   @PostMapping("/terms")

--- a/src/main/java/com/kusitms/kkium/auth/controller/AuthController.java
+++ b/src/main/java/com/kusitms/kkium/auth/controller/AuthController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kusitms.kkium.auth.controller.docs.AuthControllerDocs;
+import com.kusitms.kkium.auth.domain.type.RedirectType;
 import com.kusitms.kkium.auth.dto.request.BasicLoginRequest;
 import com.kusitms.kkium.auth.dto.request.BasicSignupRequest;
 import com.kusitms.kkium.auth.dto.response.LoginResponse;
@@ -46,8 +47,11 @@ public class AuthController implements AuthControllerDocs {
 
   @PostMapping("/login/{loginType}")
   public ResponseEntity<ApiResponse<LoginResponse>> socialLogin(
-      @PathVariable LoginType loginType, @RequestParam String code) {
-    return ResponseEntity.ok(ApiResponse.success(authService.socialLogin(loginType, code)));
+      @PathVariable LoginType loginType,
+      @RequestParam String code,
+      @RequestParam(defaultValue = "PROD") RedirectType redirectType) {
+    return ResponseEntity.ok(
+        ApiResponse.success(authService.socialLogin(loginType, code, redirectType)));
   }
 
   @PostMapping("/terms")

--- a/src/main/java/com/kusitms/kkium/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/kusitms/kkium/auth/controller/docs/AuthControllerDocs.java
@@ -1,5 +1,7 @@
 package com.kusitms.kkium.auth.controller.docs;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import com.kusitms.kkium.auth.domain.type.RedirectType;
 import com.kusitms.kkium.auth.dto.request.BasicLoginRequest;
 import com.kusitms.kkium.auth.dto.request.BasicSignupRequest;
+import com.kusitms.kkium.auth.dto.response.AccessTokenResponse;
 import com.kusitms.kkium.auth.dto.response.LoginResponse;
 import com.kusitms.kkium.global.response.ApiResponse;
 import com.kusitms.kkium.user.domain.type.LoginType;
@@ -58,7 +61,8 @@ public interface AuthControllerDocs {
         description = "이메일 또는 비밀번호 불일치",
         content = @Content(schema = @Schema(implementation = ApiResponse.class)))
   })
-  ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody BasicLoginRequest request);
+  ResponseEntity<ApiResponse<LoginResponse>> login(
+      @Valid @RequestBody BasicLoginRequest request, HttpServletResponse response);
 
   @Operation(
       summary = "소셜 로그인",
@@ -81,7 +85,39 @@ public interface AuthControllerDocs {
   ResponseEntity<ApiResponse<LoginResponse>> socialLogin(
       @PathVariable LoginType loginType,
       @RequestParam String code,
-      @RequestParam(defaultValue = "PROD") RedirectType redirectType);
+      @RequestParam(defaultValue = "PROD") RedirectType redirectType,
+      HttpServletResponse response);
+
+  @Operation(
+      summary = "Access Token 재발급",
+      description = "HttpOnly Cookie의 refresh token으로 access token을 재발급합니다.")
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "Access Token 재발급 성공",
+        content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "401",
+        description = "Refresh Token 없음, 만료 또는 불일치",
+        content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "404",
+        description = "유저 없음",
+        content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+  })
+  ResponseEntity<ApiResponse<AccessTokenResponse>> reissue(HttpServletRequest request);
+
+  @Operation(
+      summary = "로그아웃",
+      description = "Redis에 저장된 refresh token을 삭제하고 refresh token 쿠키를 만료시킵니다.")
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "로그아웃 성공",
+        content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+  })
+  ResponseEntity<ApiResponse<Void>> logout(
+      HttpServletRequest request, HttpServletResponse response);
 
   @Operation(summary = "약관 동의", description = "로그인한 사용자의 약관 동의를 완료 처리합니다.")
   @ApiResponses({

--- a/src/main/java/com/kusitms/kkium/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/kusitms/kkium/auth/controller/docs/AuthControllerDocs.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import com.kusitms.kkium.auth.domain.type.RedirectType;
 import com.kusitms.kkium.auth.dto.request.BasicLoginRequest;
 import com.kusitms.kkium.auth.dto.request.BasicSignupRequest;
 import com.kusitms.kkium.auth.dto.response.LoginResponse;
@@ -59,7 +60,10 @@ public interface AuthControllerDocs {
   })
   ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody BasicLoginRequest request);
 
-  @Operation(summary = "소셜 로그인", description = "KAKAO 또는 GOOGLE 인가 코드로 로그인합니다. 최초 로그인 시 자동 가입됩니다.")
+  @Operation(
+      summary = "소셜 로그인",
+      description =
+          "KAKAO 또는 GOOGLE 인가 코드로 로그인합니다. 최초 로그인 시 자동 가입됩니다. redirectType으로 LOCAL/PROD redirect URI를 선택할 수 있습니다.")
   @ApiResponses({
     @io.swagger.v3.oas.annotations.responses.ApiResponse(
         responseCode = "200",
@@ -75,7 +79,9 @@ public interface AuthControllerDocs {
         content = @Content(schema = @Schema(implementation = ApiResponse.class)))
   })
   ResponseEntity<ApiResponse<LoginResponse>> socialLogin(
-      @PathVariable LoginType loginType, @RequestParam String code);
+      @PathVariable LoginType loginType,
+      @RequestParam String code,
+      @RequestParam(defaultValue = "PROD") RedirectType redirectType);
 
   @Operation(summary = "약관 동의", description = "로그인한 사용자의 약관 동의를 완료 처리합니다.")
   @ApiResponses({

--- a/src/main/java/com/kusitms/kkium/auth/domain/type/RedirectType.java
+++ b/src/main/java/com/kusitms/kkium/auth/domain/type/RedirectType.java
@@ -1,0 +1,6 @@
+package com.kusitms.kkium.auth.domain.type;
+
+public enum RedirectType {
+  LOCAL,
+  PROD
+}

--- a/src/main/java/com/kusitms/kkium/auth/dto/response/AccessTokenResponse.java
+++ b/src/main/java/com/kusitms/kkium/auth/dto/response/AccessTokenResponse.java
@@ -1,0 +1,3 @@
+package com.kusitms.kkium.auth.dto.response;
+
+public record AccessTokenResponse(String accessToken) {}

--- a/src/main/java/com/kusitms/kkium/auth/service/AuthService.java
+++ b/src/main/java/com/kusitms/kkium/auth/service/AuthService.java
@@ -12,6 +12,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kusitms.kkium.auth.domain.type.RedirectType;
 import com.kusitms.kkium.auth.dto.request.BasicLoginRequest;
 import com.kusitms.kkium.auth.dto.request.BasicSignupRequest;
 import com.kusitms.kkium.auth.dto.response.LoginResponse;
@@ -81,11 +82,16 @@ public class AuthService {
 
   @Transactional
   public LoginResponse socialLogin(LoginType loginType, String code) {
+    return socialLogin(loginType, code, RedirectType.PROD);
+  }
+
+  @Transactional
+  public LoginResponse socialLogin(LoginType loginType, String code, RedirectType redirectType) {
     SocialLoginStrategy loginStrategy = loginStrategyMap.get(loginType.name());
     if (loginStrategy == null) {
       throw new BaseException(INVALID_INPUT_VALUE);
     }
-    return loginStrategy.login(code);
+    return loginStrategy.login(code, redirectType);
   }
 
   private User recreateBasicUser(User deletedUser, BasicLoginRequest request, LocalDateTime now) {

--- a/src/main/java/com/kusitms/kkium/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/kusitms/kkium/auth/service/RefreshTokenService.java
@@ -1,0 +1,132 @@
+package com.kusitms.kkium.auth.service;
+
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.INVALID_TOKEN;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.USER_NOT_FOUND;
+
+import java.time.Duration;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+
+import com.kusitms.kkium.auth.dto.response.AccessTokenResponse;
+import com.kusitms.kkium.auth.utils.JwtTokenProvider;
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+  private static final String REFRESH_TOKEN_KEY_PREFIX = "auth:refresh:";
+
+  private final JwtTokenProvider jwtTokenProvider;
+  private final StringRedisTemplate redisTemplate;
+  private final UserRepository userRepository;
+
+  @Value("${auth.refresh-token.expiration}")
+  private long refreshTokenExpiration;
+
+  @Value("${auth.refresh-token.cookie-name}")
+  private String refreshTokenCookieName;
+
+  @Value("${auth.refresh-token.cookie-secure}")
+  private boolean refreshTokenCookieSecure;
+
+  @Value("${auth.refresh-token.cookie-same-site}")
+  private String refreshTokenCookieSameSite;
+
+  public void issueRefreshToken(String accessToken, HttpServletResponse response) {
+    String userId = jwtTokenProvider.getUserPk(accessToken);
+    String refreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+    redisTemplate
+        .opsForValue()
+        .set(redisKey(userId), refreshToken, Duration.ofMillis(refreshTokenExpiration));
+
+    response.addHeader(HttpHeaders.SET_COOKIE, createCookie(refreshToken).toString());
+  }
+
+  public AccessTokenResponse reissue(HttpServletRequest request) {
+    String refreshToken = resolveRefreshToken(request);
+    if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
+      throw new BaseException(INVALID_TOKEN);
+    }
+
+    String userId = jwtTokenProvider.getUserPk(refreshToken);
+    userRepository
+        .findByIdAndDeleteAtIsNull(Long.parseLong(userId))
+        .orElseThrow(() -> new BaseException(USER_NOT_FOUND));
+
+    String savedRefreshToken = redisTemplate.opsForValue().get(redisKey(userId));
+    if (!refreshToken.equals(savedRefreshToken)) {
+      throw new BaseException(INVALID_TOKEN);
+    }
+
+    return new AccessTokenResponse(jwtTokenProvider.createAccessToken(userId));
+  }
+
+  public void logout(HttpServletRequest request, HttpServletResponse response) {
+    String refreshToken = resolveRefreshTokenOrNull(request);
+    if (refreshToken != null && jwtTokenProvider.validateRefreshToken(refreshToken)) {
+      String userId = jwtTokenProvider.getUserPk(refreshToken);
+      redisTemplate.delete(redisKey(userId));
+    }
+
+    response.addHeader(HttpHeaders.SET_COOKIE, expireCookie().toString());
+  }
+
+  private String resolveRefreshToken(HttpServletRequest request) {
+    String refreshToken = resolveRefreshTokenOrNull(request);
+    if (refreshToken == null || refreshToken.isBlank()) {
+      throw new BaseException(INVALID_TOKEN);
+    }
+    return refreshToken;
+  }
+
+  private String resolveRefreshTokenOrNull(HttpServletRequest request) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies == null) {
+      return null;
+    }
+
+    for (Cookie cookie : cookies) {
+      if (refreshTokenCookieName.equals(cookie.getName())) {
+        return cookie.getValue();
+      }
+    }
+    return null;
+  }
+
+  private ResponseCookie createCookie(String refreshToken) {
+    return ResponseCookie.from(refreshTokenCookieName, refreshToken)
+        .httpOnly(true)
+        .secure(refreshTokenCookieSecure)
+        .sameSite(refreshTokenCookieSameSite)
+        .path("/api/v1/auth")
+        .maxAge(Duration.ofMillis(refreshTokenExpiration))
+        .build();
+  }
+
+  private ResponseCookie expireCookie() {
+    return ResponseCookie.from(refreshTokenCookieName, "")
+        .httpOnly(true)
+        .secure(refreshTokenCookieSecure)
+        .sameSite(refreshTokenCookieSameSite)
+        .path("/api/v1/auth")
+        .maxAge(0)
+        .build();
+  }
+
+  private String redisKey(String userId) {
+    return REFRESH_TOKEN_KEY_PREFIX + userId;
+  }
+}

--- a/src/main/java/com/kusitms/kkium/auth/service/strategy/GoogleLoginStrategy.java
+++ b/src/main/java/com/kusitms/kkium/auth/service/strategy/GoogleLoginStrategy.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Service;
 
+import com.kusitms.kkium.auth.domain.type.RedirectType;
 import com.kusitms.kkium.auth.dto.response.LoginResponse;
 import com.kusitms.kkium.auth.dto.response.google.GoogleUserInfoResponse;
 import com.kusitms.kkium.auth.utils.JwtTokenProvider;
@@ -28,7 +29,12 @@ public class GoogleLoginStrategy implements SocialLoginStrategy {
 
   @Override
   public LoginResponse login(String code) {
-    String googleAccessToken = googleApiClient.getAccessToken(code);
+    return login(code, RedirectType.PROD);
+  }
+
+  @Override
+  public LoginResponse login(String code, RedirectType redirectType) {
+    String googleAccessToken = googleApiClient.getAccessToken(code, redirectType);
     GoogleUserInfoResponse userInfo = googleApiClient.getUserInfo(googleAccessToken);
 
     String socialId = userInfo.id();

--- a/src/main/java/com/kusitms/kkium/auth/service/strategy/KakaoLoginStrategy.java
+++ b/src/main/java/com/kusitms/kkium/auth/service/strategy/KakaoLoginStrategy.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Service;
 
+import com.kusitms.kkium.auth.domain.type.RedirectType;
 import com.kusitms.kkium.auth.dto.response.LoginResponse;
 import com.kusitms.kkium.auth.dto.response.kakao.KakaoUserInfoResponse;
 import com.kusitms.kkium.auth.utils.JwtTokenProvider;
@@ -28,7 +29,12 @@ public class KakaoLoginStrategy implements SocialLoginStrategy {
 
   @Override
   public LoginResponse login(String code) {
-    String kakaoAccessToken = kakaoApiClient.getAccessToken(code);
+    return login(code, RedirectType.PROD);
+  }
+
+  @Override
+  public LoginResponse login(String code, RedirectType redirectType) {
+    String kakaoAccessToken = kakaoApiClient.getAccessToken(code, redirectType);
     KakaoUserInfoResponse userInfo = kakaoApiClient.getUserInfo(kakaoAccessToken);
 
     String socialId = String.valueOf(userInfo.id());

--- a/src/main/java/com/kusitms/kkium/auth/service/strategy/SocialLoginStrategy.java
+++ b/src/main/java/com/kusitms/kkium/auth/service/strategy/SocialLoginStrategy.java
@@ -1,7 +1,12 @@
 package com.kusitms.kkium.auth.service.strategy;
 
+import com.kusitms.kkium.auth.domain.type.RedirectType;
 import com.kusitms.kkium.auth.dto.response.LoginResponse;
 
 public interface SocialLoginStrategy {
   LoginResponse login(String code);
+
+  default LoginResponse login(String code, RedirectType redirectType) {
+    return login(code);
+  }
 }

--- a/src/main/java/com/kusitms/kkium/auth/utils/JwtTokenProvider.java
+++ b/src/main/java/com/kusitms/kkium/auth/utils/JwtTokenProvider.java
@@ -25,11 +25,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
+  private static final String TOKEN_TYPE_CLAIM = "tokenType";
+  private static final String ACCESS_TOKEN_TYPE = "ACCESS";
+  private static final String REFRESH_TOKEN_TYPE = "REFRESH";
+
   @Value("${JWT_SECRET}")
   private String secretKey;
 
   @Value("${JWT_ACCESS_TOKEN_EXPIRATION}")
   private Long expiration;
+
+  @Value("${auth.refresh-token.expiration}")
+  private Long refreshExpiration;
 
   private Key key;
 
@@ -41,11 +48,27 @@ public class JwtTokenProvider {
   }
 
   public String createToken(String userId) {
+    return createAccessToken(userId);
+  }
+
+  public String createAccessToken(String userId) {
     Date now = new Date();
     return Jwts.builder()
         .setSubject(userId)
+        .claim(TOKEN_TYPE_CLAIM, ACCESS_TOKEN_TYPE)
         .setIssuedAt(now)
         .setExpiration(new Date(now.getTime() + expiration))
+        .signWith(key, SignatureAlgorithm.HS512)
+        .compact();
+  }
+
+  public String createRefreshToken(String userId) {
+    Date now = new Date();
+    return Jwts.builder()
+        .setSubject(userId)
+        .claim(TOKEN_TYPE_CLAIM, REFRESH_TOKEN_TYPE)
+        .setIssuedAt(now)
+        .setExpiration(new Date(now.getTime() + refreshExpiration))
         .signWith(key, SignatureAlgorithm.HS512)
         .compact();
   }
@@ -59,7 +82,19 @@ public class JwtTokenProvider {
     try {
       Claims claims =
           Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(jwtToken).getBody();
-      return !claims.getExpiration().before(new Date());
+      return !claims.getExpiration().before(new Date())
+          && !REFRESH_TOKEN_TYPE.equals(claims.get(TOKEN_TYPE_CLAIM, String.class));
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  public boolean validateRefreshToken(String jwtToken) {
+    try {
+      Claims claims =
+          Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(jwtToken).getBody();
+      return !claims.getExpiration().before(new Date())
+          && REFRESH_TOKEN_TYPE.equals(claims.get(TOKEN_TYPE_CLAIM, String.class));
     } catch (Exception e) {
       return false;
     }

--- a/src/main/java/com/kusitms/kkium/auth/utils/google/GoogleApiClient.java
+++ b/src/main/java/com/kusitms/kkium/auth/utils/google/GoogleApiClient.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
+import com.kusitms.kkium.auth.domain.type.RedirectType;
 import com.kusitms.kkium.auth.dto.response.google.GoogleLoginResponse;
 import com.kusitms.kkium.auth.dto.response.google.GoogleUserInfoResponse;
 import com.kusitms.kkium.global.exception.BaseException;
@@ -29,13 +30,17 @@ public class GoogleApiClient {
   @Value("${google.client-id}")
   private String googleClientId;
 
-  @Value("${google.redirect-uri}")
-  private String googleRedirectUri;
+  @Value("${google.redirect-uri.prod}")
+  private String googleRedirectUriProd;
+
+  @Value("${google.redirect-uri.local}")
+  private String googleRedirectUriLocal;
 
   @Value("${google.client-secret}")
   private String googleClientSecret;
 
-  public String getAccessToken(String code) {
+  public String getAccessToken(String code, RedirectType redirectType) {
+    String redirectUri = resolveRedirectUri(redirectType);
     String requestBody =
         "grant_type=authorization_code"
             + "&client_id="
@@ -43,7 +48,7 @@ public class GoogleApiClient {
             + "&client_secret="
             + googleClientSecret
             + "&redirect_uri="
-            + googleRedirectUri
+            + redirectUri
             + "&code="
             + code;
 
@@ -68,6 +73,13 @@ public class GoogleApiClient {
             })
         .map(GoogleLoginResponse::accessToken)
         .block();
+  }
+
+  private String resolveRedirectUri(RedirectType redirectType) {
+    return switch (redirectType) {
+      case LOCAL -> googleRedirectUriLocal;
+      case PROD -> googleRedirectUriProd;
+    };
   }
 
   public GoogleUserInfoResponse getUserInfo(String token) {

--- a/src/main/java/com/kusitms/kkium/auth/utils/google/GoogleApiClient.java
+++ b/src/main/java/com/kusitms/kkium/auth/utils/google/GoogleApiClient.java
@@ -76,6 +76,9 @@ public class GoogleApiClient {
   }
 
   private String resolveRedirectUri(RedirectType redirectType) {
+    if (redirectType == null) {
+      return googleRedirectUriProd;
+    }
     return switch (redirectType) {
       case LOCAL -> googleRedirectUriLocal;
       case PROD -> googleRedirectUriProd;

--- a/src/main/java/com/kusitms/kkium/auth/utils/kakao/KakaoApiClient.java
+++ b/src/main/java/com/kusitms/kkium/auth/utils/kakao/KakaoApiClient.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
+import com.kusitms.kkium.auth.domain.type.RedirectType;
 import com.kusitms.kkium.auth.dto.response.kakao.KakaoLoginResponse;
 import com.kusitms.kkium.auth.dto.response.kakao.KakaoUserInfoResponse;
 import com.kusitms.kkium.global.exception.BaseException;
@@ -29,14 +30,18 @@ public class KakaoApiClient {
   @Value("${KAKAO_REST_API_KEY}")
   private String kakaoApiKey;
 
-  @Value("${KAKAO_REDIRECT_URI}")
-  private String kakaoRedirectUri;
+  @Value("${kakao.redirect-uri.prod}")
+  private String kakaoRedirectUriProd;
+
+  @Value("${kakao.redirect-uri.local}")
+  private String kakaoRedirectUriLocal;
 
   @Value("${KAKAO_CLIENT_SECRET}")
   private String kakaoClientSecret;
 
   // 인가 코드 > Access Token
-  public String getAccessToken(String code) {
+  public String getAccessToken(String code, RedirectType redirectType) {
+    String redirectUri = resolveRedirectUri(redirectType);
     String requestBody =
         "grant_type=authorization_code"
             + "&client_id="
@@ -44,7 +49,7 @@ public class KakaoApiClient {
             + "&client_secret="
             + kakaoClientSecret
             + "&redirect_uri="
-            + kakaoRedirectUri
+            + redirectUri
             + "&code="
             + code;
 
@@ -72,6 +77,13 @@ public class KakaoApiClient {
             })
         .map(KakaoLoginResponse::accessToken)
         .block();
+  }
+
+  private String resolveRedirectUri(RedirectType redirectType) {
+    return switch (redirectType) {
+      case LOCAL -> kakaoRedirectUriLocal;
+      case PROD -> kakaoRedirectUriProd;
+    };
   }
 
   // Access Token > 사용자 정보 조회

--- a/src/main/java/com/kusitms/kkium/global/config/SecurityConfig.java
+++ b/src/main/java/com/kusitms/kkium/global/config/SecurityConfig.java
@@ -59,6 +59,8 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/auth/login/**")
                     .permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/v1/auth/reissue", "/api/v1/auth/logout")
+                    .permitAll()
                     .requestMatchers("/api/v1/notion/callback")
                     .permitAll()
                     .anyRequest()

--- a/src/main/java/com/kusitms/kkium/jd/service/JdService.java
+++ b/src/main/java/com/kusitms/kkium/jd/service/JdService.java
@@ -196,6 +196,26 @@ public class JdService {
   }
 
   @Transactional
+  public void updateQuestionContent(
+      Long jdId, Long questionId, Long userId, JdQuestionCreateRequest request) {
+    Jd jd =
+        jdRepository
+            .findByIdAndDeleteAtIsNull(jdId)
+            .orElseThrow(() -> new BaseException(ErrorCode.JD_NOT_FOUND));
+
+    if (!jd.getUser().getId().equals(userId)) {
+      throw new BaseException(ErrorCode.FORBIDDEN);
+    }
+
+    JdQuestion question =
+        jdQuestionRepository
+            .findByIdAndJdId(questionId, jdId)
+            .orElseThrow(() -> new BaseException(ErrorCode.INVALID_QUESTION_FOR_JD));
+
+    question.updateContent(request.content());
+  }
+
+  @Transactional
   public void updateJd(Long jdId, Long userId, JdUpdateRequest request) {
     Jd jd = findJdById(jdId);
     User user = findUserById(userId);

--- a/src/main/java/com/kusitms/kkium/resume/controller/ResumeController.java
+++ b/src/main/java/com/kusitms/kkium/resume/controller/ResumeController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kusitms.kkium.global.response.ApiResponse;
+import com.kusitms.kkium.jd.dto.request.JdQuestionCreateRequest;
 import com.kusitms.kkium.jd.service.JdService;
 import com.kusitms.kkium.resume.controller.docs.ResumeControllerDocs;
 import com.kusitms.kkium.resume.dto.request.AiDraftRequest;
@@ -92,6 +94,16 @@ public class ResumeController implements ResumeControllerDocs {
       @PathVariable Long questionId,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     jdService.deleteQuestion(jdId, questionId, userDetails.getId());
+    return ResponseEntity.ok(ApiResponse.successWithNoContent());
+  }
+
+  @PatchMapping("/jd/{jdId}/questions/{questionId}")
+  public ResponseEntity<ApiResponse<Void>> updateQuestion(
+      @PathVariable Long jdId,
+      @PathVariable Long questionId,
+      @Valid @RequestBody JdQuestionCreateRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    jdService.updateQuestionContent(jdId, questionId, userDetails.getId(), request);
     return ResponseEntity.ok(ApiResponse.successWithNoContent());
   }
 }

--- a/src/main/java/com/kusitms/kkium/resume/controller/docs/ResumeControllerDocs.java
+++ b/src/main/java/com/kusitms/kkium/resume/controller/docs/ResumeControllerDocs.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.kusitms.kkium.global.response.ApiResponse;
+import com.kusitms.kkium.jd.dto.request.JdQuestionCreateRequest;
 import com.kusitms.kkium.resume.dto.request.AiDraftRequest;
 import com.kusitms.kkium.resume.dto.request.ResumeAnswerSaveRequest;
 import com.kusitms.kkium.resume.dto.response.AiDraftResponse;
@@ -157,5 +158,34 @@ public interface ResumeControllerDocs {
   ResponseEntity<ApiResponse<Void>> deleteQuestion(
       @PathVariable Long jdId,
       @PathVariable Long questionId,
+      @AuthenticationPrincipal CustomUserDetails userDetails);
+
+  @Operation(summary = "[자소서 작성] 문항 수정", description = "자기소개서 문항의 내용을 수정합니다.")
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "문항 수정 성공",
+        content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "400",
+        description = "요청값 검증 실패",
+        content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "401",
+        description = "인증 필요",
+        content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "403",
+        description = "공고 접근 권한 없음 또는 해당 공고에 속하지 않는 문항",
+        content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "404",
+        description = "공고 또는 문항 없음",
+        content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+  })
+  ResponseEntity<ApiResponse<Void>> updateQuestion(
+      @PathVariable Long jdId,
+      @PathVariable Long questionId,
+      @Valid @RequestBody JdQuestionCreateRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,12 +25,16 @@ spring:
 
 kakao:
   rest-api-key: ${KAKAO_REST_API_KEY}
-  redirect-uri: ${KAKAO_REDIRECT_URI}
+  redirect-uri:
+    prod: ${KAKAO_REDIRECT_URI_PROD:${KAKAO_REDIRECT_URI}}
+    local: ${KAKAO_REDIRECT_URI_LOCAL:${KAKAO_REDIRECT_URI}}
   client-secret: ${KAKAO_CLIENT_SECRET}
 
 google:
   client-id: ${GOOGLE_CLIENT_ID}
-  redirect-uri: ${GOOGLE_REDIRECT_URI}
+  redirect-uri:
+    prod: ${GOOGLE_REDIRECT_URI_PROD:${GOOGLE_REDIRECT_URI}}
+    local: ${GOOGLE_REDIRECT_URI_LOCAL:${GOOGLE_REDIRECT_URI}}
   client-secret: ${GOOGLE_CLIENT_SECRET}
   cloud:
     vision:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,13 @@ spring:
       token:
         expiration: ${JWT_ACCESS_TOKEN_EXPIRATION}
 
+auth:
+  refresh-token:
+    expiration: ${JWT_REFRESH_TOKEN_EXPIRATION:1209600000}
+    cookie-name: refreshToken
+    cookie-secure: ${REFRESH_TOKEN_COOKIE_SECURE:false}
+    cookie-same-site: ${REFRESH_TOKEN_COOKIE_SAME_SITE:Lax}
+
 kakao:
   rest-api-key: ${KAKAO_REST_API_KEY}
   redirect-uri:


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #133

## ✏️ 작업 내용

1. refresh token 기반 토큰 재발급 및 로그아웃 구현 
- 로그인 성공 시 refresh token은 HttpOnly Cookie로 발급
- access token 재발급 api 추가 
- 로그아웃 api 추가  
- 로그아웃 시 redis refresh token 삭제 및 Refresh token 쿠키 만료 처리

<br>

2. 소셜 로그인 redirect uri 분기 처리 
- 카카오/구글 로그인에서 redirectType으로 redirect uri 선택 가능하도록 수정 
- 기본 값은 PROD 

<br> 

3. 자기소개서 문항 수정 api 추가

## ✅ 체크리스트

- [ ]  PR 제목을 커밋 규칙에 맞게 작성
- [ ]  PR에 해당되는 Issue를 연결 완료
- [ ]  작업한 사람 모두를 Assign
- [ ]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
