### PR TITLE
[TEST] Notion 연동 단위 테스트 작성

### DIFF
--- a/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
+++ b/src/main/java/com/kusitms/kkium/notion/utils/NotionApiClient.java
@@ -186,7 +186,7 @@ public class NotionApiClient {
   }
 
   // /v1/search 페이징 호출하여 모든 페이지 메타데이터 수집
-  private List<JsonNode> fetchAllPagesViaSearch(String accessToken) {
+  List<JsonNode> fetchAllPagesViaSearch(String accessToken) {
     List<JsonNode> allPages = new ArrayList<>();
     String nextCursor = null;
 
@@ -262,7 +262,7 @@ public class NotionApiClient {
   }
 
   // database row 조회하여 leaf 목록에 추가
-  private void fetchDatabaseRows(
+  void fetchDatabaseRows(
       String accessToken, String databaseId, List<NotionPageListResponse.NotionPageInfo> leafs) {
     try {
       String responseBody =

--- a/src/test/java/com/kusitms/kkium/notion/service/NotionServiceTest.java
+++ b/src/test/java/com/kusitms/kkium/notion/service/NotionServiceTest.java
@@ -1,0 +1,125 @@
+package com.kusitms.kkium.notion.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
+import com.kusitms.kkium.notion.domain.NotionConnection;
+import com.kusitms.kkium.notion.dto.response.NotionTokenResponse;
+import com.kusitms.kkium.notion.repository.NotionConnectionRepository;
+import com.kusitms.kkium.notion.utils.NotionApiClient;
+
+@ExtendWith(MockitoExtension.class)
+class NotionServiceTest {
+
+  @Mock private NotionApiClient notionApiClient;
+  @Mock private NotionConnectionRepository notionConnectionRepository;
+  @Mock private StringRedisTemplate redisTemplate;
+  @Mock private ValueOperations<String, String> valueOperations;
+
+  private NotionService notionService;
+
+  private static final Long USER_ID = 1L;
+  private static final String ALLOWED_ORIGIN = "http://localhost:3000";
+
+  @BeforeEach
+  void setUp() {
+    notionService = new NotionService(notionApiClient, notionConnectionRepository, redisTemplate);
+    ReflectionTestUtils.setField(notionService, "allowedOrigins", List.of(ALLOWED_ORIGIN));
+    lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+  }
+
+  @Test
+  @DisplayName("허용된 origin이면 Redis에 state를 저장하고 인증 URL을 반환한다")
+  void getAuthorizationUrl_허용된_origin() {
+    when(notionApiClient.getAuthorizationUrl(anyString())).thenReturn("https://notion.so/auth");
+
+    String result = notionService.getAuthorizationUrl(USER_ID, ALLOWED_ORIGIN);
+
+    assertThat(result).isEqualTo("https://notion.so/auth");
+    verify(valueOperations).set(anyString(), anyString(), eq(10L), eq(TimeUnit.MINUTES));
+  }
+
+  @Test
+  @DisplayName("허용되지 않은 origin이면 ResponseStatusException을 던진다")
+  void getAuthorizationUrl_허용안된_origin() {
+    assertThatThrownBy(() -> notionService.getAuthorizationUrl(USER_ID, "http://evil.com"))
+        .isInstanceOf(ResponseStatusException.class);
+  }
+
+  @Test
+  @DisplayName("유효한 state로 콜백 처리 시 access_token을 저장하고 redirect URL을 반환한다")
+  void handleCallback_정상_신규_저장() {
+    String stateValue = "test-state-uuid";
+    String state = USER_ID + ":" + stateValue + ":" + ALLOWED_ORIGIN;
+    NotionTokenResponse tokenResponse =
+        new NotionTokenResponse("access-token", "workspace-id", "워크스페이스");
+
+    when(valueOperations.get("notion:state:" + stateValue))
+        .thenReturn(USER_ID + ":" + ALLOWED_ORIGIN);
+    when(redisTemplate.delete(anyString())).thenReturn(true);
+    when(notionApiClient.getAccessToken(anyString())).thenReturn(tokenResponse);
+    when(notionConnectionRepository.findByUserId(USER_ID)).thenReturn(Optional.empty());
+
+    String result = notionService.handleCallback("auth-code", state);
+
+    assertThat(result).isEqualTo(ALLOWED_ORIGIN + "/experience/add?success=true");
+    verify(notionConnectionRepository).save(any(NotionConnection.class));
+  }
+
+  @Test
+  @DisplayName("만료된 state로 콜백 처리 시 NOTION_INVALID_STATE 예외를 던진다")
+  void handleCallback_만료된_state() {
+    String stateValue = "expired-state";
+    String state = USER_ID + ":" + stateValue + ":" + ALLOWED_ORIGIN;
+
+    when(valueOperations.get("notion:state:" + stateValue)).thenReturn(null);
+
+    assertThatThrownBy(() -> notionService.handleCallback("code", state))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.NOTION_INVALID_STATE);
+  }
+
+  @Test
+  @DisplayName("origin에 ':' 포함된 URL도 state에서 정확히 파싱된다")
+  void handleCallback_origin_포트_포함_파싱() {
+    // state = "1:uuid:http://localhost:3000" — split(":", 3)으로 파싱
+    String stateValue = "test-uuid";
+    String state = USER_ID + ":" + stateValue + ":" + ALLOWED_ORIGIN;
+    NotionTokenResponse tokenResponse = new NotionTokenResponse("token", "ws-id", "ws-name");
+
+    when(valueOperations.get("notion:state:" + stateValue))
+        .thenReturn(USER_ID + ":" + ALLOWED_ORIGIN);
+    when(redisTemplate.delete(anyString())).thenReturn(true);
+    when(notionApiClient.getAccessToken(anyString())).thenReturn(tokenResponse);
+    when(notionConnectionRepository.findByUserId(USER_ID)).thenReturn(Optional.empty());
+
+    String result = notionService.handleCallback("code", state);
+
+    // 포트 포함 origin이 그대로 파싱됨
+    assertThat(result).isEqualTo(ALLOWED_ORIGIN + "/experience/add?success=true");
+  }
+}

--- a/src/test/java/com/kusitms/kkium/notion/service/NotionServiceTest.java
+++ b/src/test/java/com/kusitms/kkium/notion/service/NotionServiceTest.java
@@ -66,7 +66,9 @@ class NotionServiceTest {
   @DisplayName("허용되지 않은 origin이면 ResponseStatusException을 던진다")
   void getAuthorizationUrl_허용안된_origin() {
     assertThatThrownBy(() -> notionService.getAuthorizationUrl(USER_ID, "http://evil.com"))
-        .isInstanceOf(ResponseStatusException.class);
+        .isInstanceOf(ResponseStatusException.class)
+        .extracting("statusCode")
+        .isEqualTo(org.springframework.http.HttpStatus.BAD_REQUEST);
   }
 
   @Test

--- a/src/test/java/com/kusitms/kkium/notion/utils/NotionApiClientTest.java
+++ b/src/test/java/com/kusitms/kkium/notion/utils/NotionApiClientTest.java
@@ -145,7 +145,7 @@ class NotionApiClientTest {
     String url = notionApiClient.getAuthorizationUrl(state);
 
     assertThat(url).contains("client_id=test-client-id");
-    assertThat(url).contains("state=");
+    assertThat(url).contains("state=" + state);
     assertThat(url).contains("redirect_uri=");
   }
 }

--- a/src/test/java/com/kusitms/kkium/notion/utils/NotionApiClientTest.java
+++ b/src/test/java/com/kusitms/kkium/notion/utils/NotionApiClientTest.java
@@ -1,0 +1,151 @@
+package com.kusitms.kkium.notion.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kusitms.kkium.notion.dto.response.NotionPageListResponse;
+
+@ExtendWith(MockitoExtension.class)
+class NotionApiClientTest {
+
+  @Mock private WebClient webClient;
+
+  @Spy @InjectMocks private NotionApiClient notionApiClient;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private static final String ACCESS_TOKEN = "test-access-token";
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(notionApiClient, "clientId", "test-client-id");
+    ReflectionTestUtils.setField(notionApiClient, "clientSecret", "test-client-secret");
+    ReflectionTestUtils.setField(notionApiClient, "redirectUri", "http://localhost:8080/callback");
+  }
+
+  // ── fixture builders ──────────────────────────────────────────────────────
+
+  private JsonNode buildPage(String id, String parentType, String parentId, String title)
+      throws Exception {
+    String parentJson =
+        switch (parentType) {
+          case "workspace" -> "{\"type\":\"workspace\",\"workspace\":true}";
+          case "page_id" -> "{\"type\":\"page_id\",\"page_id\":\"" + parentId + "\"}";
+          case "database_id" -> "{\"type\":\"database_id\",\"database_id\":\"" + parentId + "\"}";
+          default -> "{\"type\":\"" + parentType + "\"}";
+        };
+    String json =
+        """
+        {
+          "id": "%s",
+          "object": "page",
+          "parent": %s,
+          "properties": {
+            "제목": {"type": "title", "title": [{"plain_text": "%s"}]}
+          },
+          "last_edited_time": "2024-01-01T00:00:00.000Z"
+        }
+        """
+            .formatted(id, parentJson, title);
+    return objectMapper.readTree(json);
+  }
+
+  private JsonNode buildDatabase(String id, String title) throws Exception {
+    String json =
+        """
+        {
+          "id": "%s",
+          "object": "database",
+          "title": [{"plain_text": "%s"}],
+          "parent": {"type": "workspace", "workspace": true},
+          "last_edited_time": "2024-01-01T00:00:00.000Z"
+        }
+        """
+            .formatted(id, title);
+    return objectMapper.readTree(json);
+  }
+
+  // ── tests ────────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("부모 없는 페이지는 leaf로 반환된다")
+  void getPages_루트_페이지_leaf() throws Exception {
+    JsonNode page = buildPage("page-1", "workspace", null, "루트 페이지");
+    doReturn(List.of(page)).when(notionApiClient).fetchAllPagesViaSearch(ACCESS_TOKEN);
+
+    List<NotionPageListResponse.NotionPageInfo> result = notionApiClient.getPages(ACCESS_TOKEN);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).pageId()).isEqualTo("page-1");
+  }
+
+  @Test
+  @DisplayName("자식 페이지가 있는 부모 페이지는 leaf에서 제외되고 자식만 leaf로 반환된다")
+  void getPages_부모페이지_leaf_제외() throws Exception {
+    JsonNode parent = buildPage("parent-id", "workspace", null, "부모");
+    JsonNode child = buildPage("child-id", "page_id", "parent-id", "자식");
+    doReturn(List.of(parent, child)).when(notionApiClient).fetchAllPagesViaSearch(ACCESS_TOKEN);
+
+    List<NotionPageListResponse.NotionPageInfo> result = notionApiClient.getPages(ACCESS_TOKEN);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).pageId()).isEqualTo("child-id");
+  }
+
+  @Test
+  @DisplayName("database 타입 페이지는 leaf에 포함되고 database row 조회가 호출된다")
+  void getPages_database_leaf_포함() throws Exception {
+    JsonNode db = buildDatabase("db-id", "데이터베이스");
+    doReturn(List.of(db)).when(notionApiClient).fetchAllPagesViaSearch(ACCESS_TOKEN);
+    doNothing().when(notionApiClient).fetchDatabaseRows(anyString(), anyString(), any());
+
+    List<NotionPageListResponse.NotionPageInfo> result = notionApiClient.getPages(ACCESS_TOKEN);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).pageId()).isEqualTo("db-id");
+    verify(notionApiClient).fetchDatabaseRows(eq(ACCESS_TOKEN), eq("db-id"), any());
+  }
+
+  @Test
+  @DisplayName("parent.type이 database_id인 페이지(DB row)는 일반 루프에서 스킵된다")
+  void getPages_database_row_스킵() throws Exception {
+    JsonNode dbRow = buildPage("row-id", "database_id", "db-id", "DB 행");
+    doReturn(List.of(dbRow)).when(notionApiClient).fetchAllPagesViaSearch(ACCESS_TOKEN);
+
+    List<NotionPageListResponse.NotionPageInfo> result = notionApiClient.getPages(ACCESS_TOKEN);
+
+    // database row는 일반 페이지 루프에서 스킵 (fetchDatabaseRows에서 처리)
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("getAuthorizationUrl은 state와 clientId가 포함된 URL을 반환한다")
+  void getAuthorizationUrl_state_포함() {
+    String state = "my-test-state";
+
+    String url = notionApiClient.getAuthorizationUrl(state);
+
+    assertThat(url).contains("client_id=test-client-id");
+    assertThat(url).contains("state=");
+    assertThat(url).contains("redirect_uri=");
+  }
+}


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #174 

## ✏️ 작업 내용

- `NotionApiClient` 내부 메서드 접근 제어자 변경
  - `fetchAllPagesViaSearch`, `fetchDatabaseRows` `private` → package-private 
- `NotionService` 단위 테스트 작성
  - 허용된/허용 안 된 origin 검증
  - Redis state CSRF 방어 (정상 콜백 / 만료된 state)
  - `:` 포함 origin URL 파싱 정확성 (`split(":", 3)` 동작 검증)
- `NotionApiClient` leaf 판별 로직 단위 테스트 작성 (`@Spy` 기반)
  - 루트 페이지 leaf 포함
  - 자식 있는 부모 페이지 leaf 제외
  - database 타입 leaf 포함 + `fetchDatabaseRows` 호출 검증
  - database row(`parent.type = database_id`) 일반 루프 스킵
- `./gradlew test` 전체 통과 확인

## ✅ 체크리스트

- [ ]  PR 제목을 커밋 규칙에 맞게 작성
- [ ]  PR에 해당되는 Issue를 연결 완료
- [ ]  작업한 사람 모두를 Assign
- [ ]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
