### PR TITLE
[TEST] Home·Resume·자기소개서 문항 삭제 단위 테스트 작성

### DIFF
--- a/src/test/java/com/kusitms/kkium/home/service/HomeServiceTest.java
+++ b/src/test/java/com/kusitms/kkium/home/service/HomeServiceTest.java
@@ -1,0 +1,134 @@
+package com.kusitms.kkium.home.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.kusitms.kkium.experience.domain.type.PieceType;
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
+import com.kusitms.kkium.home.dto.response.HomeResponse;
+import com.kusitms.kkium.home.repository.HomeRepository;
+import com.kusitms.kkium.jd.domain.Jd;
+import com.kusitms.kkium.user.domain.User;
+import com.kusitms.kkium.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class HomeServiceTest {
+
+  @Mock private HomeRepository homeRepository;
+  @Mock private UserRepository userRepository;
+
+  private HomeService homeService;
+
+  private static final Long USER_ID = 1L;
+
+  @BeforeEach
+  void setUp() {
+    homeService = new HomeService(homeRepository, userRepository);
+  }
+
+  @Test
+  @DisplayName("홈 대시보드 정상 조회: targetJd가 있으면 정보가 포함된 응답을 반환한다")
+  void getHome_정상_조회() {
+    User user = mock(User.class);
+    Jd jd = mock(Jd.class);
+
+    List<Object[]> rawCounts = new ArrayList<>();
+    rawCounts.add(new Object[] {PieceType.ACTIVITY, 5L});
+
+    when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+    when(user.getJobType()).thenReturn(null);
+    when(homeRepository.findTargetJds(USER_ID)).thenReturn(List.of(jd));
+    when(homeRepository.countTotalExperience(USER_ID)).thenReturn(5);
+    when(homeRepository.countThisMonthExperience(eq(USER_ID), any(), any()))
+        .thenReturn(3, 2); // 이번달=3, 지난달=2
+    when(homeRepository.countByPieceType(USER_ID, PieceType.ALL)).thenReturn(rawCounts);
+
+    HomeResponse result = homeService.getHome(USER_ID);
+
+    assertThat(result).isNotNull();
+    assertThat(result.targetJds()).hasSize(1);
+    assertThat(result.totalExperienceCount()).isEqualTo(5);
+    assertThat(result.thisMonthExperienceCount()).isEqualTo(3);
+    assertThat(result.lastMonthDiff()).isEqualTo(1); // 3 - 2
+  }
+
+  @Test
+  @DisplayName("홈 대시보드 조회: targetJd가 없으면 targetJds가 빈 리스트로 반환된다")
+  void getHome_targetJd_없음() {
+    User user = mock(User.class);
+
+    when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+    when(user.getJobType()).thenReturn(null);
+    when(homeRepository.findTargetJds(USER_ID)).thenReturn(List.of());
+    when(homeRepository.countTotalExperience(USER_ID)).thenReturn(0);
+    when(homeRepository.countThisMonthExperience(eq(USER_ID), any(), any())).thenReturn(0, 0);
+    when(homeRepository.countByPieceType(USER_ID, PieceType.ALL)).thenReturn(new ArrayList<>());
+
+    HomeResponse result = homeService.getHome(USER_ID);
+
+    assertThat(result.targetJds()).isEmpty();
+    assertThat(result.totalExperienceCount()).isZero();
+  }
+
+  @Test
+  @DisplayName("홈 대시보드 조회: 사용자가 없으면 USER_NOT_FOUND 예외를 던진다")
+  void getHome_사용자_없음() {
+    when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> homeService.getHome(USER_ID))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.USER_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("홈 대시보드 조회: jobType이 null이면 JobTypeInfo의 typeName도 null이다")
+  void getHome_jobType_없음() {
+    User user = mock(User.class);
+
+    when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+    when(user.getJobType()).thenReturn(null);
+    when(homeRepository.findTargetJds(USER_ID)).thenReturn(List.of());
+    when(homeRepository.countTotalExperience(USER_ID)).thenReturn(0);
+    when(homeRepository.countThisMonthExperience(eq(USER_ID), any(), any())).thenReturn(0, 0);
+    when(homeRepository.countByPieceType(USER_ID, PieceType.ALL)).thenReturn(new ArrayList<>());
+
+    HomeResponse result = homeService.getHome(USER_ID);
+
+    assertThat(result.jobType().typeName()).isNull();
+  }
+
+  @Test
+  @DisplayName("홈 대시보드 조회: 이번달 경험이 지난달보다 적으면 lastMonthDiff가 음수다")
+  void getHome_lastMonthDiff_음수() {
+    User user = mock(User.class);
+
+    when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+    when(user.getJobType()).thenReturn(null);
+    when(homeRepository.findTargetJds(USER_ID)).thenReturn(List.of());
+    when(homeRepository.countTotalExperience(USER_ID)).thenReturn(0);
+    when(homeRepository.countThisMonthExperience(eq(USER_ID), any(), any()))
+        .thenReturn(1, 5); // 이번달=1, 지난달=5
+    when(homeRepository.countByPieceType(USER_ID, PieceType.ALL)).thenReturn(new ArrayList<>());
+
+    HomeResponse result = homeService.getHome(USER_ID);
+
+    assertThat(result.lastMonthDiff()).isEqualTo(-4); // 1 - 5
+  }
+}

