### PR TITLE
[TEST] 경험-공고 매칭 서비스 단위 테스트

### DIFF
--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
@@ -150,10 +150,15 @@ public class LlmMatchScoreService {
   private LlmWritingGuideResult parseWritingGuideResult(String response) {
     try {
       JsonNode parsed = OBJECT_MAPPER.readTree(response);
+      if (!parsed.has("connectionToJd") || !parsed.has("writingGuide")) {
+        throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
+      }
       List<String> keywords = new ArrayList<>();
       for (JsonNode k : parsed.path("coreKeywords")) keywords.add(k.asText());
       return new LlmWritingGuideResult(
           keywords, parsed.path("connectionToJd").asText(), parsed.path("writingGuide").asText());
+    } catch (BaseException e) {
+      throw e;
     } catch (Exception e) {
       log.warn("작성 가이드 LLM 응답 파싱 실패: {}", e.getMessage());
       throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
@@ -171,6 +176,9 @@ public class LlmMatchScoreService {
   private LlmExperienceDetailResult parseExperienceDetailResult(String response) {
     try {
       JsonNode parsed = OBJECT_MAPPER.readTree(response);
+      if (!parsed.has("strengths") || !parsed.has("weaknesses") || !parsed.has("usageGuide")) {
+        throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
+      }
       List<HighlightKeyword> keywords = new ArrayList<>();
       for (JsonNode k : parsed.path("highlightKeywords")) {
         String keyword = k.path("keyword").asText();
@@ -186,6 +194,8 @@ public class LlmMatchScoreService {
           parsed.path("weaknesses").asText(),
           parsed.path("usageGuide").asText(),
           keywords);
+    } catch (BaseException e) {
+      throw e;
     } catch (Exception e) {
       log.warn("경험 상세 분석 LLM 응답 파싱 실패: {}", e.getMessage());
       throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
@@ -7,12 +7,15 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kusitms.kkium.experience.domain.Experience;
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
 import com.kusitms.kkium.jd.domain.Jd;
 import com.kusitms.kkium.jd.domain.JdQuestion;
 import com.kusitms.kkium.jd.utils.llm.result.*;
@@ -94,59 +97,66 @@ public class LlmMatchScoreService {
               .header("Authorization", "Bearer " + apiKey)
               .bodyValue(body)
               .retrieve()
+              .onStatus(
+                  HttpStatusCode::is4xxClientError,
+                  clientResponse -> {
+                    log.warn("OpenAI 클라이언트 에러: {}", clientResponse.statusCode());
+                    return clientResponse.createException();
+                  })
+              .onStatus(
+                  HttpStatusCode::is5xxServerError,
+                  clientResponse -> {
+                    log.warn("OpenAI 서버 에러: {}", clientResponse.statusCode());
+                    return clientResponse.createException();
+                  })
               .bodyToMono(String.class)
               .block();
 
       JsonNode root = OBJECT_MAPPER.readTree(response);
       return root.path("choices").path(0).path("message").path("content").asText();
+    } catch (BaseException e) {
+      throw e;
     } catch (Exception e) {
       log.warn("OpenAI 호출 실패: {}", e.getMessage());
-      return null;
+      throw new BaseException(ErrorCode.LLM_CALL_FAILED);
     }
   }
 
   // 응답 파싱
 
   private LlmMatchResult parseCombinedResult(String response, List<Experience> experiences) {
-    Map<Long, Integer> fallback = buildFallbackScores(experiences);
-    if (response == null) return new LlmMatchResult(fallback, 0);
     try {
       JsonNode parsed = OBJECT_MAPPER.readTree(response);
-      Map<Long, Integer> usageScores = parseUsageScores(parsed, fallback);
+      Map<Long, Integer> usageScores = parseUsageScores(parsed, buildFallbackScores(experiences));
       return new LlmMatchResult(
           usageScores, Math.max(0, Math.min(100, parsed.path("applicationScore").asInt(0))));
     } catch (Exception e) {
       log.warn("LLM 응답 파싱 실패: {}", e.getMessage());
-      return new LlmMatchResult(fallback, 0);
+      throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
     }
   }
 
   private LlmQuestionMatchResult parseQuestionMatchResult(
       String response, List<Experience> experiences) {
-    Map<Long, Integer> fallback = buildFallbackScores(experiences);
-    if (response == null) return new LlmQuestionMatchResult(fallback);
     try {
       JsonNode parsed = OBJECT_MAPPER.readTree(response);
-      return new LlmQuestionMatchResult(parseUsageScores(parsed, fallback));
+      return new LlmQuestionMatchResult(parseUsageScores(parsed, buildFallbackScores(experiences)));
     } catch (Exception e) {
       log.warn("문항별 LLM 응답 파싱 실패: {}", e.getMessage());
-      return new LlmQuestionMatchResult(fallback);
+      throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
     }
   }
 
   private LlmWritingGuideResult parseWritingGuideResult(String response) {
-    if (response == null) return LlmWritingGuideResult.empty();
     try {
       JsonNode parsed = OBJECT_MAPPER.readTree(response);
       List<String> keywords = new ArrayList<>();
       for (JsonNode k : parsed.path("coreKeywords")) keywords.add(k.asText());
       return new LlmWritingGuideResult(
-          keywords,
-          parsed.path("connectionToJd").asText("분석에 실패했습니다."),
-          parsed.path("writingGuide").asText("분석에 실패했습니다."));
+          keywords, parsed.path("connectionToJd").asText(), parsed.path("writingGuide").asText());
     } catch (Exception e) {
       log.warn("작성 가이드 LLM 응답 파싱 실패: {}", e.getMessage());
-      return LlmWritingGuideResult.empty();
+      throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
     }
   }
 
@@ -159,7 +169,6 @@ public class LlmMatchScoreService {
           "softSkill");
 
   private LlmExperienceDetailResult parseExperienceDetailResult(String response) {
-    if (response == null) return LlmExperienceDetailResult.empty();
     try {
       JsonNode parsed = OBJECT_MAPPER.readTree(response);
       List<HighlightKeyword> keywords = new ArrayList<>();
@@ -173,13 +182,13 @@ public class LlmMatchScoreService {
         keywords.add(new HighlightKeyword(keyword, sources));
       }
       return new LlmExperienceDetailResult(
-          parsed.path("strengths").asText("분석에 실패했습니다."),
-          parsed.path("weaknesses").asText("분석에 실패했습니다."),
-          parsed.path("usageGuide").asText("분석에 실패했습니다."),
+          parsed.path("strengths").asText(),
+          parsed.path("weaknesses").asText(),
+          parsed.path("usageGuide").asText(),
           keywords);
     } catch (Exception e) {
       log.warn("경험 상세 분석 LLM 응답 파싱 실패: {}", e.getMessage());
-      return LlmExperienceDetailResult.empty();
+      throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
     }
   }
 

--- a/src/main/java/com/kusitms/kkium/resume/service/ResumeQuestionExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/resume/service/ResumeQuestionExperienceService.java
@@ -56,8 +56,8 @@ public class ResumeQuestionExperienceService {
             .findById(questionId)
             .orElseThrow(() -> new BaseException(QUESTION_NOT_FOUND));
 
-    // 3. 유저의 전체 경험 조회
-    List<Experience> allExperiences = experienceRepository.findAllByUserIdNoPage(userId);
+    // 3. 유저의 전체 경험 조회 (experience_order 조인 없이 모든 경험 가져옴)
+    List<Experience> allExperiences = experienceRepository.findAllByUserIdForAnalysis(userId);
 
     if (allExperiences.isEmpty()) {
       return new ResumeQuestionExperienceResponse(List.of());

--- a/src/test/java/com/kusitms/kkium/experience/service/ExperienceServiceUpdateTest.java
+++ b/src/test/java/com/kusitms/kkium/experience/service/ExperienceServiceUpdateTest.java
@@ -1,0 +1,630 @@
+package com.kusitms.kkium.experience.service;
+
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_COMPANY_TOO_LONG;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_EDUCATION_NAME_TOO_LONG;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_NOT_FOUND;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_ORGANIZATION_NAME_TOO_LONG;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_ROLE_TOO_LONG;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.FORBIDDEN;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.INVALID_INPUT_VALUE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import com.kusitms.kkium.experience.domain.Activity;
+import com.kusitms.kkium.experience.domain.Career;
+import com.kusitms.kkium.experience.domain.Education;
+import com.kusitms.kkium.experience.domain.Etc;
+import com.kusitms.kkium.experience.domain.Experience;
+import com.kusitms.kkium.experience.domain.Piece;
+import com.kusitms.kkium.experience.domain.type.PieceType;
+import com.kusitms.kkium.experience.domain.type.TagCategory;
+import com.kusitms.kkium.experience.dto.request.ExperienceUpdateRequest;
+import com.kusitms.kkium.experience.dto.request.ExperienceUpdateRequest.Detail;
+import com.kusitms.kkium.experience.dto.request.TagCreateRequest;
+import com.kusitms.kkium.experience.repository.ActivityRepository;
+import com.kusitms.kkium.experience.repository.CareerRepository;
+import com.kusitms.kkium.experience.repository.EducationRepository;
+import com.kusitms.kkium.experience.repository.EtcRepository;
+import com.kusitms.kkium.experience.repository.ExperienceOrderRepository;
+import com.kusitms.kkium.experience.repository.ExperienceRepository;
+import com.kusitms.kkium.experience.repository.PieceRepository;
+import com.kusitms.kkium.experience.repository.TagRepository;
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.home.service.JobTypeUpdateService;
+import com.kusitms.kkium.jd.service.JdExperienceAnalysisService;
+import com.kusitms.kkium.user.domain.User;
+import com.kusitms.kkium.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ExperienceServiceUpdateTest {
+
+  @Mock private UserRepository userRepository;
+  @Mock private PieceRepository pieceRepository;
+  @Mock private ExperienceRepository experienceRepository;
+  @Mock private ExperienceOrderRepository experienceOrderRepository;
+  @Mock private ActivityRepository activityRepository;
+  @Mock private CareerRepository careerRepository;
+  @Mock private EducationRepository educationRepository;
+  @Mock private EtcRepository etcRepository;
+  @Mock private TagRepository tagRepository;
+  @Mock private ExperienceEmbeddingService experienceEmbeddingService;
+  @Mock private JobTypeUpdateService jobTypeUpdateService;
+  @Mock private JdExperienceAnalysisService jdExperienceAnalysisService;
+  @Mock private ExperiencePeriodResolver experiencePeriodResolver;
+
+  private ExperienceService experienceService;
+
+  @BeforeEach
+  void setUp() {
+    TransactionSynchronizationManager.initSynchronization();
+    experienceService =
+        new ExperienceService(
+            userRepository,
+            pieceRepository,
+            experienceRepository,
+            experienceOrderRepository,
+            activityRepository,
+            careerRepository,
+            educationRepository,
+            etcRepository,
+            tagRepository,
+            experienceEmbeddingService,
+            jobTypeUpdateService,
+            jdExperienceAnalysisService,
+            experiencePeriodResolver);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TransactionSynchronizationManager.clearSynchronization();
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 경험이면 EXPERIENCE_NOT_FOUND 예외를 던진다")
+  void throwWhenExperienceNotFound() {
+    when(experienceRepository.findByIdWithPiece(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> experienceService.update(1L, 999L, activityRequest("제목")))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(EXPERIENCE_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("경험 소유자가 아닌 유저가 수정 요청하면 FORBIDDEN 예외를 던진다")
+  void throwWhenUserIsNotExperienceOwner() {
+    Long ownerId = 1L;
+    Long requestUserId = 2L;
+    User owner = createUser(ownerId);
+    Experience experience = createExperience(owner, PieceType.ACTIVITY);
+    setId(experience, 10L);
+
+    when(experienceRepository.findByIdWithPiece(10L)).thenReturn(Optional.of(experience));
+
+    assertThatThrownBy(() -> experienceService.update(requestUserId, 10L, activityRequest("제목")))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("ACTIVITY 수정 시 공통 필드와 activity detail이 모두 업데이트된다")
+  void updateActivityExperience() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Experience experience = createExperience(owner, PieceType.ACTIVITY);
+    setId(experience, 10L);
+    Activity activity = createActivity(experience);
+
+    when(experienceRepository.findByIdWithPiece(10L)).thenReturn(Optional.of(experience));
+    when(tagRepository.findByExperienceId(10L)).thenReturn(List.of());
+    when(activityRepository.findByExperienceId(10L)).thenReturn(Optional.of(activity));
+
+    ExperienceUpdateRequest request = activityRequest("수정된 제목");
+    experienceService.update(userId, 10L, request);
+
+    assertThat(experience.getTitle()).isEqualTo("수정된 제목");
+    assertThat(experience.getOneLineIntro()).isEqualTo("한 줄 소개");
+    assertThat(activity.getName()).isEqualTo("끼움 동아리");
+    assertThat(activity.getRole()).isEqualTo("백엔드");
+    verify(jdExperienceAnalysisService).evictCache(10L);
+  }
+
+  @Test
+  @DisplayName("ACTIVITY 수정 시 필수 필드(name)가 null이면 INVALID_INPUT_VALUE 예외를 던진다")
+  void throwWhenActivityNameIsNull() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Experience experience = createExperience(owner, PieceType.ACTIVITY);
+    setId(experience, 10L);
+
+    when(experienceRepository.findByIdWithPiece(10L)).thenReturn(Optional.of(experience));
+    when(tagRepository.findByExperienceId(10L)).thenReturn(List.of());
+
+    // name=null인 ACTIVITY 요청
+    ExperienceUpdateRequest request =
+        new ExperienceUpdateRequest(
+            "제목",
+            "한 줄 소개",
+            List.of(),
+            "S",
+            "T",
+            "A",
+            "R",
+            "L",
+            new Detail(
+                null,
+                5,
+                "백엔드",
+                80,
+                null,
+                null,
+                null,
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 6, 30)));
+
+    assertThatThrownBy(() -> experienceService.update(userId, 10L, request))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(INVALID_INPUT_VALUE);
+  }
+
+  @Test
+  @DisplayName("ACTIVITY role이 50자 초과이면 EXPERIENCE_ROLE_TOO_LONG 예외를 던진다")
+  void throwWhenActivityRoleTooLong() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Experience experience = createExperience(owner, PieceType.ACTIVITY);
+    setId(experience, 10L);
+
+    when(experienceRepository.findByIdWithPiece(10L)).thenReturn(Optional.of(experience));
+    when(tagRepository.findByExperienceId(10L)).thenReturn(List.of());
+
+    String tooLongRole = "a".repeat(51);
+    ExperienceUpdateRequest request =
+        new ExperienceUpdateRequest(
+            "제목",
+            "한 줄 소개",
+            List.of(),
+            "S",
+            "T",
+            "A",
+            "R",
+            "L",
+            new Detail(
+                "끼움",
+                5,
+                tooLongRole,
+                80,
+                null,
+                null,
+                null,
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 6, 30)));
+
+    assertThatThrownBy(() -> experienceService.update(userId, 10L, request))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(EXPERIENCE_ROLE_TOO_LONG);
+  }
+
+  @Test
+  @DisplayName("CAREER 수정 시 공통 필드와 career detail이 모두 업데이트된다")
+  void updateCareerExperience() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Experience experience = createExperience(owner, PieceType.CAREER);
+    setId(experience, 10L);
+    Career career = createCareer(experience);
+
+    when(experienceRepository.findByIdWithPiece(10L)).thenReturn(Optional.of(experience));
+    when(tagRepository.findByExperienceId(10L)).thenReturn(List.of());
+    when(careerRepository.findByExperienceId(10L)).thenReturn(Optional.of(career));
+
+    ExperienceUpdateRequest request = careerRequest("수정된 제목");
+    experienceService.update(userId, 10L, request);
+
+    assertThat(experience.getTitle()).isEqualTo("수정된 제목");
+    assertThat(career.getCompany()).isEqualTo("끼움 회사");
+    verify(jdExperienceAnalysisService).evictCache(10L);
+  }
+
+  @Test
+  @DisplayName("CAREER company가 50자 초과이면 EXPERIENCE_COMPANY_TOO_LONG 예외를 던진다")
+  void throwWhenCareerCompanyTooLong() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Experience experience = createExperience(owner, PieceType.CAREER);
+    setId(experience, 10L);
+
+    when(experienceRepository.findByIdWithPiece(10L)).thenReturn(Optional.of(experience));
+    when(tagRepository.findByExperienceId(10L)).thenReturn(List.of());
+
+    String tooLongCompany = "a".repeat(51);
+    ExperienceUpdateRequest request =
+        new ExperienceUpdateRequest(
+            "제목",
+            "한 줄 소개",
+            List.of(),
+            "S",
+            "T",
+            "A",
+            "R",
+            "L",
+            new Detail(
+                null,
+                null,
+                null,
+                null,
+                tooLongCompany,
+                "인턴",
+                null,
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 6, 30)));
+
+    assertThatThrownBy(() -> experienceService.update(userId, 10L, request))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(EXPERIENCE_COMPANY_TOO_LONG);
+  }
+
+  @Test
+  @DisplayName("EDUCATION 수정 시 공통 필드와 education detail이 모두 업데이트된다")
+  void updateEducationExperience() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Experience experience = createExperience(owner, PieceType.EDUCATION);
+    setId(experience, 10L);
+    Education education = createEducation(experience);
+
+    when(experienceRepository.findByIdWithPiece(10L)).thenReturn(Optional.of(experience));
+    when(tagRepository.findByExperienceId(10L)).thenReturn(List.of());
+    when(educationRepository.findByExperienceId(10L)).thenReturn(Optional.of(education));
+
+    ExperienceUpdateRequest request = educationRequest("수정된 제목");
+    experienceService.update(userId, 10L, request);
+
+    assertThat(experience.getTitle()).isEqualTo("수정된 제목");
+    assertThat(education.getOrganizationName()).isEqualTo("끼움 대학교");
+    verify(jdExperienceAnalysisService).evictCache(10L);
+  }
+
+  @Test
+  @DisplayName("EDUCATION organizationName이 50자 초과이면 EXPERIENCE_ORGANIZATION_NAME_TOO_LONG 예외를 던진다")
+  void throwWhenEducationOrganizationNameTooLong() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Experience experience = createExperience(owner, PieceType.EDUCATION);
+    setId(experience, 10L);
+
+    when(experienceRepository.findByIdWithPiece(10L)).thenReturn(Optional.of(experience));
+    when(tagRepository.findByExperienceId(10L)).thenReturn(List.of());
+
+    String tooLongOrgName = "a".repeat(51);
+    ExperienceUpdateRequest request =
+        new ExperienceUpdateRequest(
+            "제목",
+            "한 줄 소개",
+            List.of(),
+            "S",
+            "T",
+            "A",
+            "R",
+            "L",
+            new Detail(
+                "스프링 기초",
+                null,
+                null,
+                null,
+                null,
+                null,
+                tooLongOrgName,
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 6, 30)));
+
+    assertThatThrownBy(() -> experienceService.update(userId, 10L, request))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(EXPERIENCE_ORGANIZATION_NAME_TOO_LONG);
+  }
+
+  @Test
+  @DisplayName("EDUCATION name이 80자 초과이면 EXPERIENCE_EDUCATION_NAME_TOO_LONG 예외를 던진다")
+  void throwWhenEducationNameTooLong() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Experience experience = createExperience(owner, PieceType.EDUCATION);
+    setId(experience, 10L);
+
+    when(experienceRepository.findByIdWithPiece(10L)).thenReturn(Optional.of(experience));
+    when(tagRepository.findByExperienceId(10L)).thenReturn(List.of());
+
+    String tooLongName = "a".repeat(81);
+    ExperienceUpdateRequest request =
+        new ExperienceUpdateRequest(
+            "제목",
+            "한 줄 소개",
+            List.of(),
+            "S",
+            "T",
+            "A",
+            "R",
+            "L",
+            new Detail(
+                tooLongName,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "끼움 대학교",
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 6, 30)));
+
+    assertThatThrownBy(() -> experienceService.update(userId, 10L, request))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(EXPERIENCE_EDUCATION_NAME_TOO_LONG);
+  }
+
+  @Test
+  @DisplayName("ETC 수정 시 공통 필드와 etc detail이 업데이트된다")
+  void updateEtcExperience() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Experience experience = createExperience(owner, PieceType.ETC);
+    setId(experience, 10L);
+    Etc etc = createEtc(experience);
+
+    when(experienceRepository.findByIdWithPiece(10L)).thenReturn(Optional.of(experience));
+    when(tagRepository.findByExperienceId(10L)).thenReturn(List.of());
+    when(etcRepository.findByExperienceId(10L)).thenReturn(Optional.of(etc));
+
+    ExperienceUpdateRequest request = etcRequest("수정된 제목");
+    experienceService.update(userId, 10L, request);
+
+    assertThat(experience.getTitle()).isEqualTo("수정된 제목");
+    verify(jdExperienceAnalysisService).evictCache(10L);
+  }
+
+  @Test
+  @DisplayName("수정 시 기존 태그를 전체 삭제하고 새 태그를 저장한다")
+  void deleteOldTagsAndSaveNewTags() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Experience experience = createExperience(owner, PieceType.ACTIVITY);
+    setId(experience, 10L);
+    Activity activity = createActivity(experience);
+
+    when(experienceRepository.findByIdWithPiece(10L)).thenReturn(Optional.of(experience));
+    when(tagRepository.findByExperienceId(10L)).thenReturn(List.of());
+    when(activityRepository.findByExperienceId(10L)).thenReturn(Optional.of(activity));
+
+    ExperienceUpdateRequest request = activityRequest("제목");
+    experienceService.update(userId, 10L, request);
+
+    verify(tagRepository).deleteAll(any());
+    verify(tagRepository).saveAll(any());
+  }
+
+  // ── 캐시 무효화 ───────────────────────────────────────────────
+
+  @Test
+  @DisplayName("수정 성공 시 Redis 캐시를 무효화한다")
+  void evictCacheAfterUpdate() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Experience experience = createExperience(owner, PieceType.ACTIVITY);
+    setId(experience, 10L);
+    Activity activity = createActivity(experience);
+
+    when(experienceRepository.findByIdWithPiece(10L)).thenReturn(Optional.of(experience));
+    when(tagRepository.findByExperienceId(10L)).thenReturn(List.of());
+    when(activityRepository.findByExperienceId(10L)).thenReturn(Optional.of(activity));
+
+    experienceService.update(userId, 10L, activityRequest("제목"));
+
+    verify(jdExperienceAnalysisService).evictCache(10L);
+  }
+
+  @Test
+  @DisplayName("권한 검증 실패 시 캐시 무효화를 호출하지 않는다")
+  void notEvictCacheWhenForbidden() {
+    Long ownerId = 1L;
+    Long requestUserId = 2L;
+    User owner = createUser(ownerId);
+    Experience experience = createExperience(owner, PieceType.ACTIVITY);
+    setId(experience, 10L);
+
+    when(experienceRepository.findByIdWithPiece(10L)).thenReturn(Optional.of(experience));
+
+    assertThatThrownBy(() -> experienceService.update(requestUserId, 10L, activityRequest("제목")))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(FORBIDDEN);
+
+    verify(jdExperienceAnalysisService, never()).evictCache(any());
+  }
+
+  private User createUser(Long id) {
+    User user =
+        User.basicLoginBuilder()
+            .name("테스트 유저")
+            .email("test" + id + "@example.com")
+            .password("encoded-password")
+            .build();
+    setId(user, id);
+    return user;
+  }
+
+  private Experience createExperience(User owner, PieceType type) {
+    Piece piece = Piece.builder().type(type).user(owner).build();
+    return Experience.builder()
+        .piece(piece)
+        .title("기존 제목")
+        .oneLineIntro("기존 한 줄 소개")
+        .situation("S")
+        .task("T")
+        .act("A")
+        .result("R")
+        .taken("L")
+        .build();
+  }
+
+  private Activity createActivity(Experience experience) {
+    return Activity.builder()
+        .name("기존 동아리")
+        .teamNum(5)
+        .role("기존 역할")
+        .contributionRate(80)
+        .startDate(LocalDate.of(2023, 1, 1))
+        .endDate(LocalDate.of(2023, 6, 30))
+        .experience(experience)
+        .build();
+  }
+
+  private Career createCareer(Experience experience) {
+    return Career.builder()
+        .name("기존 제목")
+        .company("기존 회사")
+        .employmentStatus("인턴")
+        .startDate(LocalDate.of(2023, 1, 1))
+        .endDate(LocalDate.of(2023, 6, 30))
+        .experience(experience)
+        .build();
+  }
+
+  private Education createEducation(Experience experience) {
+    return Education.builder()
+        .organizationName("기존 대학교")
+        .name("기존 강의명")
+        .startDate(LocalDate.of(2023, 1, 1))
+        .endDate(LocalDate.of(2023, 6, 30))
+        .experience(experience)
+        .build();
+  }
+
+  private Etc createEtc(Experience experience) {
+    return Etc.builder()
+        .startDate(LocalDate.of(2023, 1, 1))
+        .endDate(LocalDate.of(2023, 6, 30))
+        .experience(experience)
+        .build();
+  }
+
+  private ExperienceUpdateRequest activityRequest(String title) {
+    return new ExperienceUpdateRequest(
+        title,
+        "한 줄 소개",
+        List.of(new TagCreateRequest(TagCategory.TECH, "Java")),
+        "S",
+        "T",
+        "A",
+        "R",
+        "L",
+        new Detail(
+            "끼움 동아리",
+            5,
+            "백엔드",
+            80,
+            null,
+            null,
+            null,
+            LocalDate.of(2024, 1, 1),
+            LocalDate.of(2024, 6, 30)));
+  }
+
+  private ExperienceUpdateRequest careerRequest(String title) {
+    return new ExperienceUpdateRequest(
+        title,
+        "한 줄 소개",
+        List.of(new TagCreateRequest(TagCategory.TECH, "Spring")),
+        "S",
+        "T",
+        "A",
+        "R",
+        "L",
+        new Detail(
+            null,
+            null,
+            null,
+            null,
+            "끼움 회사",
+            "인턴",
+            null,
+            LocalDate.of(2024, 1, 1),
+            LocalDate.of(2024, 6, 30)));
+  }
+
+  private ExperienceUpdateRequest educationRequest(String title) {
+    return new ExperienceUpdateRequest(
+        title,
+        "한 줄 소개",
+        List.of(new TagCreateRequest(TagCategory.COMPETENCY, "문제해결")),
+        "S",
+        "T",
+        "A",
+        "R",
+        "L",
+        new Detail(
+            "스프링 기초",
+            null,
+            null,
+            null,
+            null,
+            null,
+            "끼움 대학교",
+            LocalDate.of(2024, 1, 1),
+            LocalDate.of(2024, 6, 30)));
+  }
+
+  private ExperienceUpdateRequest etcRequest(String title) {
+    return new ExperienceUpdateRequest(
+        title,
+        "한 줄 소개",
+        List.of(),
+        "S",
+        "T",
+        "A",
+        "R",
+        "L",
+        new Detail(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            LocalDate.of(2024, 1, 1),
+            LocalDate.of(2024, 6, 30)));
+  }
+
+  private void setId(Object target, Long id) {
+    try {
+      Field field = target.getClass().getDeclaredField("id");
+      field.setAccessible(true);
+      field.set(target, id);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Failed to set test id", e);
+    }
+  }
+}

