### PR TITLE
[CHORE] 테스트 환경 보완

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'java'
+	id 'jacoco'
 	id 'org.springframework.boot' version '4.0.5'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'com.diffplug.spotless' version '6.25.0'
@@ -36,6 +37,7 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.testcontainers:testcontainers'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'
@@ -92,6 +94,19 @@ jar {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacoco {
+	toolVersion = "0.8.12"
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		html.required = true
+		xml.required = true
+	}
 }
 
 tasks.register('installGitHooks') {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -67,7 +67,7 @@ notion:
   client-secret: test-notion-client-secret
   redirect-uri: http://localhost:8080/api/v1/notion/callback
   frontend-redirect-uri: http://localhost:3000/notion/callback
-  aes-secret-key: test-aes-key-for-kkium-testing!!
+  aes-secret-key: "test-aes-key-for-kkium-testing!!"
   allowed-origins: http://localhost:3000
 
 openai:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -67,7 +67,7 @@ notion:
   client-secret: test-notion-client-secret
   redirect-uri: http://localhost:8080/api/v1/notion/callback
   frontend-redirect-uri: http://localhost:3000/notion/callback
-  aes-secret-key: test-aes-key-for-kkium-testing-123
+  aes-secret-key: test-aes-key-for-kkium-testing!!
   allowed-origins: http://localhost:3000
 
 openai:


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #167 

## ✏️ 작업 내용

- `notion.aes-secret-key`를 32바이트(AES-256) 값으로 교체
- MockWebServer 테스트 의존성 추가
- JaCoCo 플러그인 및 리포트 설정 추가
- 변경 후 `./gradlew test` 실행하여 기존 테스트 18개 통과 확인

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