--- a/src/test/java/com/kusitms/kkium/jd/service/JdDeleteQuestionServiceTest.java
+++ b/src/test/java/com/kusitms/kkium/jd/service/JdDeleteQuestionServiceTest.java
@@ -1,0 +1,122 @@
+package com.kusitms.kkium.jd.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
+import com.kusitms.kkium.jd.domain.Jd;
+import com.kusitms.kkium.jd.domain.JdQuestion;
+import com.kusitms.kkium.jd.repository.JdAnswerRepository;
+import com.kusitms.kkium.jd.repository.JdQuestionRepository;
+import com.kusitms.kkium.jd.repository.JdRepository;
+import com.kusitms.kkium.resume.repository.AnswerExperienceRepository;
+import com.kusitms.kkium.user.domain.User;
+import com.kusitms.kkium.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class JdDeleteQuestionServiceTest {
+
+  @Mock private JdRepository jdRepository;
+  @Mock private JdQuestionRepository jdQuestionRepository;
+  @Mock private JdAnswerRepository jdAnswerRepository;
+  @Mock private AnswerExperienceRepository answerExperienceRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private JdExperienceAnalysisService jdExperienceAnalysisService;
+
+  private JdService jdService;
+
+  private static final Long USER_ID = 1L;
+  private static final Long OTHER_USER_ID = 2L;
+  private static final Long JD_ID = 10L;
+  private static final Long QUESTION_ID = 100L;
+
+  @BeforeEach
+  void setUp() {
+    jdService =
+        new JdService(
+            jdRepository,
+            jdQuestionRepository,
+            jdAnswerRepository,
+            answerExperienceRepository,
+            userRepository,
+            jdExperienceAnalysisService);
+  }
+
+  @Test
+  @DisplayName("자기소개서 문항 정상 삭제: 관련 답변·경험·문항이 순서대로 삭제되고 orderNum이 재정렬된다")
+  void deleteQuestion_정상_삭제() {
+    Jd jd = mock(Jd.class);
+    User owner = mock(User.class);
+    JdQuestion question = mock(JdQuestion.class);
+
+    when(jdRepository.findByIdAndDeleteAtIsNull(JD_ID)).thenReturn(Optional.of(jd));
+    when(jd.getUser()).thenReturn(owner);
+    when(owner.getId()).thenReturn(USER_ID);
+    when(jdQuestionRepository.findByIdAndJdId(QUESTION_ID, JD_ID))
+        .thenReturn(Optional.of(question));
+    when(question.getOrderNum()).thenReturn(2);
+
+    jdService.deleteQuestion(JD_ID, QUESTION_ID, USER_ID);
+
+    verify(answerExperienceRepository).deleteAllByJdQuestion(question);
+    verify(jdAnswerRepository).deleteAllByJdQuestion(question);
+    verify(jdQuestionRepository).delete(question);
+    verify(jdQuestionRepository).decrementOrderNumAfter(JD_ID, 2);
+  }
+
+  @Test
+  @DisplayName("자기소개서 문항 삭제: JD가 존재하지 않으면 JD_NOT_FOUND 예외를 던진다")
+  void deleteQuestion_JD_없음() {
+    when(jdRepository.findByIdAndDeleteAtIsNull(JD_ID)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> jdService.deleteQuestion(JD_ID, QUESTION_ID, USER_ID))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.JD_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("자기소개서 문항 삭제: 타인 소유 JD이면 FORBIDDEN 예외를 던진다")
+  void deleteQuestion_타인_소유_FORBIDDEN() {
+    Jd jd = mock(Jd.class);
+    User owner = mock(User.class);
+
+    when(jdRepository.findByIdAndDeleteAtIsNull(JD_ID)).thenReturn(Optional.of(jd));
+    when(jd.getUser()).thenReturn(owner);
+    when(owner.getId()).thenReturn(OTHER_USER_ID);
+
+    assertThatThrownBy(() -> jdService.deleteQuestion(JD_ID, QUESTION_ID, USER_ID))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.FORBIDDEN);
+  }
+
+  @Test
+  @DisplayName("자기소개서 문항 삭제: 존재하지 않는 문항이면 INVALID_QUESTION_FOR_JD 예외를 던진다")
+  void deleteQuestion_없는_문항() {
+    Jd jd = mock(Jd.class);
+    User owner = mock(User.class);
+
+    when(jdRepository.findByIdAndDeleteAtIsNull(JD_ID)).thenReturn(Optional.of(jd));
+    when(jd.getUser()).thenReturn(owner);
+    when(owner.getId()).thenReturn(USER_ID);
+    when(jdQuestionRepository.findByIdAndJdId(QUESTION_ID, JD_ID)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> jdService.deleteQuestion(JD_ID, QUESTION_ID, USER_ID))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.INVALID_QUESTION_FOR_JD);
+  }
+}

