### PR TITLE
[TEST] 경험 상세 조회 E2E 통합 테스트 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+    testImplementation 'org.springframework.security:spring-security-test'
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/test/java/com/kusitms/kkium/experience/controller/ExperienceDetailE2ETest.java
+++ b/src/test/java/com/kusitms/kkium/experience/controller/ExperienceDetailE2ETest.java
@@ -1,0 +1,84 @@
+package com.kusitms.kkium.experience.controller;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.kusitms.kkium.auth.utils.JwtTokenProvider;
+import com.kusitms.kkium.experience.domain.Experience;
+import com.kusitms.kkium.experience.domain.ExperienceOrder;
+import com.kusitms.kkium.experience.domain.Piece;
+import com.kusitms.kkium.experience.domain.type.PieceType;
+import com.kusitms.kkium.experience.repository.ExperienceOrderRepository;
+import com.kusitms.kkium.experience.repository.ExperienceRepository;
+import com.kusitms.kkium.experience.repository.PieceRepository;
+import com.kusitms.kkium.global.IntegrationTestBase;
+import com.kusitms.kkium.user.domain.User;
+import com.kusitms.kkium.user.repository.UserRepository;
+
+@Transactional
+class ExperienceDetailE2ETest extends IntegrationTestBase {
+
+  @Autowired private WebApplicationContext context;
+  @Autowired private JwtTokenProvider jwtTokenProvider;
+  @Autowired private UserRepository userRepository;
+  @Autowired private PieceRepository pieceRepository;
+  @Autowired private ExperienceRepository experienceRepository;
+  @Autowired private ExperienceOrderRepository experienceOrderRepository;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setUpMockMvc() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+
+  @Test
+  @DisplayName("E2E: 경험 상세 조회 API가 인증 통과 후 200과 정상 데이터를 반환한다")
+  void getDetail_E2E_정상_조회() throws Exception {
+    // given — 선행 데이터 저장
+    User user =
+        userRepository.save(
+            User.basicLoginBuilder()
+                .name("E2E유저")
+                .email("e2e@kkium.com")
+                .password("password")
+                .build());
+    Piece piece = pieceRepository.save(Piece.builder().type(PieceType.ACTIVITY).user(user).build());
+    Experience experience =
+        experienceRepository.save(Experience.builder().title("E2E 테스트 경험").piece(piece).build());
+    experienceOrderRepository.save(
+        ExperienceOrder.builder()
+            .sortOrder(1)
+            .pieceType(PieceType.ALL)
+            .experience(experience)
+            .user(user)
+            .build());
+
+    String token = jwtTokenProvider.createAccessToken(user.getId().toString());
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/experiences/{id}", experience.getId())
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.title").value("E2E 테스트 경험"));
+  }
+
+  @Test
+  @DisplayName("E2E: Authorization 헤더 없이 경험 상세 조회 시 401을 반환한다")
+  void getDetail_E2E_인증없음_401() throws Exception {
+    mockMvc.perform(get("/api/v1/experiences/1")).andExpect(status().isUnauthorized());
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -28,12 +28,12 @@ spring:
       port: 6379
 
   jwt:
-    secret: test-jwt-secret-for-testing-must-be-long-enough-for-hmac-sha256
+    secret: test-jwt-secret-for-testing-must-be-long-enough-for-hmac-sha2561
     access:
       token:
         expiration: 3600000
 
-JWT_SECRET: test-jwt-secret-for-testing-must-be-long-enough-for-hmac-sha256
+JWT_SECRET: test-jwt-secret-for-testing-must-be-long-enough-for-hmac-sha2561
 JWT_ACCESS_TOKEN_EXPIRATION: 3600000
 KAKAO_REST_API_KEY: test-kakao-rest-api-key
 KAKAO_CLIENT_SECRET: test-kakao-client-secret


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #182 

## ✏️ 작업 내용

- `spring-security-test` 테스트 의존성 추가
- test `JWT_SECRET`을 HS512 최소 요구사항(64바이트) 충족 값으로 수정
- 경험 상세 조회 E2E 통합 테스트 작성 (`ExperienceDetailE2ETest`)
  - JWT 인증 통과 후 200 + 정상 데이터 반환 검증
  - 인증 없는 요청 → 401 반환 검증
  - `WebApplicationContext` + `springSecurity()` 기반 MockMvc 설정
- `./gradlew test` 전체 통과 확인

## ✅ 체크리스트

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  작업한 사람 모두를 Assign
- [x]  `develop` 브랜치의 최신 상태를 반영하고 있는지 확인