--- a/src/test/java/com/kusitms/kkium/jd/GoldStandardDataGenerator.java
+++ b/src/test/java/com/kusitms/kkium/jd/GoldStandardDataGenerator.java
@@ -33,6 +33,7 @@ import com.kusitms.kkium.jd.utils.llm.JdMatchPromptBuilder;
  *
  * <p>출력 파일: - gold_standard_jd_info.csv (평가자가 참고할 JD 정보) - gold_standard_eval.csv (평가 시트)
  */
+@Disabled("수동 실행 전용 - 로컬 DB, OpenAI API 호출 필요")
 @SpringBootTest
 @ActiveProfiles("local")
 class GoldStandardDataGenerator {

--- a/src/test/java/com/kusitms/kkium/jd/LlmConsistencyTest.java
+++ b/src/test/java/com/kusitms/kkium/jd/LlmConsistencyTest.java
@@ -29,6 +29,7 @@ import com.kusitms.kkium.jd.utils.llm.JdMatchPromptBuilder;
  * <p>사용법: 1. 아래 TARGET_JD_ID, TARGET_USER_ID를 실제 DB 데이터에 맞게 수정 2. local 프로파일로 실행 (DB 연결 필요) 3.
  * OpenAI API 키가 환경변수에 설정되어 있어야 함
  */
+@Disabled("수동 실행 전용 - 로컬 DB, OpenAI API 호출 필요")
 @SpringBootTest
 @ActiveProfiles("local")
 class LlmConsistencyTest {

--- a/src/test/java/com/kusitms/kkium/jd/service/JdExperienceAnalysisServiceTest.java
+++ b/src/test/java/com/kusitms/kkium/jd/service/JdExperienceAnalysisServiceTest.java
@@ -1,0 +1,236 @@
+package com.kusitms.kkium.jd.service;
+
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_NOT_FOUND;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.FORBIDDEN;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.JD_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kusitms.kkium.experience.domain.Experience;
+import com.kusitms.kkium.experience.domain.Piece;
+import com.kusitms.kkium.experience.domain.type.PieceType;
+import com.kusitms.kkium.experience.repository.ExperienceRepository;
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.jd.domain.Jd;
+import com.kusitms.kkium.jd.dto.response.JdExperienceAnalysisResponse;
+import com.kusitms.kkium.jd.dto.response.JdExperienceAnalysisResponse.ExperienceAnalysis;
+import com.kusitms.kkium.jd.repository.JdRepository;
+import com.kusitms.kkium.jd.utils.llm.LlmMatchScoreService;
+import com.kusitms.kkium.jd.utils.llm.result.LlmExperienceDetailResult;
+import com.kusitms.kkium.user.domain.User;
+
+@ExtendWith(MockitoExtension.class)
+class JdExperienceAnalysisServiceTest {
+
+  @Mock private JdRepository jdRepository;
+  @Mock private ExperienceRepository experienceRepository;
+  @Mock private LlmMatchScoreService llmMatchScoreService;
+  @Mock private StringRedisTemplate redisTemplate;
+  @Mock private ValueOperations<String, String> valueOperations;
+
+  private JdExperienceAnalysisService jdExperienceAnalysisService;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeEach
+  void setUp() {
+    jdExperienceAnalysisService =
+        new JdExperienceAnalysisService(
+            jdRepository, experienceRepository, llmMatchScoreService, redisTemplate, objectMapper);
+  }
+
+  // ── NOT FOUND ──────────────────────────────────────────────
+
+  @Test
+  @DisplayName("존재하지 않는 JD이면 JD_NOT_FOUND 예외를 던진다")
+  void throwWhenJdNotFound() {
+    when(jdRepository.findById(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> jdExperienceAnalysisService.analyze(999L, 1L, 1L))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(JD_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 경험이면 EXPERIENCE_NOT_FOUND 예외를 던진다")
+  void throwWhenExperienceNotFound() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createJd(owner);
+    setId(jd, 10L);
+
+    // 실행 순서: 1.JD조회 → 2.JD소유자검증 → 3.경험조회(여기서 예외) → 4... → 5.Redis
+    // Redis stub 불필요
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(experienceRepository.findByIdWithPiece(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> jdExperienceAnalysisService.analyze(10L, 999L, userId))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(EXPERIENCE_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("JD 소유자가 아닌 유저가 요청하면 FORBIDDEN 예외를 던진다")
+  void throwWhenUserIsNotJdOwner() {
+    Long jdOwnerId = 1L;
+    Long requestUserId = 2L;
+    User owner = createUser(jdOwnerId);
+    Jd jd = createJd(owner);
+    setId(jd, 10L);
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+
+    assertThatThrownBy(() -> jdExperienceAnalysisService.analyze(10L, 1L, requestUserId))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("경험 소유자가 다른 유저이면 FORBIDDEN 예외를 던진다")
+  void throwWhenUserIsNotExperienceOwner() {
+    Long userId = 1L;
+    Long otherUserId = 2L;
+    User owner = createUser(userId);
+    User other = createUser(otherUserId);
+    Jd jd = createJd(owner);
+    setId(jd, 10L);
+    Experience otherExperience = createExperience(other);
+    setId(otherExperience, 30L);
+
+    // 실행 순서: 1.JD조회 → 2.JD소유자검증 → 3.경험조회 → 4.경험소유자검증(여기서 예외) → 5.Redis
+    // Redis stub 불필요
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(experienceRepository.findByIdWithPiece(30L)).thenReturn(Optional.of(otherExperience));
+
+    assertThatThrownBy(() -> jdExperienceAnalysisService.analyze(10L, 30L, userId))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("Redis 캐시 히트 시 LLM을 호출하지 않고 캐시 결과를 반환한다")
+  void returnCachedResultWithoutLlmCall() throws Exception {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createJd(owner);
+    setId(jd, 10L);
+    Experience experience = createExperience(owner);
+    setId(experience, 30L);
+
+    JdExperienceAnalysisResponse cached =
+        new JdExperienceAnalysisResponse(
+            30L, new ExperienceAnalysis("강점입니다.", "약점입니다.", "활용 가이드입니다.", List.of()));
+    String cachedJson = objectMapper.writeValueAsString(cached);
+
+    // 실행 순서: 1.JD조회 → 2.JD소유자검증 → 3.경험조회 → 4.경험소유자검증 → 5.Redis(캐시 히트 → 즉시 반환)
+    // 3번 경험 조회가 Redis보다 먼저 실행되므로 stub 필요
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(experienceRepository.findByIdWithPiece(30L)).thenReturn(Optional.of(experience));
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    when(valueOperations.get("jd-analysis:30:10")).thenReturn(cachedJson);
+
+    JdExperienceAnalysisResponse response = jdExperienceAnalysisService.analyze(10L, 30L, userId);
+
+    assertThat(response.experienceId()).isEqualTo(30L);
+    assertThat(response.analysis().strengths()).isEqualTo("강점입니다.");
+    verify(llmMatchScoreService, never()).analyzeExperienceDetail(any(), any());
+  }
+
+  @Test
+  @DisplayName("Redis 캐시 미스 시 LLM을 호출하고 결과를 캐시에 저장한다")
+  void callLlmAndSaveCacheOnCacheMiss() throws Exception {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createJd(owner);
+    setId(jd, 10L);
+    Experience experience = createExperience(owner);
+    setId(experience, 30L);
+    LlmExperienceDetailResult llmResult =
+        new LlmExperienceDetailResult("강점입니다.", "약점입니다.", "활용 가이드입니다.", List.of());
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    when(valueOperations.get("jd-analysis:30:10")).thenReturn(null);
+    when(experienceRepository.findByIdWithPiece(30L)).thenReturn(Optional.of(experience));
+    when(llmMatchScoreService.analyzeExperienceDetail(jd, experience)).thenReturn(llmResult);
+
+    JdExperienceAnalysisResponse response = jdExperienceAnalysisService.analyze(10L, 30L, userId);
+
+    assertThat(response.experienceId()).isEqualTo(30L);
+    assertThat(response.analysis().strengths()).isEqualTo("강점입니다.");
+    assertThat(response.analysis().weaknesses()).isEqualTo("약점입니다.");
+    assertThat(response.analysis().usageGuide()).isEqualTo("활용 가이드입니다.");
+    verify(llmMatchScoreService).analyzeExperienceDetail(jd, experience);
+    verify(valueOperations).set(eq("jd-analysis:30:10"), anyString(), any());
+  }
+
+  private User createUser(Long id) {
+    User user =
+        User.basicLoginBuilder()
+            .name("테스트 유저")
+            .email("test" + id + "@example.com")
+            .password("encoded-password")
+            .build();
+    setId(user, id);
+    return user;
+  }
+
+  private Jd createJd(User owner) {
+    return Jd.builder()
+        .user(owner)
+        .postingTitle("백엔드 개발자")
+        .companyName("끼움")
+        .recruitmentField("백엔드")
+        .hardSkill("Java, Spring")
+        .softSkill("협업")
+        .rawText("공고 본문")
+        .build();
+  }
+
+  private Experience createExperience(User owner) {
+    Piece piece = Piece.builder().type(PieceType.ACTIVITY).user(owner).build();
+    return Experience.builder()
+        .piece(piece)
+        .title("정산 배치 안정화")
+        .oneLineIntro("장애율을 낮춘 프로젝트")
+        .situation("배치가 자주 실패했습니다.")
+        .task("안정화가 필요했습니다.")
+        .act("재시도 로직을 개선했습니다.")
+        .result("실패율을 낮췄습니다.")
+        .taken("모니터링의 중요성을 배웠습니다.")
+        .build();
+  }
+
+  private void setId(Object target, Long id) {
+    try {
+      Field field = target.getClass().getDeclaredField("id");
+      field.setAccessible(true);
+      field.set(target, id);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Failed to set test id", e);
+    }
+  }
+}

--- a/src/test/java/com/kusitms/kkium/jd/service/JdMatchServiceTest.java
+++ b/src/test/java/com/kusitms/kkium/jd/service/JdMatchServiceTest.java
@@ -1,0 +1,291 @@
+package com.kusitms.kkium.jd.service;
+
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.JD_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.kusitms.kkium.experience.domain.Experience;
+import com.kusitms.kkium.experience.domain.Piece;
+import com.kusitms.kkium.experience.domain.type.PieceType;
+import com.kusitms.kkium.experience.repository.ExperienceRepository;
+import com.kusitms.kkium.experience.repository.TagRepository;
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.jd.domain.Jd;
+import com.kusitms.kkium.jd.domain.type.AnalysisStatus;
+import com.kusitms.kkium.jd.dto.response.JdMatchAnalysisResponse;
+import com.kusitms.kkium.jd.repository.JdMatchRepository;
+import com.kusitms.kkium.jd.repository.JdMatchRepository.PieceSimilarity;
+import com.kusitms.kkium.jd.repository.JdRepository;
+import com.kusitms.kkium.jd.utils.llm.LlmMatchScoreService;
+import com.kusitms.kkium.jd.utils.llm.result.LlmMatchResult;
+import com.kusitms.kkium.user.domain.User;
+
+@ExtendWith(MockitoExtension.class)
+class JdMatchServiceTest {
+
+  @Mock private JdRepository jdRepository;
+  @Mock private ExperienceRepository experienceRepository;
+  @Mock private TagRepository tagRepository;
+  @Mock private JdMatchRepository jdMatchRepository;
+  @Mock private LlmMatchScoreService llmMatchScoreService;
+
+  private JdMatchService jdMatchService;
+
+  @BeforeEach
+  void setUp() {
+    jdMatchService =
+        new JdMatchService(
+            jdRepository,
+            experienceRepository,
+            tagRepository,
+            jdMatchRepository,
+            llmMatchScoreService);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 JD이면 JD_NOT_FOUND 예외를 던진다")
+  void throwWhenJdNotFound() {
+    when(jdRepository.findById(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> jdMatchService.analyze(999L, 1L))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(JD_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("분석 상태가 PENDING이면 경험 조회 없이 상태만 반환한다")
+  void returnPendingStatusWithoutExperienceQuery() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createJd(owner, "Java, Spring", "협업");
+    setId(jd, 10L);
+    // Jd 빌더 기본값이 PENDING이므로 그대로 사용
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+
+    JdMatchAnalysisResponse response = jdMatchService.analyze(10L, userId);
+
+    assertThat(response.analysisStatus()).isEqualTo(AnalysisStatus.PENDING);
+    assertThat(response.jdInfo()).isNull();
+    assertThat(response.matchResult()).isNull();
+    verify(experienceRepository, never()).findAllByUserIdForAnalysis(any());
+  }
+
+  @Test
+  @DisplayName("분석 상태가 IN_PROGRESS이면 경험 조회 없이 상태만 반환한다")
+  void returnInProgressStatusWithoutExperienceQuery() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createJd(owner, "Java", "문제 해결");
+    setId(jd, 10L);
+    jd.updateAnalysisStatus(AnalysisStatus.PENDING);
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+
+    JdMatchAnalysisResponse response = jdMatchService.analyze(10L, userId);
+
+    assertThat(response.analysisStatus()).isEqualTo(AnalysisStatus.PENDING);
+    assertThat(response.jdInfo()).isNull();
+    verify(experienceRepository, never()).findAllByUserIdForAnalysis(any());
+  }
+
+  @Test
+  @DisplayName("분석 완료 상태에서 유저 경험이 없으면 applicationFitScore=0, 빈 카드 목록을 반환한다")
+  void returnEmptyMatchResultWhenNoExperiences() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createCompletedJd(owner);
+    setId(jd, 10L);
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(experienceRepository.findAllByUserIdForAnalysis(userId)).thenReturn(List.of());
+
+    JdMatchAnalysisResponse response = jdMatchService.analyze(10L, userId);
+
+    assertThat(response.analysisStatus()).isEqualTo(AnalysisStatus.COMPLETED);
+    assertThat(response.jdInfo()).isNotNull();
+    assertThat(response.matchResult().applicationFitScore()).isZero();
+    assertThat(response.matchResult().experiences()).isEmpty();
+    verify(llmMatchScoreService, never()).scoreAll(any(), any());
+  }
+
+  @Test
+  @DisplayName("활용 적합도는 임베딩 점수 × 0.3 + LLM 점수 × 0.7로 계산된다")
+  void calculateUsageFitScoreWithWeightedFormula() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createCompletedJd(owner);
+    setId(jd, 10L);
+
+    // pieceId=100, 임베딩=60, LLM=80 → 활용적합도 = round(60*0.3 + 80*0.7) = round(18+56) = 74
+    Piece piece = Piece.builder().type(PieceType.ACTIVITY).user(owner).build();
+    setId(piece, 100L);
+    Experience exp = createExperienceWithPiece(piece);
+    setId(exp, 30L);
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(experienceRepository.findAllByUserIdForAnalysis(userId)).thenReturn(List.of(exp));
+    when(jdMatchRepository.findSimilaritiesByJdAndUser(10L, userId))
+        .thenReturn(List.of(new PieceSimilarity(100L, 60)));
+    when(llmMatchScoreService.scoreAll(eq(jd), any()))
+        .thenReturn(new LlmMatchResult(Map.of(100L, 80), 70));
+    when(tagRepository.findByExperienceIdIn(List.of(30L))).thenReturn(List.of());
+
+    JdMatchAnalysisResponse response = jdMatchService.analyze(10L, userId);
+
+    assertThat(response.matchResult().experiences()).hasSize(1);
+    assertThat(response.matchResult().experiences().get(0).usageFitScore()).isEqualTo(74);
+  }
+
+  @Test
+  @DisplayName("임베딩 점수가 없는 경험은 임베딩 점수 0으로 처리한다")
+  void useZeroEmbeddingScoreWhenNotFound() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createCompletedJd(owner);
+    setId(jd, 10L);
+
+    // pieceId=100, 임베딩 점수 없음(0), LLM=50 → 활용적합도 = round(0*0.3 + 50*0.7) = 35
+    Piece piece = Piece.builder().type(PieceType.ACTIVITY).user(owner).build();
+    setId(piece, 100L);
+    Experience exp = createExperienceWithPiece(piece);
+    setId(exp, 30L);
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(experienceRepository.findAllByUserIdForAnalysis(userId)).thenReturn(List.of(exp));
+    when(jdMatchRepository.findSimilaritiesByJdAndUser(10L, userId)).thenReturn(List.of());
+    when(llmMatchScoreService.scoreAll(eq(jd), any()))
+        .thenReturn(new LlmMatchResult(Map.of(100L, 50), 40));
+    when(tagRepository.findByExperienceIdIn(List.of(30L))).thenReturn(List.of());
+
+    JdMatchAnalysisResponse response = jdMatchService.analyze(10L, userId);
+
+    assertThat(response.matchResult().experiences().get(0).usageFitScore()).isEqualTo(35);
+  }
+
+  @Test
+  @DisplayName("경험 카드 목록은 활용 적합도 내림차순으로 정렬된다")
+  void sortExperienceCardsByUsageFitScoreDesc() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createCompletedJd(owner);
+    setId(jd, 10L);
+
+    // pieceId=101 → 임베딩=80, LLM=90 → 활용적합도 = round(80*0.3+90*0.7) = round(24+63) = 87
+    // pieceId=102 → 임베딩=40, LLM=30 → 활용적합도 = round(40*0.3+30*0.7) = round(12+21) = 33
+    Piece piece1 = Piece.builder().type(PieceType.ACTIVITY).user(owner).build();
+    setId(piece1, 101L);
+    Piece piece2 = Piece.builder().type(PieceType.CAREER).user(owner).build();
+    setId(piece2, 102L);
+    Experience exp1 = createExperienceWithPiece(piece1);
+    setId(exp1, 31L);
+    Experience exp2 = createExperienceWithPiece(piece2);
+    setId(exp2, 32L);
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(experienceRepository.findAllByUserIdForAnalysis(userId))
+        .thenReturn(List.of(exp2, exp1)); // 의도적으로 낮은 점수 먼저
+    when(jdMatchRepository.findSimilaritiesByJdAndUser(10L, userId))
+        .thenReturn(List.of(new PieceSimilarity(101L, 80), new PieceSimilarity(102L, 40)));
+    when(llmMatchScoreService.scoreAll(eq(jd), any()))
+        .thenReturn(new LlmMatchResult(Map.of(101L, 90, 102L, 30), 60));
+    when(tagRepository.findByExperienceIdIn(any())).thenReturn(List.of());
+
+    JdMatchAnalysisResponse response = jdMatchService.analyze(10L, userId);
+
+    List<JdMatchAnalysisResponse.ExperienceMatchCard> cards = response.matchResult().experiences();
+    assertThat(cards).hasSize(2);
+    assertThat(cards.get(0).usageFitScore()).isGreaterThan(cards.get(1).usageFitScore());
+    assertThat(cards.get(0).experienceId()).isEqualTo(31L);
+    assertThat(cards.get(1).experienceId()).isEqualTo(32L);
+  }
+
+  @Test
+  @DisplayName("hardSkill과 softSkill은 쉼표로 분리되어 JdInfo에 리스트로 담긴다")
+  void parseSkillTagsIntoListInJdInfo() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createCompletedJd(owner);
+    setId(jd, 10L);
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(experienceRepository.findAllByUserIdForAnalysis(userId)).thenReturn(List.of());
+
+    JdMatchAnalysisResponse response = jdMatchService.analyze(10L, userId);
+
+    assertThat(response.jdInfo().hardSkills()).containsExactly("Java", "Spring");
+    assertThat(response.jdInfo().softSkills()).containsExactly("협업", "문제 해결");
+  }
+
+  private User createUser(Long id) {
+    User user =
+        User.basicLoginBuilder()
+            .name("테스트 유저")
+            .email("test" + id + "@example.com")
+            .password("encoded-password")
+            .build();
+    setId(user, id);
+    return user;
+  }
+
+  private Jd createJd(User owner, String hardSkill, String softSkill) {
+    return Jd.builder()
+        .user(owner)
+        .postingTitle("백엔드 개발자")
+        .companyName("끼움")
+        .recruitmentField("백엔드")
+        .hardSkill(hardSkill)
+        .softSkill(softSkill)
+        .rawText("공고 본문")
+        .build();
+  }
+
+  /** COMPLETED 상태의 JD를 생성한다 (hardSkill, softSkill 기본값 포함) */
+  private Jd createCompletedJd(User owner) {
+    Jd jd = createJd(owner, "Java, Spring", "협업, 문제 해결");
+    jd.updateAnalysisStatus(AnalysisStatus.COMPLETED);
+    jd.updateAnalysis("주요 업무", "필수 자격", "우대 사항", "Java, Spring", "협업, 문제 해결");
+    return jd;
+  }
+
+  private Experience createExperienceWithPiece(Piece piece) {
+    return Experience.builder()
+        .piece(piece)
+        .title("정산 배치 안정화")
+        .oneLineIntro("장애율을 낮춘 프로젝트")
+        .situation("배치가 자주 실패했습니다.")
+        .task("안정화가 필요했습니다.")
+        .act("재시도 로직을 개선했습니다.")
+        .result("실패율을 낮췄습니다.")
+        .taken("모니터링의 중요성을 배웠습니다.")
+        .build();
+  }
+
+  private void setId(Object target, Long id) {
+    try {
+      Field field = target.getClass().getDeclaredField("id");
+      field.setAccessible(true);
+      field.set(target, id);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Failed to set test id", e);
+    }
+  }
+}

--- a/src/test/java/com/kusitms/kkium/resume/service/ResumeQuestionExperienceServiceTest.java
+++ b/src/test/java/com/kusitms/kkium/resume/service/ResumeQuestionExperienceServiceTest.java
@@ -107,7 +107,7 @@ class ResumeQuestionExperienceServiceTest {
 
     when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
     when(jdQuestionRepository.findById(20L)).thenReturn(Optional.of(question));
-    when(experienceRepository.findAllByUserIdNoPage(userId)).thenReturn(List.of());
+    when(experienceRepository.findAllByUserIdForAnalysis(userId)).thenReturn(List.of());
 
     ResumeQuestionExperienceResponse response =
         resumeQuestionExperienceService.getExperiencesWithFitScore(10L, 20L, userId);
@@ -134,7 +134,7 @@ class ResumeQuestionExperienceServiceTest {
 
     when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
     when(jdQuestionRepository.findById(20L)).thenReturn(Optional.of(question));
-    when(experienceRepository.findAllByUserIdNoPage(userId)).thenReturn(List.of(exp));
+    when(experienceRepository.findAllByUserIdForAnalysis(userId)).thenReturn(List.of(exp));
     when(jdMatchRepository.findSimilaritiesByJdAndUser(10L, userId))
         .thenReturn(List.of(new PieceSimilarity(100L, 60)));
     when(llmMatchScoreService.scoreAllByQuestion(eq(jd), eq(question), any()))
@@ -166,7 +166,7 @@ class ResumeQuestionExperienceServiceTest {
 
     when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
     when(jdQuestionRepository.findById(20L)).thenReturn(Optional.of(question));
-    when(experienceRepository.findAllByUserIdNoPage(userId)).thenReturn(List.of(exp));
+    when(experienceRepository.findAllByUserIdForAnalysis(userId)).thenReturn(List.of(exp));
     when(jdMatchRepository.findSimilaritiesByJdAndUser(10L, userId)).thenReturn(List.of());
     when(llmMatchScoreService.scoreAllByQuestion(eq(jd), eq(question), any()))
         .thenReturn(new LlmQuestionMatchResult(Map.of(100L, 50)));
@@ -201,7 +201,7 @@ class ResumeQuestionExperienceServiceTest {
 
     when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
     when(jdQuestionRepository.findById(20L)).thenReturn(Optional.of(question));
-    when(experienceRepository.findAllByUserIdNoPage(userId))
+    when(experienceRepository.findAllByUserIdForAnalysis(userId))
         .thenReturn(List.of(exp2, exp1)); // 낮은 점수 먼저 투입
     when(jdMatchRepository.findSimilaritiesByJdAndUser(10L, userId))
         .thenReturn(List.of(new PieceSimilarity(101L, 80), new PieceSimilarity(102L, 40)));
@@ -237,7 +237,7 @@ class ResumeQuestionExperienceServiceTest {
 
     when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
     when(jdQuestionRepository.findById(20L)).thenReturn(Optional.of(question));
-    when(experienceRepository.findAllByUserIdNoPage(userId)).thenReturn(List.of(exp));
+    when(experienceRepository.findAllByUserIdForAnalysis(userId)).thenReturn(List.of(exp));
     when(jdMatchRepository.findSimilaritiesByJdAndUser(10L, userId)).thenReturn(List.of());
     when(llmMatchScoreService.scoreAllByQuestion(eq(jd), eq(question), any()))
         .thenReturn(new LlmQuestionMatchResult(Map.of(100L, 60)));

--- a/src/test/java/com/kusitms/kkium/resume/service/ResumeQuestionExperienceServiceTest.java
+++ b/src/test/java/com/kusitms/kkium/resume/service/ResumeQuestionExperienceServiceTest.java
@@ -1,0 +1,302 @@
+package com.kusitms.kkium.resume.service;
+
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.JD_NOT_FOUND;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.QUESTION_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.kusitms.kkium.experience.domain.Experience;
+import com.kusitms.kkium.experience.domain.Piece;
+import com.kusitms.kkium.experience.domain.type.PieceType;
+import com.kusitms.kkium.experience.repository.ExperienceRepository;
+import com.kusitms.kkium.experience.service.ExperiencePeriodResolver;
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.jd.domain.Jd;
+import com.kusitms.kkium.jd.domain.JdQuestion;
+import com.kusitms.kkium.jd.repository.JdMatchRepository;
+import com.kusitms.kkium.jd.repository.JdMatchRepository.PieceSimilarity;
+import com.kusitms.kkium.jd.repository.JdQuestionRepository;
+import com.kusitms.kkium.jd.repository.JdRepository;
+import com.kusitms.kkium.jd.utils.llm.LlmMatchScoreService;
+import com.kusitms.kkium.jd.utils.llm.result.LlmQuestionMatchResult;
+import com.kusitms.kkium.resume.dto.response.ResumeQuestionExperienceResponse;
+import com.kusitms.kkium.resume.dto.response.ResumeQuestionExperienceResponse.ExperienceMatchItem;
+import com.kusitms.kkium.user.domain.User;
+
+@ExtendWith(MockitoExtension.class)
+class ResumeQuestionExperienceServiceTest {
+
+  @Mock private JdRepository jdRepository;
+  @Mock private JdQuestionRepository jdQuestionRepository;
+  @Mock private ExperienceRepository experienceRepository;
+  @Mock private JdMatchRepository jdMatchRepository;
+  @Mock private LlmMatchScoreService llmMatchScoreService;
+  @Mock private ExperiencePeriodResolver experiencePeriodResolver;
+
+  private ResumeQuestionExperienceService resumeQuestionExperienceService;
+
+  @BeforeEach
+  void setUp() {
+    resumeQuestionExperienceService =
+        new ResumeQuestionExperienceService(
+            jdRepository,
+            jdQuestionRepository,
+            experienceRepository,
+            jdMatchRepository,
+            llmMatchScoreService,
+            experiencePeriodResolver);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 JD이면 JD_NOT_FOUND 예외를 던진다")
+  void throwWhenJdNotFound() {
+    when(jdRepository.findById(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () -> resumeQuestionExperienceService.getExperiencesWithFitScore(999L, 1L, 1L))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(JD_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 문항이면 QUESTION_NOT_FOUND 예외를 던진다")
+  void throwWhenQuestionNotFound() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createJd(owner);
+    setId(jd, 10L);
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(jdQuestionRepository.findById(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () -> resumeQuestionExperienceService.getExperiencesWithFitScore(10L, 999L, userId))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(QUESTION_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("유저 경험이 없으면 LLM 호출 없이 빈 리스트를 반환한다")
+  void returnEmptyListWithoutLlmCallWhenNoExperiences() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createJd(owner);
+    setId(jd, 10L);
+    JdQuestion question = createQuestion(jd);
+    setId(question, 20L);
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(jdQuestionRepository.findById(20L)).thenReturn(Optional.of(question));
+    when(experienceRepository.findAllByUserIdNoPage(userId)).thenReturn(List.of());
+
+    ResumeQuestionExperienceResponse response =
+        resumeQuestionExperienceService.getExperiencesWithFitScore(10L, 20L, userId);
+
+    assertThat(response.experiences()).isEmpty();
+    verify(llmMatchScoreService, never()).scoreAllByQuestion(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("활용 적합도는 임베딩 점수 × 0.3 + LLM 점수 × 0.7로 계산된다")
+  void calculateUsageFitScoreWithWeightedFormula() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createJd(owner);
+    setId(jd, 10L);
+    JdQuestion question = createQuestion(jd);
+    setId(question, 20L);
+
+    // pieceId=100, 임베딩=60, LLM=80 → 활용적합도 = round(60*0.3 + 80*0.7) = round(18+56) = 74
+    Piece piece = Piece.builder().type(PieceType.ACTIVITY).user(owner).build();
+    setId(piece, 100L);
+    Experience exp = createExperienceWithPiece(piece);
+    setId(exp, 30L);
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(jdQuestionRepository.findById(20L)).thenReturn(Optional.of(question));
+    when(experienceRepository.findAllByUserIdNoPage(userId)).thenReturn(List.of(exp));
+    when(jdMatchRepository.findSimilaritiesByJdAndUser(10L, userId))
+        .thenReturn(List.of(new PieceSimilarity(100L, 60)));
+    when(llmMatchScoreService.scoreAllByQuestion(eq(jd), eq(question), any()))
+        .thenReturn(new LlmQuestionMatchResult(Map.of(100L, 80)));
+    when(experiencePeriodResolver.resolvePeriodBulk(any())).thenReturn(Map.of());
+
+    ResumeQuestionExperienceResponse response =
+        resumeQuestionExperienceService.getExperiencesWithFitScore(10L, 20L, userId);
+
+    assertThat(response.experiences()).hasSize(1);
+    assertThat(response.experiences().get(0).usageFitScore()).isEqualTo(74);
+  }
+
+  @Test
+  @DisplayName("임베딩 점수가 없는 경험은 임베딩 점수 0으로 처리한다")
+  void useZeroEmbeddingScoreWhenNotFound() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createJd(owner);
+    setId(jd, 10L);
+    JdQuestion question = createQuestion(jd);
+    setId(question, 20L);
+
+    // pieceId=100, 임베딩 없음(0), LLM=50 → 활용적합도 = round(0*0.3 + 50*0.7) = 35
+    Piece piece = Piece.builder().type(PieceType.ACTIVITY).user(owner).build();
+    setId(piece, 100L);
+    Experience exp = createExperienceWithPiece(piece);
+    setId(exp, 30L);
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(jdQuestionRepository.findById(20L)).thenReturn(Optional.of(question));
+    when(experienceRepository.findAllByUserIdNoPage(userId)).thenReturn(List.of(exp));
+    when(jdMatchRepository.findSimilaritiesByJdAndUser(10L, userId)).thenReturn(List.of());
+    when(llmMatchScoreService.scoreAllByQuestion(eq(jd), eq(question), any()))
+        .thenReturn(new LlmQuestionMatchResult(Map.of(100L, 50)));
+    when(experiencePeriodResolver.resolvePeriodBulk(any())).thenReturn(Map.of());
+
+    ResumeQuestionExperienceResponse response =
+        resumeQuestionExperienceService.getExperiencesWithFitScore(10L, 20L, userId);
+
+    assertThat(response.experiences().get(0).usageFitScore()).isEqualTo(35);
+  }
+
+  @Test
+  @DisplayName("경험 목록은 활용 적합도 내림차순으로 정렬된다")
+  void sortExperiencesByUsageFitScoreDesc() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createJd(owner);
+    setId(jd, 10L);
+    JdQuestion question = createQuestion(jd);
+    setId(question, 20L);
+
+    // pieceId=101 → 임베딩=80, LLM=90 → 활용적합도 = round(80*0.3+90*0.7) = 87
+    // pieceId=102 → 임베딩=40, LLM=30 → 활용적합도 = round(40*0.3+30*0.7) = 33
+    Piece piece1 = Piece.builder().type(PieceType.ACTIVITY).user(owner).build();
+    setId(piece1, 101L);
+    Piece piece2 = Piece.builder().type(PieceType.CAREER).user(owner).build();
+    setId(piece2, 102L);
+    Experience exp1 = createExperienceWithPiece(piece1);
+    setId(exp1, 31L);
+    Experience exp2 = createExperienceWithPiece(piece2);
+    setId(exp2, 32L);
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(jdQuestionRepository.findById(20L)).thenReturn(Optional.of(question));
+    when(experienceRepository.findAllByUserIdNoPage(userId))
+        .thenReturn(List.of(exp2, exp1)); // 낮은 점수 먼저 투입
+    when(jdMatchRepository.findSimilaritiesByJdAndUser(10L, userId))
+        .thenReturn(List.of(new PieceSimilarity(101L, 80), new PieceSimilarity(102L, 40)));
+    when(llmMatchScoreService.scoreAllByQuestion(eq(jd), eq(question), any()))
+        .thenReturn(new LlmQuestionMatchResult(Map.of(101L, 90, 102L, 30)));
+    when(experiencePeriodResolver.resolvePeriodBulk(any())).thenReturn(Map.of());
+
+    ResumeQuestionExperienceResponse response =
+        resumeQuestionExperienceService.getExperiencesWithFitScore(10L, 20L, userId);
+
+    List<ExperienceMatchItem> items = response.experiences();
+    assertThat(items).hasSize(2);
+    assertThat(items.get(0).usageFitScore()).isGreaterThan(items.get(1).usageFitScore());
+    assertThat(items.get(0).experienceId()).isEqualTo(31L);
+    assertThat(items.get(1).experienceId()).isEqualTo(32L);
+  }
+
+  @Test
+  @DisplayName("기간 정보가 있는 경험은 시작일과 종료일이 응답에 포함된다")
+  void includePeriodInResponseWhenResolved() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createJd(owner);
+    setId(jd, 10L);
+    JdQuestion question = createQuestion(jd);
+    setId(question, 20L);
+    Piece piece = Piece.builder().type(PieceType.ACTIVITY).user(owner).build();
+    setId(piece, 100L);
+    Experience exp = createExperienceWithPiece(piece);
+    setId(exp, 30L);
+    LocalDate start = LocalDate.of(2024, 1, 1);
+    LocalDate end = LocalDate.of(2024, 6, 30);
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(jdQuestionRepository.findById(20L)).thenReturn(Optional.of(question));
+    when(experienceRepository.findAllByUserIdNoPage(userId)).thenReturn(List.of(exp));
+    when(jdMatchRepository.findSimilaritiesByJdAndUser(10L, userId)).thenReturn(List.of());
+    when(llmMatchScoreService.scoreAllByQuestion(eq(jd), eq(question), any()))
+        .thenReturn(new LlmQuestionMatchResult(Map.of(100L, 60)));
+    when(experiencePeriodResolver.resolvePeriodBulk(any()))
+        .thenReturn(Map.of(30L, new LocalDate[] {start, end}));
+
+    ResumeQuestionExperienceResponse response =
+        resumeQuestionExperienceService.getExperiencesWithFitScore(10L, 20L, userId);
+
+    ExperienceMatchItem item = response.experiences().get(0);
+    assertThat(item.startDate()).isEqualTo(start);
+    assertThat(item.endDate()).isEqualTo(end);
+  }
+
+  private User createUser(Long id) {
+    User user =
+        User.basicLoginBuilder()
+            .name("테스트 유저")
+            .email("test" + id + "@example.com")
+            .password("encoded-password")
+            .build();
+    setId(user, id);
+    return user;
+  }
+
+  private Jd createJd(User owner) {
+    return Jd.builder()
+        .user(owner)
+        .postingTitle("백엔드 개발자")
+        .companyName("끼움")
+        .recruitmentField("백엔드")
+        .rawText("공고 본문")
+        .build();
+  }
+
+  private JdQuestion createQuestion(Jd jd) {
+    return JdQuestion.builder().jd(jd).orderNum(1).content("지원 동기를 작성해주세요.").build();
+  }
+
+  private Experience createExperienceWithPiece(Piece piece) {
+    return Experience.builder()
+        .piece(piece)
+        .title("정산 배치 안정화")
+        .oneLineIntro("장애율을 낮춘 프로젝트")
+        .situation("배치가 자주 실패했습니다.")
+        .task("안정화가 필요했습니다.")
+        .act("재시도 로직을 개선했습니다.")
+        .result("실패율을 낮췄습니다.")
+        .taken("모니터링의 중요성을 배웠습니다.")
+        .build();
+  }
+
+  private void setId(Object target, Long id) {
+    try {
+      Field field = target.getClass().getDeclaredField("id");
+      field.setAccessible(true);
+      field.set(target, id);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Failed to set test id", e);
+    }
+  }
+}

--- a/src/test/java/com/kusitms/kkium/resume/service/ResumeWritingGuideServiceTest.java
+++ b/src/test/java/com/kusitms/kkium/resume/service/ResumeWritingGuideServiceTest.java
@@ -1,0 +1,302 @@
+package com.kusitms.kkium.resume.service;
+
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_NOT_FOUND;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_SELECTION_LIMIT;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.FORBIDDEN;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.JD_NOT_FOUND;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.QUESTION_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.kusitms.kkium.experience.domain.Experience;
+import com.kusitms.kkium.experience.domain.Piece;
+import com.kusitms.kkium.experience.domain.type.PieceType;
+import com.kusitms.kkium.experience.repository.ExperienceRepository;
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.jd.domain.Jd;
+import com.kusitms.kkium.jd.domain.JdQuestion;
+import com.kusitms.kkium.jd.repository.JdQuestionRepository;
+import com.kusitms.kkium.jd.repository.JdRepository;
+import com.kusitms.kkium.jd.utils.llm.LlmMatchScoreService;
+import com.kusitms.kkium.jd.utils.llm.result.LlmWritingGuideResult;
+import com.kusitms.kkium.resume.dto.response.ResumeWritingGuideResponse;
+import com.kusitms.kkium.user.domain.User;
+
+@ExtendWith(MockitoExtension.class)
+class ResumeWritingGuideServiceTest {
+
+  @Mock private JdRepository jdRepository;
+  @Mock private JdQuestionRepository jdQuestionRepository;
+  @Mock private ExperienceRepository experienceRepository;
+  @Mock private LlmMatchScoreService llmMatchScoreService;
+
+  private ResumeWritingGuideService resumeWritingGuideService;
+
+  @BeforeEach
+  void setUp() {
+    resumeWritingGuideService =
+        new ResumeWritingGuideService(
+            jdRepository, jdQuestionRepository, experienceRepository, llmMatchScoreService);
+  }
+
+  @Test
+  @DisplayName("experienceIds가 null이면 EXPERIENCE_SELECTION_LIMIT 예외를 던진다")
+  void throwWhenExperienceIdsIsNull() {
+    assertThatThrownBy(() -> resumeWritingGuideService.generateGuide(1L, 1L, null, 1L))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(EXPERIENCE_SELECTION_LIMIT);
+
+    verify(jdRepository, never()).findById(1L);
+  }
+
+  @Test
+  @DisplayName("experienceIds가 빈 리스트이면 EXPERIENCE_SELECTION_LIMIT 예외를 던진다")
+  void throwWhenExperienceIdsIsEmpty() {
+    assertThatThrownBy(() -> resumeWritingGuideService.generateGuide(1L, 1L, List.of(), 1L))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(EXPERIENCE_SELECTION_LIMIT);
+
+    verify(jdRepository, never()).findById(1L);
+  }
+
+  @Test
+  @DisplayName("experienceIds가 4개 이상이면 EXPERIENCE_SELECTION_LIMIT 예외를 던진다")
+  void throwWhenExperienceIdsExceedLimit() {
+    assertThatThrownBy(
+            () -> resumeWritingGuideService.generateGuide(1L, 1L, List.of(1L, 2L, 3L, 4L), 1L))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(EXPERIENCE_SELECTION_LIMIT);
+
+    verify(jdRepository, never()).findById(1L);
+  }
+
+  @Test
+  @DisplayName("JD 소유자가 아닌 유저가 요청하면 FORBIDDEN 예외를 던진다")
+  void throwWhenUserIsNotJdOwner() {
+    Long jdOwnerId = 1L;
+    Long requestUserId = 2L;
+    Jd jd = createJd(createUser(jdOwnerId));
+    setId(jd, 10L);
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+
+    assertThatThrownBy(
+            () -> resumeWritingGuideService.generateGuide(10L, 1L, List.of(1L), requestUserId))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(FORBIDDEN);
+
+    verify(jdQuestionRepository, never()).findById(1L);
+  }
+
+  @Test
+  @DisplayName("경험 소유자가 다른 유저이면 FORBIDDEN 예외를 던진다")
+  void throwWhenUserIsNotExperienceOwner() {
+    Long userId = 1L;
+    Long otherUserId = 2L;
+    User owner = createUser(userId);
+    User other = createUser(otherUserId);
+    Jd jd = createJd(owner);
+    setId(jd, 10L);
+    JdQuestion question = createQuestion(jd);
+    setId(question, 20L);
+    Experience otherExperience = createExperience(other);
+    setId(otherExperience, 30L);
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(jdQuestionRepository.findById(20L)).thenReturn(Optional.of(question));
+    when(experienceRepository.findAllByIdIn(List.of(30L))).thenReturn(List.of(otherExperience));
+
+    assertThatThrownBy(
+            () -> resumeWritingGuideService.generateGuide(10L, 20L, List.of(30L), userId))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(FORBIDDEN);
+
+    verify(llmMatchScoreService, never())
+        .generateWritingGuide(jd, question, List.of(otherExperience));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 JD이면 JD_NOT_FOUND 예외를 던진다")
+  void throwWhenJdNotFound() {
+    when(jdRepository.findById(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> resumeWritingGuideService.generateGuide(999L, 1L, List.of(1L), 1L))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(JD_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 문항이면 QUESTION_NOT_FOUND 예외를 던진다")
+  void throwWhenQuestionNotFound() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createJd(owner);
+    setId(jd, 10L);
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(jdQuestionRepository.findById(999L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(
+            () -> resumeWritingGuideService.generateGuide(10L, 999L, List.of(1L), userId))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(QUESTION_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("조회된 경험 수가 요청한 experienceIds 수와 다르면 EXPERIENCE_NOT_FOUND 예외를 던진다")
+  void throwWhenSomeExperiencesNotFound() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createJd(owner);
+    setId(jd, 10L);
+    JdQuestion question = createQuestion(jd);
+    setId(question, 20L);
+    Experience experience = createExperience(owner);
+    setId(experience, 30L);
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(jdQuestionRepository.findById(20L)).thenReturn(Optional.of(question));
+    // 2개 요청했는데 1개만 반환
+    when(experienceRepository.findAllByIdIn(List.of(30L, 99L))).thenReturn(List.of(experience));
+
+    assertThatThrownBy(
+            () -> resumeWritingGuideService.generateGuide(10L, 20L, List.of(30L, 99L), userId))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(EXPERIENCE_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("정상 요청이면 LLM 결과를 그대로 반환한다")
+  void generateGuideSuccessfully() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createJd(owner);
+    setId(jd, 10L);
+    JdQuestion question = createQuestion(jd);
+    setId(question, 20L);
+    Experience experience = createExperience(owner);
+    setId(experience, 30L);
+    LlmWritingGuideResult llmResult =
+        new LlmWritingGuideResult(
+            List.of("Java", "Spring"),
+            "백엔드 개발 경험이 JD의 핵심 역량과 잘 일치합니다.",
+            "STAR 구조를 활용하여 문제 해결 과정을 구체적으로 서술하세요.");
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(jdQuestionRepository.findById(20L)).thenReturn(Optional.of(question));
+    when(experienceRepository.findAllByIdIn(List.of(30L))).thenReturn(List.of(experience));
+    when(llmMatchScoreService.generateWritingGuide(jd, question, List.of(experience)))
+        .thenReturn(llmResult);
+
+    ResumeWritingGuideResponse response =
+        resumeWritingGuideService.generateGuide(10L, 20L, List.of(30L), userId);
+
+    assertThat(response.coreKeywords()).containsExactly("Java", "Spring");
+    assertThat(response.connectionToJd()).isEqualTo("백엔드 개발 경험이 JD의 핵심 역량과 잘 일치합니다.");
+    assertThat(response.writingGuide()).isEqualTo("STAR 구조를 활용하여 문제 해결 과정을 구체적으로 서술하세요.");
+    verify(llmMatchScoreService).generateWritingGuide(jd, question, List.of(experience));
+  }
+
+  @Test
+  @DisplayName("경험을 최대 3개까지 선택하면 모두 LLM에 전달한다")
+  void generateGuideWithMaxExperiences() {
+    Long userId = 1L;
+    User owner = createUser(userId);
+    Jd jd = createJd(owner);
+    setId(jd, 10L);
+    JdQuestion question = createQuestion(jd);
+    setId(question, 20L);
+    Experience exp1 = createExperience(owner);
+    setId(exp1, 31L);
+    Experience exp2 = createExperience(owner);
+    setId(exp2, 32L);
+    Experience exp3 = createExperience(owner);
+    setId(exp3, 33L);
+    LlmWritingGuideResult llmResult =
+        new LlmWritingGuideResult(List.of("협업"), "다양한 경험이 있습니다.", "경험을 통합하여 서술하세요.");
+
+    when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
+    when(jdQuestionRepository.findById(20L)).thenReturn(Optional.of(question));
+    when(experienceRepository.findAllByIdIn(List.of(31L, 32L, 33L)))
+        .thenReturn(List.of(exp1, exp2, exp3));
+    when(llmMatchScoreService.generateWritingGuide(jd, question, List.of(exp1, exp2, exp3)))
+        .thenReturn(llmResult);
+
+    ResumeWritingGuideResponse response =
+        resumeWritingGuideService.generateGuide(10L, 20L, List.of(31L, 32L, 33L), userId);
+
+    assertThat(response.coreKeywords()).containsExactly("협업");
+    verify(llmMatchScoreService).generateWritingGuide(jd, question, List.of(exp1, exp2, exp3));
+  }
+
+  private User createUser(Long id) {
+    User user =
+        User.basicLoginBuilder()
+            .name("테스트 유저")
+            .email("test" + id + "@example.com")
+            .password("encoded-password")
+            .build();
+    setId(user, id);
+    return user;
+  }
+
+  private Jd createJd(User owner) {
+    return Jd.builder()
+        .user(owner)
+        .postingTitle("백엔드 개발자")
+        .companyName("끼움")
+        .recruitmentField("백엔드")
+        .rawText("공고 본문")
+        .build();
+  }
+
+  private JdQuestion createQuestion(Jd jd) {
+    return JdQuestion.builder().jd(jd).orderNum(1).content("지원 동기를 작성해주세요.").build();
+  }
+
+  private Experience createExperience(User owner) {
+    Piece piece = Piece.builder().type(PieceType.ACTIVITY).user(owner).build();
+    return Experience.builder()
+        .piece(piece)
+        .title("정산 배치 안정화")
+        .oneLineIntro("장애율을 낮춘 프로젝트")
+        .situation("배치가 자주 실패했습니다.")
+        .task("안정화가 필요했습니다.")
+        .act("재시도 로직을 개선했습니다.")
+        .result("실패율을 낮췄습니다.")
+        .taken("모니터링의 중요성을 배웠습니다.")
+        .build();
+  }
+
+  private void setId(Object target, Long id) {
+    try {
+      Field field = target.getClass().getDeclaredField("id");
+      field.setAccessible(true);
+      field.set(target, id);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Failed to set test id", e);
+    }
+  }
+}


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #171 

## ✏️ 작업 내용

- JdMatchService, JdExperienceAnalysisService, ResumeQuestionExperienceService, ResumeWritingGuideService, ExperienceService(경험 수정) 단위 테스트 추가

## 🐛 버그 수정
- `ResumeQuestionExperienceService` 문항별 경험 조회 시 `findAllByUserIdNoPage` → `findAllByUserIdForAnalysis` 로 변경 (experience_order 미등록 경험 누락 문제)
- `LlmMatchScoreService` OpenAI 호출 실패(4xx/5xx) 시 fallback 점수 반환 → `LLM_CALL_FAILED` 예외 처리로 변경 (사용자가 오류를 인지하지 못하는 문제)
- 수동 실행 전용 테스트(`LlmConsistencyTest`, `GoldStandardDataGenerator`) 클래스 레벨 `@Disabled` 추가

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