--- a/src/test/java/com/kusitms/kkium/jd/service/JdDeleteQuestionServiceTest.java
+++ b/src/test/java/com/kusitms/kkium/jd/service/JdDeleteQuestionServiceTest.java
@@ -2,7 +2,6 @@ package com.kusitms.kkium.jd.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -11,7 +10,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.kusitms.kkium.global.exception.BaseException;
@@ -70,10 +71,12 @@ class JdDeleteQuestionServiceTest {
 
     jdService.deleteQuestion(JD_ID, QUESTION_ID, USER_ID);
 
-    verify(answerExperienceRepository).deleteAllByJdQuestion(question);
-    verify(jdAnswerRepository).deleteAllByJdQuestion(question);
-    verify(jdQuestionRepository).delete(question);
-    verify(jdQuestionRepository).decrementOrderNumAfter(JD_ID, 2);
+    InOrder inOrder =
+        Mockito.inOrder(answerExperienceRepository, jdAnswerRepository, jdQuestionRepository);
+    inOrder.verify(answerExperienceRepository).deleteAllByJdQuestion(question);
+    inOrder.verify(jdAnswerRepository).deleteAllByJdQuestion(question);
+    inOrder.verify(jdQuestionRepository).delete(question);
+    inOrder.verify(jdQuestionRepository).decrementOrderNumAfter(JD_ID, 2);
   }
 
   @Test

