### PR TITLE
[FEAT] 경험 분석 LLM 응답 안정성 강화

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/GeminiLlmService.java
@@ -6,9 +6,13 @@ import com.kusitms.kkium.experience.dto.response.ExperienceAnalyzeResponse;
 import com.kusitms.kkium.experience.service.llm.pipeline.ExperiencePromptBuilder;
 import com.kusitms.kkium.experience.service.llm.pipeline.ExperienceResponseParser;
 import com.kusitms.kkium.experience.service.llm.pipeline.GeminiApiClient;
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GeminiLlmService implements LlmService {
@@ -20,7 +24,25 @@ public class GeminiLlmService implements LlmService {
   @Override
   public ExperienceAnalyzeResponse analyze(Long userId, String extractedText) {
     String prompt = promptBuilder.build(extractedText);
+
+    try {
+      return callAndParse(prompt);
+    } catch (BaseException e) {
+      if (!isParsingError(e)) {
+        throw e;
+      }
+      log.warn("응답 파싱 실패, 1회 재시도: {}", e.getErrorCode());
+      return callAndParse(prompt);
+    }
+  }
+
+  private ExperienceAnalyzeResponse callAndParse(String prompt) {
     String rawJson = apiClient.call(prompt);
     return responseParser.parse(rawJson);
+  }
+
+  private boolean isParsingError(BaseException e) {
+    ErrorCode code = e.getErrorCode();
+    return code == ErrorCode.LLM_RESPONSE_INVALID || code == ErrorCode.LLM_SCHEMA_VIOLATION;
   }
 }

--- a/src/main/java/com/kusitms/kkium/experience/service/llm/pipeline/ExperienceResponseParser.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/pipeline/ExperienceResponseParser.java
@@ -22,9 +22,20 @@ public class ExperienceResponseParser {
   public ExperienceAnalyzeResponse parse(String rawResponse) {
     if (rawResponse == null || rawResponse.isBlank()) {
       log.error("Gemini 응답이 비어있음");
-      throw new BaseException(ErrorCode.LLM_CALL_FAILED);
+      throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
     }
 
+    String jsonText = extractJsonText(rawResponse);
+
+    try {
+      return objectMapper.readValue(jsonText, ExperienceAnalyzeResponse.class);
+    } catch (JsonProcessingException e) {
+      log.error("Gemini 응답 스키마 위반: {}", e.getMessage());
+      throw new BaseException(ErrorCode.LLM_SCHEMA_VIOLATION);
+    }
+  }
+
+  private String extractJsonText(String rawResponse) {
     try {
       JsonNode root = objectMapper.readTree(rawResponse);
       String jsonText =
@@ -36,17 +47,22 @@ public class ExperienceResponseParser {
               .path("text")
               .asText();
 
-      // JSON 객체 범위만 추출
+      if (jsonText.isBlank()) {
+        log.error("Gemini 응답에서 텍스트를 찾을 수 없음");
+        throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
+      }
+
+      // JSON 객체 범위만 추출 (responseSchema가 있어도 보험으로 유지)
       int startIndex = jsonText.indexOf("{");
       int endIndex = jsonText.lastIndexOf("}");
       if (startIndex != -1 && endIndex != -1 && startIndex < endIndex) {
         jsonText = jsonText.substring(startIndex, endIndex + 1);
       }
 
-      return objectMapper.readValue(jsonText, ExperienceAnalyzeResponse.class);
+      return jsonText;
     } catch (JsonProcessingException e) {
-      log.error("Gemini 응답 파싱 실패: {}", e.getMessage());
-      throw new BaseException(ErrorCode.LLM_CALL_FAILED);
+      log.error("Gemini 응답 JSON 파싱 실패: {}", e.getMessage());
+      throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
     }
   }
 }

--- a/src/main/java/com/kusitms/kkium/experience/service/llm/pipeline/ExperienceSchemaLoader.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/pipeline/ExperienceSchemaLoader.java
@@ -1,0 +1,39 @@
+package com.kusitms.kkium.experience.service.llm.pipeline;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import jakarta.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ExperienceSchemaLoader {
+
+  private final ObjectMapper objectMapper;
+
+  @Value("classpath:prompts/experience/analyze-schema.json")
+  private Resource schemaResource;
+
+  private Map<String, Object> schema;
+
+  @PostConstruct
+  public void init() throws IOException {
+    try (InputStream inputStream = schemaResource.getInputStream()) {
+      this.schema = objectMapper.readValue(inputStream, new TypeReference<>() {});
+    }
+  }
+
+  public Map<String, Object> get() {
+    return schema;
+  }
+}

--- a/src/main/java/com/kusitms/kkium/experience/service/llm/pipeline/GeminiApiClient.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/llm/pipeline/GeminiApiClient.java
@@ -25,6 +25,7 @@ public class GeminiApiClient {
       "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent";
 
   private final WebClient webClient;
+  private final ExperienceSchemaLoader schemaLoader;
 
   @Value("${gemini.api-key}")
   private String apiKey;
@@ -33,7 +34,12 @@ public class GeminiApiClient {
     Map<String, Object> requestBody =
         Map.of(
             "contents", List.of(Map.of("parts", List.of(Map.of("text", prompt)))),
-            "generationConfig", Map.of("response_mime_type", "application/json"));
+            "generationConfig",
+                Map.of(
+                    "response_mime_type",
+                    "application/json",
+                    "response_schema",
+                    schemaLoader.get()));
 
     try {
       String response =

--- a/src/main/java/com/kusitms/kkium/global/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/kusitms/kkium/global/exception/errorcode/ErrorCode.java
@@ -55,6 +55,8 @@ public enum ErrorCode {
   FILE_ALREADY_UPLOADED(HttpStatus.CONFLICT, "E002", "이미 업로드된 자료가 있습니다. 다시 업로드하면 초기화됩니다."),
   PDF_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "E003", "PDF 파일 파싱에 실패했습니다."),
   LLM_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "E004", "AI 분석에 실패했습니다. 다시 시도해주세요."),
+  LLM_RESPONSE_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "E011", "AI 응답이 올바르지 않습니다. 다시 시도해주세요."),
+  LLM_SCHEMA_VIOLATION(HttpStatus.INTERNAL_SERVER_ERROR, "E012", "AI 응답 형식이 올바르지 않습니다. 다시 시도해주세요."),
   OCR_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "J008", "이미지 텍스트 추출에 실패했습니다."),
   INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "J009", "PNG, JPG, JPEG 파일만 업로드 가능합니다.");
 

