### PR TITLE
[REFACTOR] 클래스 책임 분리 및 캐시 키 관리 클래스 도입

### DIFF
--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceDetailValidator.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceDetailValidator.java
@@ -1,0 +1,74 @@
+package com.kusitms.kkium.experience.service;
+
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_COMPANY_TOO_LONG;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_EDUCATION_NAME_TOO_LONG;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_ORGANIZATION_NAME_TOO_LONG;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_ROLE_TOO_LONG;
+import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.INVALID_INPUT_VALUE;
+
+import org.springframework.stereotype.Component;
+
+import com.kusitms.kkium.experience.domain.type.PieceType;
+import com.kusitms.kkium.experience.dto.request.ExperienceUpdateRequest.Detail;
+import com.kusitms.kkium.global.exception.BaseException;
+
+/** 경험 유형별 상세 필드 유효성 검증을 담당한다. */
+@Component
+public class ExperienceDetailValidator {
+
+  private static final int MAX_ROLE_LENGTH = 50;
+  private static final int MAX_COMPANY_LENGTH = 50;
+  private static final int MAX_ORGANIZATION_NAME_LENGTH = 50;
+  private static final int MAX_EDUCATION_NAME_LENGTH = 80;
+
+  /**
+   * PieceType에 맞는 유효성 검증을 실행한다.
+   *
+   * @throws BaseException INVALID_INPUT_VALUE — 필수 필드 누락
+   * @throws BaseException EXPERIENCE_ROLE_TOO_LONG — role 50자 초과
+   * @throws BaseException EXPERIENCE_COMPANY_TOO_LONG — company 50자 초과
+   * @throws BaseException EXPERIENCE_ORGANIZATION_NAME_TOO_LONG — organizationName 50자 초과
+   * @throws BaseException EXPERIENCE_EDUCATION_NAME_TOO_LONG — name 80자 초과
+   */
+  public void validate(PieceType type, Detail detail) {
+    switch (type) {
+      case ACTIVITY -> validateActivity(detail);
+      case CAREER -> validateCareer(detail);
+      case EDUCATION -> validateEducation(detail);
+      case ETC -> {} // ETC는 필수 필드 없음
+    }
+  }
+
+  private void validateActivity(Detail detail) {
+    if (detail.name() == null
+        || detail.teamNum() == null
+        || detail.role() == null
+        || detail.contributionRate() == null) {
+      throw new BaseException(INVALID_INPUT_VALUE);
+    }
+    if (detail.role().length() > MAX_ROLE_LENGTH) {
+      throw new BaseException(EXPERIENCE_ROLE_TOO_LONG);
+    }
+  }
+
+  private void validateCareer(Detail detail) {
+    if (detail.company() == null || detail.employmentStatus() == null) {
+      throw new BaseException(INVALID_INPUT_VALUE);
+    }
+    if (detail.company().length() > MAX_COMPANY_LENGTH) {
+      throw new BaseException(EXPERIENCE_COMPANY_TOO_LONG);
+    }
+  }
+
+  private void validateEducation(Detail detail) {
+    if (detail.organizationName() == null || detail.name() == null) {
+      throw new BaseException(INVALID_INPUT_VALUE);
+    }
+    if (detail.organizationName().length() > MAX_ORGANIZATION_NAME_LENGTH) {
+      throw new BaseException(EXPERIENCE_ORGANIZATION_NAME_TOO_LONG);
+    }
+    if (detail.name().length() > MAX_EDUCATION_NAME_LENGTH) {
+      throw new BaseException(EXPERIENCE_EDUCATION_NAME_TOO_LONG);
+    }
+  }
+}

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceDetailValidator.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceDetailValidator.java
@@ -31,6 +31,9 @@ public class ExperienceDetailValidator {
    * @throws BaseException EXPERIENCE_EDUCATION_NAME_TOO_LONG — name 80자 초과
    */
   public void validate(PieceType type, Detail detail) {
+    if (type != PieceType.ETC && detail == null) {
+      throw new BaseException(INVALID_INPUT_VALUE);
+    }
     switch (type) {
       case ACTIVITY -> validateActivity(detail);
       case CAREER -> validateCareer(detail);

--- a/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
+++ b/src/main/java/com/kusitms/kkium/experience/service/ExperienceService.java
@@ -1,11 +1,7 @@
 package com.kusitms.kkium.experience.service;
 
-import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_COMPANY_TOO_LONG;
-import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_EDUCATION_NAME_TOO_LONG;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_NOT_FOUND;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_ORDER_NOT_FOUND;
-import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_ORGANIZATION_NAME_TOO_LONG;
-import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.EXPERIENCE_ROLE_TOO_LONG;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.FORBIDDEN;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.INVALID_INPUT_VALUE;
 import static com.kusitms.kkium.global.exception.errorcode.ErrorCode.USER_NOT_FOUND;
@@ -66,6 +62,7 @@ public class ExperienceService {
   private final JobTypeUpdateService jobTypeUpdateService;
   private final JdExperienceAnalysisService jdExperienceAnalysisService;
   private final ExperiencePeriodResolver experiencePeriodResolver;
+  private final ExperienceDetailValidator experienceDetailValidator;
 
   @Transactional(readOnly = true)
   public ExperienceDetailResponse getDetail(Long userId, Long experienceId) {
@@ -423,65 +420,46 @@ public class ExperienceService {
             .collect(Collectors.toList());
     tagRepository.saveAll(newTags);
 
-    // 3. 유형별 detail 수정
+    // 3. 유형별 detail 유효성 검증
     PieceType type = experience.getPiece().getType();
     ExperienceUpdateRequest.Detail detail = request.detail();
+    experienceDetailValidator.validate(type, detail);
 
+    // 4. 유형별 detail 수정
     switch (type) {
-      case ACTIVITY -> {
-        if (detail.name() == null
-            || detail.teamNum() == null
-            || detail.role() == null
-            || detail.contributionRate() == null) {
-          throw new BaseException(INVALID_INPUT_VALUE);
-        }
-        if (detail.role().length() > 50) throw new BaseException(EXPERIENCE_ROLE_TOO_LONG);
-        activityRepository
-            .findByExperienceId(experienceId)
-            .ifPresent(
-                a ->
-                    a.update(
-                        detail.name(),
-                        detail.teamNum(),
-                        detail.role(),
-                        detail.contributionRate(),
-                        detail.startDate(),
-                        detail.endDate()));
-      }
-      case CAREER -> {
-        if (detail.company() == null || detail.employmentStatus() == null) {
-          throw new BaseException(INVALID_INPUT_VALUE);
-        }
-        if (detail.company().length() > 50) throw new BaseException(EXPERIENCE_COMPANY_TOO_LONG);
-        careerRepository
-            .findByExperienceId(experienceId)
-            .ifPresent(
-                c ->
-                    c.update(
-                        request.title(),
-                        detail.company(),
-                        detail.employmentStatus(),
-                        detail.startDate(),
-                        detail.endDate()));
-      }
-      case EDUCATION -> {
-        if (detail.organizationName() == null || detail.name() == null) {
-          throw new BaseException(INVALID_INPUT_VALUE);
-        }
-        if (detail.organizationName().length() > 50)
-          throw new BaseException(EXPERIENCE_ORGANIZATION_NAME_TOO_LONG);
-        if (detail.name().length() > 80)
-          throw new BaseException(EXPERIENCE_EDUCATION_NAME_TOO_LONG);
-        educationRepository
-            .findByExperienceId(experienceId)
-            .ifPresent(
-                e ->
-                    e.update(
-                        detail.organizationName(),
-                        detail.name(),
-                        detail.startDate(),
-                        detail.endDate()));
-      }
+      case ACTIVITY ->
+          activityRepository
+              .findByExperienceId(experienceId)
+              .ifPresent(
+                  a ->
+                      a.update(
+                          detail.name(),
+                          detail.teamNum(),
+                          detail.role(),
+                          detail.contributionRate(),
+                          detail.startDate(),
+                          detail.endDate()));
+      case CAREER ->
+          careerRepository
+              .findByExperienceId(experienceId)
+              .ifPresent(
+                  c ->
+                      c.update(
+                          request.title(),
+                          detail.company(),
+                          detail.employmentStatus(),
+                          detail.startDate(),
+                          detail.endDate()));
+      case EDUCATION ->
+          educationRepository
+              .findByExperienceId(experienceId)
+              .ifPresent(
+                  e ->
+                      e.update(
+                          detail.organizationName(),
+                          detail.name(),
+                          detail.startDate(),
+                          detail.endDate()));
       case ETC ->
           etcRepository
               .findByExperienceId(experienceId)

--- a/src/main/java/com/kusitms/kkium/jd/service/JdExperienceAnalysisService.java
+++ b/src/main/java/com/kusitms/kkium/jd/service/JdExperienceAnalysisService.java
@@ -22,6 +22,7 @@ import com.kusitms.kkium.jd.domain.Jd;
 import com.kusitms.kkium.jd.dto.response.JdExperienceAnalysisResponse;
 import com.kusitms.kkium.jd.dto.response.JdExperienceAnalysisResponse.ExperienceAnalysis;
 import com.kusitms.kkium.jd.repository.JdRepository;
+import com.kusitms.kkium.jd.utils.JdAnalysisCacheKeyManager;
 import com.kusitms.kkium.jd.utils.llm.LlmMatchScoreService;
 import com.kusitms.kkium.jd.utils.llm.result.LlmExperienceDetailResult;
 
@@ -34,7 +35,6 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 public class JdExperienceAnalysisService {
 
-  private static final String CACHE_KEY_PREFIX = "jd-analysis:";
   private static final Duration CACHE_TTL = Duration.ofDays(7);
   private final JdRepository jdRepository;
   private final ExperienceRepository experienceRepository;
@@ -63,7 +63,7 @@ public class JdExperienceAnalysisService {
     }
 
     // 5. Redis 캐시 조회
-    String cacheKey = CACHE_KEY_PREFIX + experienceId + ":" + jdId;
+    String cacheKey = JdAnalysisCacheKeyManager.of(experienceId, jdId);
     try {
       String cached = redisTemplate.opsForValue().get(cacheKey);
       if (cached != null) {
@@ -105,12 +105,13 @@ public class JdExperienceAnalysisService {
   // 경험 수정/삭제 시 캐시 무효화 - jd-analysis:{experienceId}:*
   public void evictCache(Long experienceId) {
     scanAndDelete(
-        CACHE_KEY_PREFIX + experienceId + ":*", "[경험 상세 분석] 캐시 무효화 - experienceId=" + experienceId);
+        JdAnalysisCacheKeyManager.byExperience(experienceId),
+        "[경험 상세 분석] 캐시 무효화 - experienceId=" + experienceId);
   }
 
   // JD 삭제 시 캐시 무효화 - jd-analysis:*:{jdId}
   public void evictCacheByJdId(Long jdId) {
-    scanAndDelete(CACHE_KEY_PREFIX + "*:" + jdId, "[경험 상세 분석] JD 캐시 무효화 - jdId=" + jdId);
+    scanAndDelete(JdAnalysisCacheKeyManager.byJd(jdId), "[경험 상세 분석] JD 캐시 무효화 - jdId=" + jdId);
   }
 
   private void scanAndDelete(String pattern, String logPrefix) {

--- a/src/main/java/com/kusitms/kkium/jd/utils/JdAnalysisCacheKeyManager.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/JdAnalysisCacheKeyManager.java
@@ -1,0 +1,24 @@
+package com.kusitms.kkium.jd.utils;
+
+/** JD 경험 상세 분석 Redis 캐시 키 생성을 중앙 관리한다. */
+public final class JdAnalysisCacheKeyManager {
+
+  private static final String PREFIX = "jd-analysis:";
+
+  private JdAnalysisCacheKeyManager() {}
+
+  /** 단건 캐시 키: jd-analysis:{experienceId}:{jdId} */
+  public static String of(Long experienceId, Long jdId) {
+    return PREFIX + experienceId + ":" + jdId;
+  }
+
+  /** 경험 기준 와일드카드: jd-analysis:{experienceId}:* (경험 수정/삭제 시 무효화) */
+  public static String byExperience(Long experienceId) {
+    return PREFIX + experienceId + ":*";
+  }
+
+  /** JD 기준 와일드카드: jd-analysis:*:{jdId} (JD 삭제 시 무효화) */
+  public static String byJd(Long jdId) {
+    return PREFIX + "*:" + jdId;
+  }
+}

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmApiClient.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmApiClient.java
@@ -1,0 +1,81 @@
+package com.kusitms.kkium.jd.utils.llm;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
+
+import lombok.extern.slf4j.Slf4j;
+
+/** OpenAI API 호출만 담당하는 클라이언트 */
+@Slf4j
+@Component
+public class LlmApiClient {
+
+  private static final String OPENAI_URL = "https://api.openai.com/v1/chat/completions";
+  private static final String MODEL = "gpt-4o";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final WebClient webClient;
+  private final String apiKey;
+
+  public LlmApiClient(WebClient webClient, @Value("${openai.api.key}") String apiKey) {
+    this.webClient = webClient;
+    this.apiKey = apiKey;
+  }
+
+  /**
+   * OpenAI API를 호출하고 응답 content 문자열을 반환한다.
+   *
+   * @throws BaseException LLM_CALL_FAILED — 4xx/5xx/네트워크 오류
+   */
+  public String call(String prompt, Map<String, Object> jsonSchema) {
+    Map<String, Object> body = new HashMap<>();
+    body.put("model", MODEL);
+    body.put("temperature", 0);
+    body.put("messages", List.of(Map.of("role", "user", "content", prompt)));
+    body.put("response_format", Map.of("type", "json_schema", "json_schema", jsonSchema));
+
+    try {
+      String response =
+          webClient
+              .post()
+              .uri(OPENAI_URL)
+              .header("Content-Type", "application/json")
+              .header("Authorization", "Bearer " + apiKey)
+              .bodyValue(body)
+              .retrieve()
+              .onStatus(
+                  HttpStatusCode::is4xxClientError,
+                  clientResponse -> {
+                    log.warn("OpenAI 클라이언트 에러: {}", clientResponse.statusCode());
+                    return clientResponse.createException();
+                  })
+              .onStatus(
+                  HttpStatusCode::is5xxServerError,
+                  clientResponse -> {
+                    log.warn("OpenAI 서버 에러: {}", clientResponse.statusCode());
+                    return clientResponse.createException();
+                  })
+              .bodyToMono(String.class)
+              .block();
+
+      JsonNode root = OBJECT_MAPPER.readTree(response);
+      return root.path("choices").path(0).path("message").path("content").asText();
+    } catch (BaseException e) {
+      throw e;
+    } catch (Exception e) {
+      log.warn("OpenAI 호출 실패: {}", e.getMessage());
+      throw new BaseException(ErrorCode.LLM_CALL_FAILED);
+    }
+  }
+}

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmApiClient.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmApiClient.java
@@ -1,5 +1,6 @@
 package com.kusitms.kkium.jd.utils.llm;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,7 +68,7 @@ public class LlmApiClient {
                     return clientResponse.createException();
                   })
               .bodyToMono(String.class)
-              .block();
+              .block(Duration.ofSeconds(60));
 
       JsonNode root = OBJECT_MAPPER.readTree(response);
       return root.path("choices").path(0).path("message").path("content").asText();

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchResultParser.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchResultParser.java
@@ -1,0 +1,150 @@
+package com.kusitms.kkium.jd.utils.llm;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kusitms.kkium.experience.domain.Experience;
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
+import com.kusitms.kkium.jd.utils.llm.result.HighlightKeyword;
+import com.kusitms.kkium.jd.utils.llm.result.LlmExperienceDetailResult;
+import com.kusitms.kkium.jd.utils.llm.result.LlmMatchResult;
+import com.kusitms.kkium.jd.utils.llm.result.LlmQuestionMatchResult;
+import com.kusitms.kkium.jd.utils.llm.result.LlmWritingGuideResult;
+
+import lombok.extern.slf4j.Slf4j;
+
+/** LLM 응답 JSON 파싱만 담당하는 파서 */
+@Slf4j
+@Component
+public class LlmMatchResultParser {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final List<String> VALID_SOURCES =
+      List.of(
+          "mainResponsibilities",
+          "requiredQualifications",
+          "preferredQualifications",
+          "hardSkill",
+          "softSkill");
+
+  /**
+   * 활용 적합도 + 지원 적합도 파싱
+   *
+   * @throws BaseException LLM_RESPONSE_INVALID — JSON 파싱 실패
+   */
+  public LlmMatchResult parseCombinedResult(String response, List<Experience> experiences) {
+    try {
+      JsonNode parsed = OBJECT_MAPPER.readTree(response);
+      Map<Long, Integer> usageScores = parseUsageScores(parsed, buildFallbackScores(experiences));
+      return new LlmMatchResult(
+          usageScores, Math.max(0, Math.min(100, parsed.path("applicationScore").asInt(0))));
+    } catch (BaseException e) {
+      throw e;
+    } catch (Exception e) {
+      log.warn("LLM 응답 파싱 실패: {}", e.getMessage());
+      throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
+    }
+  }
+
+  /**
+   * 문항별 활용 적합도 파싱
+   *
+   * @throws BaseException LLM_RESPONSE_INVALID — JSON 파싱 실패
+   */
+  public LlmQuestionMatchResult parseQuestionMatchResult(
+      String response, List<Experience> experiences) {
+    try {
+      JsonNode parsed = OBJECT_MAPPER.readTree(response);
+      return new LlmQuestionMatchResult(parseUsageScores(parsed, buildFallbackScores(experiences)));
+    } catch (BaseException e) {
+      throw e;
+    } catch (Exception e) {
+      log.warn("문항별 LLM 응답 파싱 실패: {}", e.getMessage());
+      throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
+    }
+  }
+
+  /**
+   * 자소서 작성 가이드 파싱
+   *
+   * @throws BaseException LLM_RESPONSE_INVALID — 필수 필드 누락 또는 JSON 파싱 실패
+   */
+  public LlmWritingGuideResult parseWritingGuideResult(String response) {
+    try {
+      JsonNode parsed = OBJECT_MAPPER.readTree(response);
+      if (!parsed.has("connectionToJd") || !parsed.has("writingGuide")) {
+        throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
+      }
+      List<String> keywords = new ArrayList<>();
+      for (JsonNode k : parsed.path("coreKeywords")) keywords.add(k.asText());
+      return new LlmWritingGuideResult(
+          keywords, parsed.path("connectionToJd").asText(), parsed.path("writingGuide").asText());
+    } catch (BaseException e) {
+      throw e;
+    } catch (Exception e) {
+      log.warn("작성 가이드 LLM 응답 파싱 실패: {}", e.getMessage());
+      throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
+    }
+  }
+
+  /**
+   * 경험 상세 분석 파싱
+   *
+   * @throws BaseException LLM_RESPONSE_INVALID — 필수 필드 누락 또는 JSON 파싱 실패
+   */
+  public LlmExperienceDetailResult parseExperienceDetailResult(String response) {
+    try {
+      JsonNode parsed = OBJECT_MAPPER.readTree(response);
+      if (!parsed.has("strengths") || !parsed.has("weaknesses") || !parsed.has("usageGuide")) {
+        throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
+      }
+      List<HighlightKeyword> keywords = new ArrayList<>();
+      for (JsonNode k : parsed.path("highlightKeywords")) {
+        String keyword = k.path("keyword").asText();
+        List<String> sources = new ArrayList<>();
+        for (JsonNode s : k.path("sources")) {
+          String source = s.asText();
+          if (VALID_SOURCES.contains(source)) sources.add(source);
+        }
+        keywords.add(new HighlightKeyword(keyword, sources));
+      }
+      return new LlmExperienceDetailResult(
+          parsed.path("strengths").asText(),
+          parsed.path("weaknesses").asText(),
+          parsed.path("usageGuide").asText(),
+          keywords);
+    } catch (BaseException e) {
+      throw e;
+    } catch (Exception e) {
+      log.warn("경험 상세 분석 LLM 응답 파싱 실패: {}", e.getMessage());
+      throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
+    }
+  }
+
+  // 공통 유틸
+
+  private Map<Long, Integer> buildFallbackScores(List<Experience> experiences) {
+    return experiences.stream()
+        .collect(
+            Collectors.toMap(
+                e -> e.getPiece().getId(), e -> 50, (existing, replacement) -> existing));
+  }
+
+  private Map<Long, Integer> parseUsageScores(JsonNode parsed, Map<Long, Integer> fallback) {
+    Map<Long, Integer> usageScores = new HashMap<>();
+    for (JsonNode item : parsed.path("usageScores")) {
+      usageScores.put(
+          item.path("pieceId").asLong(), Math.max(0, Math.min(100, item.path("score").asInt(50))));
+    }
+    fallback.forEach(usageScores::putIfAbsent);
+    return usageScores;
+  }
+}

--- a/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
+++ b/src/main/java/com/kusitms/kkium/jd/utils/llm/LlmMatchScoreService.java
@@ -1,223 +1,72 @@
 package com.kusitms.kkium.jd.utils.llm;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kusitms.kkium.experience.domain.Experience;
-import com.kusitms.kkium.global.exception.BaseException;
-import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
 import com.kusitms.kkium.jd.domain.Jd;
 import com.kusitms.kkium.jd.domain.JdQuestion;
-import com.kusitms.kkium.jd.utils.llm.result.*;
-import com.kusitms.kkium.jd.utils.llm.result.HighlightKeyword;
 import com.kusitms.kkium.jd.utils.llm.result.LlmExperienceDetailResult;
 import com.kusitms.kkium.jd.utils.llm.result.LlmMatchResult;
 import com.kusitms.kkium.jd.utils.llm.result.LlmQuestionMatchResult;
 import com.kusitms.kkium.jd.utils.llm.result.LlmWritingGuideResult;
 
-import lombok.extern.slf4j.Slf4j;
+import lombok.RequiredArgsConstructor;
 
-@Slf4j
+/**
+ * LLM 기반 경험-공고 적합도 분석 서비스 (오케스트레이션)
+ *
+ * <p>프롬프트 빌드 → API 호출 → 파싱의 흐름을 조율한다. - 프롬프트 빌드: {@link JdMatchPromptBuilder} - API 호출: {@link
+ * LlmApiClient} - 응답 파싱: {@link LlmMatchResultParser}
+ */
 @Component
+@RequiredArgsConstructor
 public class LlmMatchScoreService {
 
-  private static final String OPENAI_URL = "https://api.openai.com/v1/chat/completions";
-  private static final String MODEL = "gpt-4o";
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-  private final WebClient webClient;
-  private final String apiKey;
   private final JdMatchPromptBuilder promptBuilder;
-
-  public LlmMatchScoreService(
-      WebClient webClient,
-      @Value("${openai.api.key}") String apiKey,
-      JdMatchPromptBuilder promptBuilder) {
-    this.webClient = webClient;
-    this.apiKey = apiKey;
-    this.promptBuilder = promptBuilder;
-  }
+  private final LlmApiClient apiClient;
+  private final LlmMatchResultParser parser;
 
   /** LLM 1번 호출로 활용 적합도(경험별) + 지원 적합도(포트폴리오 종합)를 한꺼번에 반환 */
   public LlmMatchResult scoreAll(Jd jd, List<Experience> experiences) {
     if (experiences.isEmpty()) return new LlmMatchResult(Map.of(), 0);
-    String prompt = promptBuilder.buildCombinedPrompt(jd, experiences);
-    String response = callOpenAi(prompt, promptBuilder.buildCombinedSchema());
-    return parseCombinedResult(response, experiences);
+    String response =
+        apiClient.call(
+            promptBuilder.buildCombinedPrompt(jd, experiences),
+            promptBuilder.buildCombinedSchema());
+    return parser.parseCombinedResult(response, experiences);
   }
 
   /** 문항 컨텍스트를 포함해 활용 적합도를 계산 (자소서 작성 화면 경험 선택 모달용) */
   public LlmQuestionMatchResult scoreAllByQuestion(
       Jd jd, JdQuestion question, List<Experience> experiences) {
     if (experiences.isEmpty()) return new LlmQuestionMatchResult(Map.of());
-    String prompt = promptBuilder.buildQuestionCombinedPrompt(jd, question, experiences);
-    String response = callOpenAi(prompt, promptBuilder.buildQuestionCombinedSchema());
-    return parseQuestionMatchResult(response, experiences);
+    String response =
+        apiClient.call(
+            promptBuilder.buildQuestionCombinedPrompt(jd, question, experiences),
+            promptBuilder.buildQuestionCombinedSchema());
+    return parser.parseQuestionMatchResult(response, experiences);
   }
 
   /** 선택된 경험들을 기반으로 자소서 작성 가이드 생성 */
   public LlmWritingGuideResult generateWritingGuide(
       Jd jd, JdQuestion question, List<Experience> experiences) {
     if (experiences.isEmpty()) return LlmWritingGuideResult.empty();
-    String prompt = promptBuilder.buildWritingGuidePrompt(jd, question, experiences);
-    String response = callOpenAi(prompt, promptBuilder.buildWritingGuideSchema());
-    return parseWritingGuideResult(response);
+    String response =
+        apiClient.call(
+            promptBuilder.buildWritingGuidePrompt(jd, question, experiences),
+            promptBuilder.buildWritingGuideSchema());
+    return parser.parseWritingGuideResult(response);
   }
 
   /** 경험 카드 클릭 시 상세 분석 */
   public LlmExperienceDetailResult analyzeExperienceDetail(Jd jd, Experience experience) {
-    String prompt = promptBuilder.buildExperienceDetailPrompt(jd, experience);
-    String response = callOpenAi(prompt, promptBuilder.buildExperienceDetailSchema());
-    return parseExperienceDetailResult(response);
-  }
-
-  // API 호출
-  private String callOpenAi(String prompt, Map<String, Object> jsonSchema) {
-    Map<String, Object> body = new HashMap<>();
-    body.put("model", MODEL);
-    body.put("temperature", 0);
-    body.put("messages", List.of(Map.of("role", "user", "content", prompt)));
-    body.put("response_format", Map.of("type", "json_schema", "json_schema", jsonSchema));
-    try {
-      String response =
-          webClient
-              .post()
-              .uri(OPENAI_URL)
-              .header("Content-Type", "application/json")
-              .header("Authorization", "Bearer " + apiKey)
-              .bodyValue(body)
-              .retrieve()
-              .onStatus(
-                  HttpStatusCode::is4xxClientError,
-                  clientResponse -> {
-                    log.warn("OpenAI 클라이언트 에러: {}", clientResponse.statusCode());
-                    return clientResponse.createException();
-                  })
-              .onStatus(
-                  HttpStatusCode::is5xxServerError,
-                  clientResponse -> {
-                    log.warn("OpenAI 서버 에러: {}", clientResponse.statusCode());
-                    return clientResponse.createException();
-                  })
-              .bodyToMono(String.class)
-              .block();
-
-      JsonNode root = OBJECT_MAPPER.readTree(response);
-      return root.path("choices").path(0).path("message").path("content").asText();
-    } catch (BaseException e) {
-      throw e;
-    } catch (Exception e) {
-      log.warn("OpenAI 호출 실패: {}", e.getMessage());
-      throw new BaseException(ErrorCode.LLM_CALL_FAILED);
-    }
-  }
-
-  // 응답 파싱
-
-  private LlmMatchResult parseCombinedResult(String response, List<Experience> experiences) {
-    try {
-      JsonNode parsed = OBJECT_MAPPER.readTree(response);
-      Map<Long, Integer> usageScores = parseUsageScores(parsed, buildFallbackScores(experiences));
-      return new LlmMatchResult(
-          usageScores, Math.max(0, Math.min(100, parsed.path("applicationScore").asInt(0))));
-    } catch (Exception e) {
-      log.warn("LLM 응답 파싱 실패: {}", e.getMessage());
-      throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
-    }
-  }
-
-  private LlmQuestionMatchResult parseQuestionMatchResult(
-      String response, List<Experience> experiences) {
-    try {
-      JsonNode parsed = OBJECT_MAPPER.readTree(response);
-      return new LlmQuestionMatchResult(parseUsageScores(parsed, buildFallbackScores(experiences)));
-    } catch (Exception e) {
-      log.warn("문항별 LLM 응답 파싱 실패: {}", e.getMessage());
-      throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
-    }
-  }
-
-  private LlmWritingGuideResult parseWritingGuideResult(String response) {
-    try {
-      JsonNode parsed = OBJECT_MAPPER.readTree(response);
-      if (!parsed.has("connectionToJd") || !parsed.has("writingGuide")) {
-        throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
-      }
-      List<String> keywords = new ArrayList<>();
-      for (JsonNode k : parsed.path("coreKeywords")) keywords.add(k.asText());
-      return new LlmWritingGuideResult(
-          keywords, parsed.path("connectionToJd").asText(), parsed.path("writingGuide").asText());
-    } catch (BaseException e) {
-      throw e;
-    } catch (Exception e) {
-      log.warn("작성 가이드 LLM 응답 파싱 실패: {}", e.getMessage());
-      throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
-    }
-  }
-
-  private static final List<String> VALID_SOURCES =
-      List.of(
-          "mainResponsibilities",
-          "requiredQualifications",
-          "preferredQualifications",
-          "hardSkill",
-          "softSkill");
-
-  private LlmExperienceDetailResult parseExperienceDetailResult(String response) {
-    try {
-      JsonNode parsed = OBJECT_MAPPER.readTree(response);
-      if (!parsed.has("strengths") || !parsed.has("weaknesses") || !parsed.has("usageGuide")) {
-        throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
-      }
-      List<HighlightKeyword> keywords = new ArrayList<>();
-      for (JsonNode k : parsed.path("highlightKeywords")) {
-        String keyword = k.path("keyword").asText();
-        List<String> sources = new ArrayList<>();
-        for (JsonNode s : k.path("sources")) {
-          String source = s.asText();
-          if (VALID_SOURCES.contains(source)) sources.add(source);
-        }
-        keywords.add(new HighlightKeyword(keyword, sources));
-      }
-      return new LlmExperienceDetailResult(
-          parsed.path("strengths").asText(),
-          parsed.path("weaknesses").asText(),
-          parsed.path("usageGuide").asText(),
-          keywords);
-    } catch (BaseException e) {
-      throw e;
-    } catch (Exception e) {
-      log.warn("경험 상세 분석 LLM 응답 파싱 실패: {}", e.getMessage());
-      throw new BaseException(ErrorCode.LLM_RESPONSE_INVALID);
-    }
-  }
-
-  // 공통 유틸
-
-  private Map<Long, Integer> buildFallbackScores(List<Experience> experiences) {
-    return experiences.stream()
-        .collect(
-            Collectors.toMap(
-                e -> e.getPiece().getId(), e -> 50, (existing, replacement) -> existing));
-  }
-
-  private Map<Long, Integer> parseUsageScores(JsonNode parsed, Map<Long, Integer> fallback) {
-    Map<Long, Integer> usageScores = new HashMap<>();
-    for (JsonNode item : parsed.path("usageScores")) {
-      usageScores.put(
-          item.path("pieceId").asLong(), Math.max(0, Math.min(100, item.path("score").asInt(50))));
-    }
-    fallback.forEach(usageScores::putIfAbsent);
-    return usageScores;
+    String response =
+        apiClient.call(
+            promptBuilder.buildExperienceDetailPrompt(jd, experience),
+            promptBuilder.buildExperienceDetailSchema());
+    return parser.parseExperienceDetailResult(response);
   }
 }

--- a/src/test/java/com/kusitms/kkium/experience/service/ExperienceServiceUpdateTest.java
+++ b/src/test/java/com/kusitms/kkium/experience/service/ExperienceServiceUpdateTest.java
@@ -69,6 +69,8 @@ class ExperienceServiceUpdateTest {
   @Mock private JobTypeUpdateService jobTypeUpdateService;
   @Mock private JdExperienceAnalysisService jdExperienceAnalysisService;
   @Mock private ExperiencePeriodResolver experiencePeriodResolver;
+  private final ExperienceDetailValidator experienceDetailValidator =
+      new ExperienceDetailValidator();
 
   private ExperienceService experienceService;
 
@@ -89,7 +91,8 @@ class ExperienceServiceUpdateTest {
             experienceEmbeddingService,
             jobTypeUpdateService,
             jdExperienceAnalysisService,
-            experiencePeriodResolver);
+            experiencePeriodResolver,
+            experienceDetailValidator);
   }
 
   @AfterEach

--- a/src/test/java/com/kusitms/kkium/jd/service/JdExperienceAnalysisServiceTest.java
+++ b/src/test/java/com/kusitms/kkium/jd/service/JdExperienceAnalysisServiceTest.java
@@ -35,6 +35,7 @@ import com.kusitms.kkium.jd.domain.Jd;
 import com.kusitms.kkium.jd.dto.response.JdExperienceAnalysisResponse;
 import com.kusitms.kkium.jd.dto.response.JdExperienceAnalysisResponse.ExperienceAnalysis;
 import com.kusitms.kkium.jd.repository.JdRepository;
+import com.kusitms.kkium.jd.utils.JdAnalysisCacheKeyManager;
 import com.kusitms.kkium.jd.utils.llm.LlmMatchScoreService;
 import com.kusitms.kkium.jd.utils.llm.result.LlmExperienceDetailResult;
 import com.kusitms.kkium.user.domain.User;
@@ -150,7 +151,7 @@ class JdExperienceAnalysisServiceTest {
     when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
     when(experienceRepository.findByIdWithPiece(30L)).thenReturn(Optional.of(experience));
     when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-    when(valueOperations.get("jd-analysis:30:10")).thenReturn(cachedJson);
+    when(valueOperations.get(JdAnalysisCacheKeyManager.of(30L, 10L))).thenReturn(cachedJson);
 
     JdExperienceAnalysisResponse response = jdExperienceAnalysisService.analyze(10L, 30L, userId);
 
@@ -173,7 +174,7 @@ class JdExperienceAnalysisServiceTest {
 
     when(jdRepository.findById(10L)).thenReturn(Optional.of(jd));
     when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-    when(valueOperations.get("jd-analysis:30:10")).thenReturn(null);
+    when(valueOperations.get(JdAnalysisCacheKeyManager.of(30L, 10L))).thenReturn(null);
     when(experienceRepository.findByIdWithPiece(30L)).thenReturn(Optional.of(experience));
     when(llmMatchScoreService.analyzeExperienceDetail(jd, experience)).thenReturn(llmResult);
 
@@ -184,7 +185,7 @@ class JdExperienceAnalysisServiceTest {
     assertThat(response.analysis().weaknesses()).isEqualTo("약점입니다.");
     assertThat(response.analysis().usageGuide()).isEqualTo("활용 가이드입니다.");
     verify(llmMatchScoreService).analyzeExperienceDetail(jd, experience);
-    verify(valueOperations).set(eq("jd-analysis:30:10"), anyString(), any());
+    verify(valueOperations).set(eq(JdAnalysisCacheKeyManager.of(30L, 10L)), anyString(), any());
   }
 
   private User createUser(Long id) {


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #177 

## ✏️ 작업 내용

- `LlmMatchScoreService` 책임 분리 → `LlmApiClient`(OpenAI HTTP 호출), `LlmMatchResultParser`(응답 파싱) 추출
- `JdAnalysisCacheKeyManager` 도입 → Redis 캐시 키 하드코딩 중앙화
- `ExperienceDetailValidator` 분리 → `ExperienceService.update()` 내 유효성 검증 로직 추출

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