--- a/src/test/java/com/kusitms/kkium/resume/service/ResumeAnswerServiceTest.java
+++ b/src/test/java/com/kusitms/kkium/resume/service/ResumeAnswerServiceTest.java
@@ -74,7 +74,7 @@ class ResumeAnswerServiceTest {
     resumeAnswerService.saveAnswers(JD_ID, USER_ID, request);
 
     verify(jdAnswerRepository).save(any(JdAnswer.class));
-    verify(answerExperienceRepository).deleteAllByJdAnswerIdIn(anyList());
+    verify(answerExperienceRepository).deleteAllByJdAnswerIdIn(List.of(200L));
   }
 
   @Test
@@ -109,7 +109,7 @@ class ResumeAnswerServiceTest {
     User user = mock(User.class);
 
     when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
-    // questionId가 해당 jdId에 속하지 않아 1개만 조회됨 (요청은 2개)
+    // questionId가 해당 jdId에 속하지 않아 조회되지 않음 (요청은 1개, 조회는 0개)
     when(jdQuestionRepository.findAllByIdInAndJdId(anyList(), any(Long.class)))
         .thenReturn(List.of()); // 0개 반환 → size 불일치
 

--- a/src/test/java/com/kusitms/kkium/resume/service/ResumeAnswerServiceTest.java
+++ b/src/test/java/com/kusitms/kkium/resume/service/ResumeAnswerServiceTest.java
@@ -1,0 +1,140 @@
+package com.kusitms.kkium.resume.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.kusitms.kkium.global.exception.BaseException;
+import com.kusitms.kkium.global.exception.errorcode.ErrorCode;
+import com.kusitms.kkium.jd.domain.JdAnswer;
+import com.kusitms.kkium.jd.domain.JdQuestion;
+import com.kusitms.kkium.jd.repository.JdAnswerRepository;
+import com.kusitms.kkium.jd.repository.JdQuestionRepository;
+import com.kusitms.kkium.resume.dto.request.ResumeAnswerSaveRequest;
+import com.kusitms.kkium.resume.repository.AnswerExperienceRepository;
+import com.kusitms.kkium.user.domain.User;
+import com.kusitms.kkium.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ResumeAnswerServiceTest {
+
+  @Mock private JdAnswerRepository jdAnswerRepository;
+  @Mock private JdQuestionRepository jdQuestionRepository;
+  @Mock private AnswerExperienceRepository answerExperienceRepository;
+  @Mock private UserRepository userRepository;
+
+  private ResumeAnswerService resumeAnswerService;
+
+  private static final Long USER_ID = 1L;
+  private static final Long JD_ID = 10L;
+  private static final Long QUESTION_ID = 100L;
+
+  @BeforeEach
+  void setUp() {
+    resumeAnswerService =
+        new ResumeAnswerService(
+            jdAnswerRepository, jdQuestionRepository, answerExperienceRepository, userRepository);
+  }
+
+  @Test
+  @DisplayName("신규 답변 저장: 기존 답변이 없으면 새 JdAnswer를 INSERT한다")
+  void saveAnswers_신규_저장() {
+    User user = mock(User.class);
+    JdQuestion question = mock(JdQuestion.class);
+    JdAnswer savedAnswer = mock(JdAnswer.class);
+
+    when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+    when(question.getId()).thenReturn(QUESTION_ID);
+    when(jdQuestionRepository.findAllByIdInAndJdId(List.of(QUESTION_ID), JD_ID))
+        .thenReturn(List.of(question));
+    when(jdAnswerRepository.findAllByJdQuestionInAndUser(anyList(), any(User.class)))
+        .thenReturn(List.of()); // 기존 답변 없음
+    when(jdAnswerRepository.save(any(JdAnswer.class))).thenReturn(savedAnswer);
+    when(savedAnswer.getId()).thenReturn(200L);
+    when(savedAnswer.getJdQuestion()).thenReturn(question);
+
+    ResumeAnswerSaveRequest request =
+        new ResumeAnswerSaveRequest(
+            List.of(new ResumeAnswerSaveRequest.AnswerRequest(QUESTION_ID, "답변 내용", List.of())));
+
+    resumeAnswerService.saveAnswers(JD_ID, USER_ID, request);
+
+    verify(jdAnswerRepository).save(any(JdAnswer.class));
+    verify(answerExperienceRepository).deleteAllByJdAnswerIdIn(anyList());
+  }
+
+  @Test
+  @DisplayName("기존 답변 업데이트: 이미 답변이 있으면 INSERT 없이 내용을 업데이트한다")
+  void saveAnswers_기존_업데이트() {
+    User user = mock(User.class);
+    JdQuestion question = mock(JdQuestion.class);
+    JdAnswer existingAnswer = mock(JdAnswer.class);
+
+    when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+    when(question.getId()).thenReturn(QUESTION_ID);
+    when(jdQuestionRepository.findAllByIdInAndJdId(List.of(QUESTION_ID), JD_ID))
+        .thenReturn(List.of(question));
+    when(jdAnswerRepository.findAllByJdQuestionInAndUser(anyList(), any(User.class)))
+        .thenReturn(List.of(existingAnswer)); // 기존 답변 있음
+    when(existingAnswer.getJdQuestion()).thenReturn(question);
+    when(existingAnswer.getId()).thenReturn(200L);
+
+    ResumeAnswerSaveRequest request =
+        new ResumeAnswerSaveRequest(
+            List.of(new ResumeAnswerSaveRequest.AnswerRequest(QUESTION_ID, "수정된 답변", List.of())));
+
+    resumeAnswerService.saveAnswers(JD_ID, USER_ID, request);
+
+    verify(existingAnswer).updateContent("수정된 답변");
+    verify(jdAnswerRepository, never()).save(any(JdAnswer.class));
+  }
+
+  @Test
+  @DisplayName("다른 JD의 문항에 접근하면 INVALID_QUESTION_FOR_JD 예외를 던진다")
+  void saveAnswers_잘못된_JD_문항() {
+    User user = mock(User.class);
+
+    when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+    // questionId가 해당 jdId에 속하지 않아 1개만 조회됨 (요청은 2개)
+    when(jdQuestionRepository.findAllByIdInAndJdId(anyList(), any(Long.class)))
+        .thenReturn(List.of()); // 0개 반환 → size 불일치
+
+    ResumeAnswerSaveRequest request =
+        new ResumeAnswerSaveRequest(
+            List.of(new ResumeAnswerSaveRequest.AnswerRequest(QUESTION_ID, "답변", List.of())));
+
+    assertThatThrownBy(() -> resumeAnswerService.saveAnswers(JD_ID, USER_ID, request))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.INVALID_QUESTION_FOR_JD);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 사용자이면 USER_NOT_FOUND 예외를 던진다")
+  void saveAnswers_사용자_없음() {
+    when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+    ResumeAnswerSaveRequest request =
+        new ResumeAnswerSaveRequest(
+            List.of(new ResumeAnswerSaveRequest.AnswerRequest(QUESTION_ID, "답변", List.of())));
+
+    assertThatThrownBy(() -> resumeAnswerService.saveAnswers(JD_ID, USER_ID, request))
+        .isInstanceOf(BaseException.class)
+        .extracting("errorCode")
+        .isEqualTo(ErrorCode.USER_NOT_FOUND);
+  }
+}


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #180 

## ✏️ 작업 내용

- `HomeService` 단위 테스트 작성
  - targetJd 있음/없음 / USER_NOT_FOUND / jobType null / lastMonthDiff 음수
- `ResumeAnswerService` 단위 테스트 작성
  - 신규 답변 INSERT / 기존 답변 UPSERT / INVALID_QUESTION_FOR_JD / USER_NOT_FOUND
- `JdService.deleteQuestion` 단위 테스트 작성
  - 정상 삭제(cascade + orderNum 재정렬 verify) / JD_NOT_FOUND / FORBIDDEN / INVALID_QUESTION_FOR_JD
- `./gradlew test` 전체 통과 확인

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