--- a/src/main/resources/prompts/experience/analyze-schema.json
+++ b/src/main/resources/prompts/experience/analyze-schema.json
@@ -1,0 +1,69 @@
+{
+  "type": "OBJECT",
+  "properties": {
+    "title": { "type": "STRING" },
+    "oneLineIntro": { "type": "STRING" },
+    "activityInfo": {
+      "type": "OBJECT",
+      "properties": {
+        "name": { "type": "STRING", "nullable": true },
+        "teamNum": { "type": "INTEGER", "nullable": true },
+        "startDate": { "type": "STRING", "nullable": true },
+        "endDate": { "type": "STRING", "nullable": true },
+        "contributionRate": { "type": "INTEGER", "nullable": true },
+        "role": { "type": "STRING", "nullable": true }
+      }
+    },
+    "careerInfo": {
+      "type": "OBJECT",
+      "properties": {
+        "name": { "type": "STRING", "nullable": true },
+        "company": { "type": "STRING", "nullable": true },
+        "employmentStatus": { "type": "STRING", "nullable": true },
+        "startDate": { "type": "STRING", "nullable": true },
+        "endDate": { "type": "STRING", "nullable": true }
+      }
+    },
+    "educationInfo": {
+      "type": "OBJECT",
+      "properties": {
+        "organizationName": { "type": "STRING", "nullable": true },
+        "name": { "type": "STRING", "nullable": true },
+        "startDate": { "type": "STRING", "nullable": true },
+        "endDate": { "type": "STRING", "nullable": true }
+      }
+    },
+    "situation": { "type": "STRING" },
+    "task": { "type": "STRING" },
+    "act": { "type": "STRING" },
+    "result": { "type": "STRING" },
+    "taken": { "type": "STRING" },
+    "tags": {
+      "type": "ARRAY",
+      "items": {
+        "type": "OBJECT",
+        "properties": {
+          "category": {
+            "type": "STRING",
+            "enum": ["TECH", "COMPETENCY"]
+          },
+          "field": { "type": "STRING" }
+        },
+        "required": ["category", "field"]
+      }
+    }
+  },
+  "required": [
+    "title",
+    "oneLineIntro",
+    "activityInfo",
+    "careerInfo",
+    "educationInfo",
+    "situation",
+    "task",
+    "act",
+    "result",
+    "taken",
+    "tags"
+  ]
+}

--- a/src/main/resources/prompts/experience/analyze-schema.json
+++ b/src/main/resources/prompts/experience/analyze-schema.json
@@ -8,8 +8,8 @@
       "properties": {
         "name": { "type": "STRING", "nullable": true },
         "teamNum": { "type": "INTEGER", "nullable": true },
-        "startDate": { "type": "STRING", "nullable": true },
-        "endDate": { "type": "STRING", "nullable": true },
+        "startDate": { "type": "STRING", "nullable": true, "description": "YYYY-MM-DD format" },
+        "endDate": { "type": "STRING", "nullable": true, "description": "YYYY-MM-DD format" },
         "contributionRate": { "type": "INTEGER", "nullable": true },
         "role": { "type": "STRING", "nullable": true }
       }

--- a/src/main/resources/prompts/experience/analyze-schema.json
+++ b/src/main/resources/prompts/experience/analyze-schema.json
@@ -20,8 +20,8 @@
         "name": { "type": "STRING", "nullable": true },
         "company": { "type": "STRING", "nullable": true },
         "employmentStatus": { "type": "STRING", "nullable": true },
-        "startDate": { "type": "STRING", "nullable": true },
-        "endDate": { "type": "STRING", "nullable": true }
+        "startDate": { "type": "STRING", "nullable": true, "description": "YYYY-MM-DD format" },
+        "endDate": { "type": "STRING", "nullable": true, "description": "YYYY-MM-DD format" }
       }
     },
     "educationInfo": {

--- a/src/main/resources/prompts/experience/analyze-schema.json
+++ b/src/main/resources/prompts/experience/analyze-schema.json
@@ -29,8 +29,8 @@
       "properties": {
         "organizationName": { "type": "STRING", "nullable": true },
         "name": { "type": "STRING", "nullable": true },
-        "startDate": { "type": "STRING", "nullable": true },
-        "endDate": { "type": "STRING", "nullable": true }
+        "startDate": { "type": "STRING", "nullable": true, "description": "YYYY-MM-DD format" },
+        "endDate": { "type": "STRING", "nullable": true, "description": "YYYY-MM-DD format" }
       }
     },
     "situation": { "type": "STRING" },


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #152 

## ✏️ 작업 내용

### 1. ErrorCode 세분화
- 하나로 묶여있던 에러처리를 세분화
  - `LLM_CALL_FAILED` (E004): Gemini한테 요청을 보내지 못했거나, Gemini 서버가 응답을 못 줬을 때 (기존)
  - `LLM_RESPONSE_INVALID` (E011, 신규): 응답은 왔는데 내용이 비어있거나 JSON 형식이 깨져 있을 때
  - `LLM_SCHEMA_VIOLATION` (E012, 신규): JSON 자체는 읽혔는데 우리가 원한 구조랑 다를 때 (필요한 항목이 빠져있는 경우 등)

### 2. responseSchema 도입
- Gemini 응답이 호출될 때의 Json 형식 강제

### 3. 응답 파싱 실패 시 1회 재시도
- `GeminiLlmService`에서 Gemini 응답을 읽다가 실패하면 한 번 더 호출해서 시도하도록 처리

### 4. ExperienceResponseParser 정리
- 한 메서드에 모여있던 검증/파싱 로직을 분리하고 각 단계의 실패에 맞는 ErrorCode를 던지도록 수정
  - 응답이 null이거나 빈 문자열일 때 → `LLM_RESPONSE_INVALID`
  - 응답에서 Gemini 답변 텍스트를 못 찾았을 때 → `LLM_RESPONSE_INVALID`
  - 텍스트를 우리 데이터 구조로 읽다가 실패했을 때 → `LLM_SCHEMA_VIOLATION`

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
